### PR TITLE
fix: add stream:false to Grok Responses API request

### DIFF
--- a/src/adapters/grok_responses_request.rs
+++ b/src/adapters/grok_responses_request.rs
@@ -45,6 +45,7 @@ pub fn to_grok_responses_payload(
     Ok(json!({
         "model": req.model,
         "input": input,
-        "tools": tools
+        "tools": tools,
+        "stream": false
     }))
 }


### PR DESCRIPTION
## Problem

The Grok Responses API defaults to SSE streaming mode. Without explicitly setting `stream: false`, the API returns:

```
event: response.created
data: {"type":"response.created",...}

event: response.output_item.added
data: {...}
...
```

The `post_json` HTTP client calls `serde_json::from_slice(&bytes)` on the entire response body — but the first character is `e` (from `event:`), not `{`, causing:

```
parse error: invalid Grok Responses JSON: expected value at line 1 column 1
```

This makes any `web_search` call fail with `grok_provider_error` and fall back to Tavily-only results, even when the Grok API endpoint is fully reachable.

## Fix

Add `"stream": false` to the request payload so the API returns pure JSON instead of SSE.

## Test plan

- Unit tests continue to pass (no mock HTTP servers in test suite)
- Manual verification: `web_search` against a Grok-compatible API endpoint now succeeds instead of falling back