### PR TITLE
feat: add OpenAI-compatible chat/completions transport

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,6 +17,14 @@ TAVILY_API_URL=https://api.tavily.com
 # FIRECRAWL_API_URL=https://api.firecrawl.dev
 # FIRECRAWL_ENABLED=false
 
+# ── OpenAI-compatible transport (alternative to GROK_SEARCH_*) ───
+# When GROK_SEARCH_API_KEY above is unset and these three are set,
+# grok-search-rs talks to /v1/chat/completions instead of /v1/responses.
+# Useful for OpenAI-compatible gateways that do not implement /responses.
+# OPENAI_COMPATIBLE_API_URL=https://your-gateway/v1
+# OPENAI_COMPATIBLE_API_KEY=sk-...
+# OPENAI_COMPATIBLE_MODEL=grok-4.3-fast
+
 # Search source behavior.
 GROK_SEARCH_EXTRA_SOURCES=3
 GROK_SEARCH_FALLBACK_SOURCES=5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to GrokSearch-rs are documented here.
 
+## Unreleased
+
+### Added
+
+- OpenAI-compatible chat/completions transport (`OPENAI_COMPATIBLE_API_URL` / `_KEY` / `_MODEL`). When `GROK_SEARCH_API_KEY` is unset and the new triple is set, the client talks to `/v1/chat/completions` instead of `/v1/responses`. Source extraction covers OpenAI annotations, Perplexity-style citations, top-level `search_sources`, and inline `[[n]](url)` markers.
+- `Config::transport` enum (`Responses` | `ChatCompletions`) decided at startup from the configured env-var groups.
+
+### Notes
+
+- `x_search_enabled` is silently ignored on the Chat-Completions transport (warned once at startup).
+- No new crates added.
+
 ## 0.1.10 - 2026-05-16
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -209,9 +209,33 @@ Install the grok-search-rs MCP server (npx -y grok-search-rs) into my current cl
 | `doctor`     | all three             | probes each                           | —                              |
 
 
-`grok-search-rs` always calls the **Responses API** (`/v1/responses`), not `/v1/chat/completions`. Your upstream must implement that endpoint and accept the `web_search` / `x_search` tool types.
+`grok-search-rs` supports two upstream transports — by default it calls the **Responses API** (`/v1/responses`); see [Choosing a transport](#-choosing-a-transport) below for the OpenAI‑compatible `/v1/chat/completions` mode.
 
 `GROK_SEARCH_URL` accepts the root URL, a `/v1` base, or a full endpoint — all normalized to `/v1` internally. Verified upstreams: **xAI** (`https://api.x.ai`, both tools), **Modelverse** (`https://api.modelverse.cn`, `x_search` depends on relay).
+
+---
+
+## 🔀 Choosing a transport
+
+`grok-search-rs` supports two upstream transports — pick whichever your gateway implements:
+
+| Transport | Endpoint | Env-var group | Best for |
+|---|---|---|---|
+| **Responses (default)** | `POST /v1/responses` with `tools:[{"type":"web_search"}]` | `GROK_SEARCH_URL` / `GROK_SEARCH_API_KEY` / `GROK_SEARCH_MODEL` | xAI direct or any gateway implementing the Responses API (e.g. modelverse). Required for `x_search`. |
+| **Chat-Completions** | `POST /v1/chat/completions` with `tools:[{"type":"web_search"}]` | `OPENAI_COMPATIBLE_API_URL` / `OPENAI_COMPATIBLE_API_KEY` / `OPENAI_COMPATIBLE_MODEL` | OpenAI-compatible gateways that auto-search server-side or honor the `web_search` tool. |
+
+**Selection rules:**
+
+- If `GROK_SEARCH_API_KEY` is set, the Responses transport is used (even if the OpenAI-compatible group is also set).
+- Otherwise, if both `OPENAI_COMPATIBLE_API_URL` and `OPENAI_COMPATIBLE_API_KEY` are set, the Chat-Completions transport is used.
+- `x_search_enabled` is silently ignored on the Chat-Completions path; the warning prints once at startup.
+
+**Source extraction on Chat-Completions** runs four paths and merges (de-duped by URL):
+
+1. `choices[0].message.annotations[].url_citation` — OpenAI standard
+2. `choices[0].message.citations` and top-level `citations` — Perplexity-style
+3. top-level `search_sources[]` — marybrown-style auto-search gateways
+4. inline `[[n]](url)` markers in the content — last-resort fallback
 
 ---
 

--- a/src/adapters/chat_completions_request.rs
+++ b/src/adapters/chat_completions_request.rs
@@ -1,0 +1,49 @@
+use crate::model::search::{ContentBlock, SearchRequest};
+use serde_json::{json, Value};
+
+const DEFAULT_SYSTEM_HINT: &str =
+    "You may search the web when helpful. \
+     When you cite a fact, append the source URL inline so the caller can extract it.";
+
+/// Build an OpenAI-style `/v1/chat/completions` payload from a generic
+/// `SearchRequest`. The user's `system` (if any) takes precedence over the
+/// built-in hint; otherwise the hint nudges chat-style gateways that auto-search.
+///
+/// `include_web_search_tool` mirrors `Config.web_search_enabled`. Some gateways
+/// (e.g. modelverse) honor `tools:[{"type":"web_search"}]`; others (e.g.
+/// marybrown) ignore it harmlessly. We always send it when enabled — it is
+/// either useful or a no-op, never a failure mode.
+pub fn to_chat_completions_payload(
+    req: &SearchRequest,
+    model: &str,
+    include_web_search_tool: bool,
+) -> Value {
+    let system_text = req
+        .system
+        .as_deref()
+        .filter(|v| !v.trim().is_empty())
+        .unwrap_or(DEFAULT_SYSTEM_HINT);
+
+    let mut messages = vec![json!({ "role": "system", "content": system_text })];
+    for message in &req.messages {
+        let content = message
+            .content
+            .iter()
+            .map(|block| match block {
+                ContentBlock::Text { text } => text.as_str(),
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        messages.push(json!({ "role": message.role, "content": content }));
+    }
+
+    let mut payload = json!({
+        "model": model,
+        "messages": messages,
+        "stream": false,
+    });
+    if include_web_search_tool {
+        payload["tools"] = json!([{ "type": "web_search" }]);
+    }
+    payload
+}

--- a/src/adapters/chat_completions_response.rs
+++ b/src/adapters/chat_completions_response.rs
@@ -17,8 +17,8 @@ const PROVIDER_LABEL: &str = "openai_compatible";
 pub fn parse_chat_completions(raw: &Value) -> Result<SearchResponse> {
     let content = raw
         .pointer("/choices/0/message/content")
-        .and_then(Value::as_str)
-        .unwrap_or("")
+        .map(extract_content_text)
+        .unwrap_or_default()
         .trim()
         .to_string();
 
@@ -69,6 +69,52 @@ fn collect_sources_from_value(value: &Value, out: &mut Vec<Source>) {
     }
 }
 
+/// Reduce a `message.content` value to a plain string. OpenAI now returns
+/// content either as `String` (legacy) or as an array of typed parts
+/// (`[{type:"text", text:"..."}, {type:"output_text", text:"..."}]`). Concat
+/// every textual chunk so structured responses don't get treated as empty.
+fn extract_content_text(value: &Value) -> String {
+    match value {
+        Value::String(s) => s.clone(),
+        Value::Array(parts) => {
+            let mut buf = String::new();
+            for part in parts {
+                match part {
+                    Value::String(s) => {
+                        if !buf.is_empty() {
+                            buf.push('\n');
+                        }
+                        buf.push_str(s);
+                    }
+                    Value::Object(_) => {
+                        if let Some(t) = part
+                            .get("text")
+                            .or_else(|| part.get("content"))
+                            .or_else(|| part.get("value"))
+                            .and_then(Value::as_str)
+                        {
+                            if !buf.is_empty() {
+                                buf.push('\n');
+                            }
+                            buf.push_str(t);
+                        }
+                    }
+                    _ => {}
+                }
+            }
+            buf
+        }
+        Value::Object(_) => value
+            .get("text")
+            .or_else(|| value.get("content"))
+            .or_else(|| value.get("value"))
+            .and_then(Value::as_str)
+            .map(|s| s.to_string())
+            .unwrap_or_default(),
+        _ => String::new(),
+    }
+}
+
 fn collect_one(item: &Value, out: &mut Vec<Source>) {
     if let Some(url) = item.as_str() {
         if url.starts_with("http://") || url.starts_with("https://") {
@@ -76,6 +122,9 @@ fn collect_one(item: &Value, out: &mut Vec<Source>) {
         }
         return;
     }
+    // OpenAI standard annotation: { type:"url_citation", url_citation:{url,title,...} }
+    // Unwrap one level so the rest of this fn treats the nested object as the source.
+    let item = item.get("url_citation").unwrap_or(item);
     let Some(url) = item
         .get("url")
         .or_else(|| item.get("uri"))
@@ -117,6 +166,10 @@ fn collect_one(item: &Value, out: &mut Vec<Source>) {
 /// Find inline citations of the form `[[n]](https://...)` and `[[n]](http://...)`
 /// in the response text. We avoid the `regex` crate to keep the dependency
 /// footprint flat — a hand-rolled scanner is sufficient for this fixed pattern.
+///
+/// On any malformed match (missing `]]`, missing `(`, missing closing `)`,
+/// non-numeric inside `[[...]]`), advance past the offending `[[` and keep
+/// scanning so a single bad citation never wipes out later valid ones.
 fn extract_inline_bracket_citations(content: &str, out: &mut Vec<Source>) {
     let mut offset = 0usize;
     while offset < content.len() {
@@ -127,6 +180,7 @@ fn extract_inline_bracket_citations(content: &str, out: &mut Vec<Source>) {
         let abs = offset + rel_idx;
         let after = &content[abs + 2..];
         let Some(close_brackets) = after.find("]]") else {
+            // No `]]` anywhere ahead — nothing more to find. Bail out.
             break;
         };
         let between = &after[..close_brackets];
@@ -140,10 +194,29 @@ fn extract_inline_bracket_citations(content: &str, out: &mut Vec<Source>) {
             continue;
         }
         let url_start = 1usize; // skip the '('
-        let Some(close_paren) = after_brackets[url_start..].find(')') else {
-            break;
+        // Find the first `)` *that closes a well-formed URL*. URLs do not
+        // legitimately contain whitespace or another `[`, so treat those as
+        // bailout signals — otherwise a missing-`)` citation could swallow
+        // the rest of the document into a single bogus URL.
+        let url_window = &after_brackets[url_start..];
+        let mut bail: Option<usize> = None;
+        for (i, ch) in url_window.char_indices() {
+            if ch == ')' {
+                bail = Some(i);
+                break;
+            }
+            if ch == ' ' || ch == '\n' || ch == '\t' || ch == '[' || ch == '<' {
+                break;
+            }
+        }
+        let Some(close_paren) = bail else {
+            // Malformed: no `)` ahead before whitespace / next bracket. Skip
+            // past this `[[` and keep scanning; earlier code dropped every
+            // later citation in the same response.
+            offset = abs + 2;
+            continue;
         };
-        let url = &after_brackets[url_start..url_start + close_paren];
+        let url = &url_window[..close_paren];
         if url.starts_with("http://") || url.starts_with("https://") {
             out.push(Source::new(url, PROVIDER_LABEL));
         }

--- a/src/adapters/chat_completions_response.rs
+++ b/src/adapters/chat_completions_response.rs
@@ -1,0 +1,153 @@
+use crate::adapters::sources::dedupe_sources;
+use crate::error::{GrokSearchError, Result};
+use crate::model::search::SearchResponse;
+use crate::model::source::Source;
+use serde_json::Value;
+
+const PROVIDER_LABEL: &str = "openai_compatible";
+
+/// Parse an OpenAI-style chat-completions response. Source extraction runs
+/// four paths in priority order, then de-dupes by URL preserving order:
+///
+///   1. `choices[0].message.annotations[].url_citation` — OpenAI standard
+///   2. `choices[0].message.citations` and top-level `citations` —
+///      Perplexity / various OpenAI-compat gateways
+///   3. top-level `search_sources` — marybrown-style auto-search gateways
+///   4. inline `[[n]](url)` markers in the content text — last-resort fallback
+pub fn parse_chat_completions(raw: &Value) -> Result<SearchResponse> {
+    let content = raw
+        .pointer("/choices/0/message/content")
+        .and_then(Value::as_str)
+        .unwrap_or("")
+        .trim()
+        .to_string();
+
+    let mut sources: Vec<Source> = Vec::new();
+
+    // path 1: message.annotations
+    if let Some(anns) = raw.pointer("/choices/0/message/annotations") {
+        collect_sources_from_value(anns, &mut sources);
+    }
+
+    // path 2a: message.citations
+    if let Some(cits) = raw.pointer("/choices/0/message/citations") {
+        collect_sources_from_value(cits, &mut sources);
+    }
+    // path 2b: top-level citations
+    if let Some(cits) = raw.get("citations") {
+        collect_sources_from_value(cits, &mut sources);
+    }
+
+    // path 3: top-level search_sources
+    if let Some(ss) = raw.get("search_sources") {
+        collect_sources_from_value(ss, &mut sources);
+    }
+
+    // path 4: inline [[n]](url) in the content
+    extract_inline_bracket_citations(&content, &mut sources);
+
+    dedupe_sources(&mut sources);
+
+    if content.is_empty() && sources.is_empty() {
+        return Err(GrokSearchError::Parse(
+            "chat/completions response is empty and has no sources".to_string(),
+        ));
+    }
+
+    Ok(SearchResponse { content, sources })
+}
+
+fn collect_sources_from_value(value: &Value, out: &mut Vec<Source>) {
+    match value {
+        Value::Array(items) => {
+            for item in items {
+                collect_one(item, out);
+            }
+        }
+        Value::Object(_) => collect_one(value, out),
+        _ => {}
+    }
+}
+
+fn collect_one(item: &Value, out: &mut Vec<Source>) {
+    if let Some(url) = item.as_str() {
+        if url.starts_with("http://") || url.starts_with("https://") {
+            out.push(Source::new(url, PROVIDER_LABEL));
+        }
+        return;
+    }
+    let Some(url) = item
+        .get("url")
+        .or_else(|| item.get("uri"))
+        .or_else(|| item.get("href"))
+        .or_else(|| item.get("link"))
+        .and_then(Value::as_str)
+    else {
+        return;
+    };
+    if !(url.starts_with("http://") || url.starts_with("https://")) {
+        return;
+    }
+    let mut source = Source::new(url, PROVIDER_LABEL);
+    if let Some(t) = item
+        .get("title")
+        .or_else(|| item.get("name"))
+        .and_then(Value::as_str)
+    {
+        source = source.with_title(t);
+    }
+    if let Some(d) = item
+        .get("description")
+        .or_else(|| item.get("snippet"))
+        .or_else(|| item.get("content"))
+        .and_then(Value::as_str)
+    {
+        source = source.with_description(d);
+    }
+    if let Some(p) = item
+        .get("published_date")
+        .or_else(|| item.get("publishedDate"))
+        .and_then(Value::as_str)
+    {
+        source = source.with_published_date(p);
+    }
+    out.push(source);
+}
+
+/// Find inline citations of the form `[[n]](https://...)` and `[[n]](http://...)`
+/// in the response text. We avoid the `regex` crate to keep the dependency
+/// footprint flat — a hand-rolled scanner is sufficient for this fixed pattern.
+fn extract_inline_bracket_citations(content: &str, out: &mut Vec<Source>) {
+    let mut offset = 0usize;
+    while offset < content.len() {
+        let remaining = &content[offset..];
+        let Some(rel_idx) = remaining.find("[[") else {
+            break;
+        };
+        let abs = offset + rel_idx;
+        let after = &content[abs + 2..];
+        let Some(close_brackets) = after.find("]]") else {
+            break;
+        };
+        let between = &after[..close_brackets];
+        if between.is_empty() || !between.chars().all(|c| c.is_ascii_digit()) {
+            offset = abs + 2;
+            continue;
+        }
+        let after_brackets = &after[close_brackets + 2..];
+        if !after_brackets.starts_with('(') {
+            offset = abs + 2;
+            continue;
+        }
+        let url_start = 1usize; // skip the '('
+        let Some(close_paren) = after_brackets[url_start..].find(')') else {
+            break;
+        };
+        let url = &after_brackets[url_start..url_start + close_paren];
+        if url.starts_with("http://") || url.starts_with("https://") {
+            out.push(Source::new(url, PROVIDER_LABEL));
+        }
+        // advance past this whole match
+        offset = (abs + 2) + close_brackets + 2 + 1 + close_paren + 1;
+    }
+}

--- a/src/adapters/grok_responses_response.rs
+++ b/src/adapters/grok_responses_response.rs
@@ -1,3 +1,4 @@
+use crate::adapters::sources::dedupe_sources;
 use crate::error::{GrokSearchError, Result};
 use crate::model::search::SearchResponse;
 use crate::model::source::Source;
@@ -110,7 +111,3 @@ fn push_nonempty(text_parts: &mut Vec<String>, text: &str) {
     }
 }
 
-fn dedupe_sources(sources: &mut Vec<Source>) {
-    let mut seen = std::collections::HashSet::new();
-    sources.retain(|source| !source.url.trim().is_empty() && seen.insert(source.url.clone()));
-}

--- a/src/adapters/mod.rs
+++ b/src/adapters/mod.rs
@@ -1,3 +1,4 @@
+pub mod chat_completions_request;
 pub mod grok_responses_request;
 pub mod grok_responses_response;
 pub mod sources;

--- a/src/adapters/mod.rs
+++ b/src/adapters/mod.rs
@@ -1,2 +1,3 @@
 pub mod grok_responses_request;
 pub mod grok_responses_response;
+pub mod sources;

--- a/src/adapters/mod.rs
+++ b/src/adapters/mod.rs
@@ -1,4 +1,5 @@
 pub mod chat_completions_request;
+pub mod chat_completions_response;
 pub mod grok_responses_request;
 pub mod grok_responses_response;
 pub mod sources;

--- a/src/adapters/sources.rs
+++ b/src/adapters/sources.rs
@@ -1,0 +1,9 @@
+use crate::model::source::Source;
+
+/// Drop sources with empty URLs and de-duplicate by URL, preserving the order
+/// of first appearance. Shared by every response adapter so newer extraction
+/// paths inherit the same invariant for free.
+pub fn dedupe_sources(sources: &mut Vec<Source>) {
+    let mut seen = std::collections::HashSet::new();
+    sources.retain(|source| !source.url.trim().is_empty() && seen.insert(source.url.clone()));
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -334,7 +334,9 @@ fn get(map: &HashMap<String, String>, key: &str, default: &str) -> String {
 
 pub fn normalize_v1_base(url: &str) -> String {
     let mut value = url.trim().trim_end_matches('/').to_string();
-    for suffix in ["/responses"] {
+    // Strip any known full-endpoint suffix so callers can pass either a base
+    // URL or a full endpoint and converge on the same `/v1` form.
+    for suffix in ["/chat/completions", "/responses"] {
         if value.ends_with(suffix) {
             let keep = value.len() - suffix.len();
             value.truncate(keep);

--- a/src/config.rs
+++ b/src/config.rs
@@ -281,6 +281,15 @@ pub const CONFIG_TEMPLATE: &str = r#"# grok-search-rs global configuration
 # tavily_api_url    = "https://api.tavily.com"
 # firecrawl_api_url = "https://api.firecrawl.dev"
 
+# ── OpenAI-compatible transport (alternative to grok_*) ───────
+# Set these three to use a /v1/chat/completions gateway. When grok_api_key
+# above is also set, it wins; otherwise these three pick the chat-completions
+# transport. Source extraction supports OpenAI annotations, Perplexity-style
+# citations, marybrown's top-level search_sources, and inline [[n]](url).
+# openai_compatible_api_url = "https://your-gateway/v1"
+# openai_compatible_api_key = "sk-..."
+# openai_compatible_model   = "grok-4.3-fast"
+
 # ── Feature toggles ───────────────────────────────────────────
 # web_search_enabled = true
 # tavily_enabled     = true

--- a/src/config.rs
+++ b/src/config.rs
@@ -4,6 +4,12 @@ use std::time::Duration;
 
 use serde::Deserialize;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Transport {
+    Responses,
+    ChatCompletions,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Config {
     pub grok_api_url: String,
@@ -22,6 +28,10 @@ pub struct Config {
     pub fetch_max_chars: Option<usize>,
     pub cache_size: usize,
     pub timeout: Duration,
+    pub openai_compatible_api_url: Option<String>,
+    pub openai_compatible_api_key: Option<String>,
+    pub openai_compatible_model: Option<String>,
+    pub transport: Transport,
 }
 
 /// Mirror of `Config` for TOML deserialization. All fields optional so users
@@ -45,6 +55,9 @@ struct ConfigFile {
     fetch_max_chars: Option<usize>,
     cache_size: Option<usize>,
     timeout_seconds: Option<u64>,
+    openai_compatible_api_url: Option<String>,
+    openai_compatible_api_key: Option<String>,
+    openai_compatible_model: Option<String>,
 }
 
 impl ConfigFile {
@@ -97,6 +110,9 @@ impl ConfigFile {
             "GROK_SEARCH_TIMEOUT_SECONDS",
             self.timeout_seconds.map(|n| n.to_string()),
         );
+        insert("OPENAI_COMPATIBLE_API_URL", self.openai_compatible_api_url);
+        insert("OPENAI_COMPATIBLE_API_KEY", self.openai_compatible_api_key);
+        insert("OPENAI_COMPATIBLE_MODEL", self.openai_compatible_model);
         out
     }
 }
@@ -167,6 +183,19 @@ impl Config {
             fetch_max_chars: optional_positive_usize(&map, "GROK_SEARCH_FETCH_MAX_CHARS"),
             cache_size: usize_value(&map, "GROK_SEARCH_CACHE_SIZE", 256),
             timeout: Duration::from_secs(u64_value(&map, "GROK_SEARCH_TIMEOUT_SECONDS", 60)),
+            openai_compatible_api_url: map
+                .get("OPENAI_COMPATIBLE_API_URL")
+                .cloned()
+                .filter(|v| !v.is_empty()),
+            openai_compatible_api_key: map
+                .get("OPENAI_COMPATIBLE_API_KEY")
+                .cloned()
+                .filter(|v| !v.is_empty()),
+            openai_compatible_model: map
+                .get("OPENAI_COMPATIBLE_MODEL")
+                .cloned()
+                .filter(|v| !v.is_empty()),
+            transport: decide_transport(&map),
         }
     }
 
@@ -340,10 +369,78 @@ fn optional_positive_usize(map: &HashMap<String, String>, key: &str) -> Option<u
         .filter(|value| *value > 0)
 }
 
+fn decide_transport(map: &HashMap<String, String>) -> Transport {
+    let grok_key_set = map
+        .get("GROK_SEARCH_API_KEY")
+        .map(|v| !v.is_empty())
+        .unwrap_or(false);
+    let compat_url_set = map
+        .get("OPENAI_COMPATIBLE_API_URL")
+        .map(|v| !v.is_empty())
+        .unwrap_or(false);
+    let compat_key_set = map
+        .get("OPENAI_COMPATIBLE_API_KEY")
+        .map(|v| !v.is_empty())
+        .unwrap_or(false);
+
+    if grok_key_set {
+        return Transport::Responses;
+    }
+    if compat_url_set && compat_key_set {
+        return Transport::ChatCompletions;
+    }
+    Transport::Responses
+}
+
 fn redact(value: Option<&str>) -> String {
     match value {
         None => "unset".to_string(),
         Some(v) if v.len() <= 8 => "***".to_string(),
         Some(v) => format!("{}***{}", &v[..4], &v[v.len() - 4..]),
+    }
+}
+
+#[cfg(test)]
+mod transport_field_tests {
+    use super::*;
+
+    #[test]
+    fn loads_openai_compatible_fields_from_env() {
+        let cfg = Config::from_env_map([
+            ("OPENAI_COMPATIBLE_API_URL", "https://example.com/v1"),
+            ("OPENAI_COMPATIBLE_API_KEY", "sk-fake"),
+            ("OPENAI_COMPATIBLE_MODEL", "grok-4.3-fast"),
+        ]);
+        assert_eq!(
+            cfg.openai_compatible_api_url.as_deref(),
+            Some("https://example.com/v1")
+        );
+        assert_eq!(cfg.openai_compatible_api_key.as_deref(), Some("sk-fake"));
+        assert_eq!(cfg.openai_compatible_model.as_deref(), Some("grok-4.3-fast"));
+    }
+
+    #[test]
+    fn transport_defaults_to_responses_when_only_grok_set() {
+        let cfg = Config::from_env_map([("GROK_SEARCH_API_KEY", "xai-fake")]);
+        assert_eq!(cfg.transport, Transport::Responses);
+    }
+
+    #[test]
+    fn transport_chat_completions_when_only_compat_set() {
+        let cfg = Config::from_env_map([
+            ("OPENAI_COMPATIBLE_API_URL", "https://example.com/v1"),
+            ("OPENAI_COMPATIBLE_API_KEY", "sk-fake"),
+        ]);
+        assert_eq!(cfg.transport, Transport::ChatCompletions);
+    }
+
+    #[test]
+    fn transport_prefers_grok_when_both_set() {
+        let cfg = Config::from_env_map([
+            ("GROK_SEARCH_API_KEY", "xai-fake"),
+            ("OPENAI_COMPATIBLE_API_URL", "https://example.com/v1"),
+            ("OPENAI_COMPATIBLE_API_KEY", "sk-fake"),
+        ]);
+        assert_eq!(cfg.transport, Transport::Responses);
     }
 }

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -1,4 +1,5 @@
 pub mod firecrawl;
 pub mod grok;
 pub mod http;
+pub mod openai_compatible;
 pub mod tavily;

--- a/src/providers/openai_compatible.rs
+++ b/src/providers/openai_compatible.rs
@@ -1,5 +1,6 @@
 use crate::adapters::chat_completions_request::to_chat_completions_payload;
 use crate::adapters::chat_completions_response::parse_chat_completions;
+use crate::config::normalize_v1_base;
 use crate::error::Result;
 use crate::model::search::{SearchRequest, SearchResponse};
 use crate::providers::http::{build_client, post_json};
@@ -44,7 +45,11 @@ impl OpenAICompatProvider {
     ) -> Self {
         Self {
             client,
-            api_url: api_url.into().trim_end_matches('/').to_string(),
+            // Mirror the Responses provider: accept root URLs, `/v1` bases, or
+            // full endpoints, and converge on a `/v1` base. Without this,
+            // `https://api.openai.com` would produce
+            // `https://api.openai.com/chat/completions` (missing `/v1`).
+            api_url: normalize_v1_base(&api_url.into()),
             api_key: api_key.into(),
             model: model.into(),
             include_web_search_tool,
@@ -56,8 +61,15 @@ impl OpenAICompatProvider {
     }
 
     pub async fn search(&self, request: &SearchRequest) -> Result<SearchResponse> {
-        let payload =
-            to_chat_completions_payload(request, &self.model, self.include_web_search_tool);
+        // Honor per-request model overrides (e.g. WebSearchInput.model) the same
+        // way the Responses path does; fall back to the provider default only when
+        // the request leaves the field empty.
+        let model = if request.model.trim().is_empty() {
+            self.model.as_str()
+        } else {
+            request.model.as_str()
+        };
+        let payload = to_chat_completions_payload(request, model, self.include_web_search_tool);
         let raw = post_json(
             &self.client,
             &self.endpoint(),

--- a/src/providers/openai_compatible.rs
+++ b/src/providers/openai_compatible.rs
@@ -1,0 +1,71 @@
+use crate::adapters::chat_completions_request::to_chat_completions_payload;
+use crate::adapters::chat_completions_response::parse_chat_completions;
+use crate::error::Result;
+use crate::model::search::{SearchRequest, SearchResponse};
+use crate::providers::http::{build_client, post_json};
+use reqwest::Client;
+use std::time::Duration;
+
+#[derive(Clone)]
+pub struct OpenAICompatProvider {
+    client: Client,
+    api_url: String,
+    api_key: String,
+    model: String,
+    include_web_search_tool: bool,
+}
+
+impl OpenAICompatProvider {
+    pub fn new(
+        api_url: impl Into<String>,
+        api_key: impl Into<String>,
+        model: impl Into<String>,
+        include_web_search_tool: bool,
+        timeout: Duration,
+    ) -> Self {
+        Self::with_client(
+            build_client(timeout),
+            api_url,
+            api_key,
+            model,
+            include_web_search_tool,
+        )
+    }
+
+    /// Construct with an externally provided `reqwest::Client`. Used by
+    /// `SearchService::new` to share one tuned client; the `new(..., timeout)`
+    /// form remains for callers that want a per-provider client (tests).
+    pub fn with_client(
+        client: Client,
+        api_url: impl Into<String>,
+        api_key: impl Into<String>,
+        model: impl Into<String>,
+        include_web_search_tool: bool,
+    ) -> Self {
+        Self {
+            client,
+            api_url: api_url.into().trim_end_matches('/').to_string(),
+            api_key: api_key.into(),
+            model: model.into(),
+            include_web_search_tool,
+        }
+    }
+
+    pub fn endpoint(&self) -> String {
+        format!("{}/chat/completions", self.api_url)
+    }
+
+    pub async fn search(&self, request: &SearchRequest) -> Result<SearchResponse> {
+        let payload =
+            to_chat_completions_payload(request, &self.model, self.include_web_search_tool);
+        let raw = post_json(
+            &self.client,
+            &self.endpoint(),
+            &self.api_key,
+            &payload,
+            "OpenAI-compatible",
+        )
+        .await?;
+        parse_chat_completions(&raw)
+    }
+}

--- a/src/service.rs
+++ b/src/service.rs
@@ -99,18 +99,52 @@ pub struct SearchService {
 
 impl SearchService {
     pub fn new(config: Config) -> Result<Self> {
-        let grok_key = config
-            .grok_api_key
-            .clone()
-            .ok_or(GrokSearchError::MissingConfig("GROK_SEARCH_API_KEY"))?;
+        use crate::config::Transport;
         let http = crate::providers::http::build_client(config.timeout);
-        let ai: Arc<dyn AiProvider> = Arc::new(GrokResponsesProvider::with_client(
-            http.clone(),
-            config.grok_api_url.clone(),
-            grok_key,
-            config.web_search_enabled,
-            config.x_search_enabled,
-        ));
+
+        let ai: Arc<dyn AiProvider> = match config.transport {
+            Transport::Responses => {
+                let grok_key = config
+                    .grok_api_key
+                    .clone()
+                    .ok_or(GrokSearchError::MissingConfig("GROK_SEARCH_API_KEY"))?;
+                Arc::new(GrokResponsesProvider::with_client(
+                    http.clone(),
+                    config.grok_api_url.clone(),
+                    grok_key,
+                    config.web_search_enabled,
+                    config.x_search_enabled,
+                ))
+            }
+            Transport::ChatCompletions => {
+                let url = config
+                    .openai_compatible_api_url
+                    .clone()
+                    .ok_or(GrokSearchError::MissingConfig("OPENAI_COMPATIBLE_API_URL"))?;
+                let key = config
+                    .openai_compatible_api_key
+                    .clone()
+                    .ok_or(GrokSearchError::MissingConfig("OPENAI_COMPATIBLE_API_KEY"))?;
+                let model = config
+                    .openai_compatible_model
+                    .clone()
+                    .unwrap_or_else(|| config.grok_model.clone());
+                if config.x_search_enabled {
+                    eprintln!(
+                        "grok-search-rs: x_search_enabled is ignored when using OPENAI_COMPATIBLE_* transport"
+                    );
+                }
+                Arc::new(
+                    crate::providers::openai_compatible::OpenAICompatProvider::with_client(
+                        http.clone(),
+                        url,
+                        key,
+                        model,
+                        config.web_search_enabled,
+                    ),
+                )
+            }
+        };
 
         let sources = if config.tavily_enabled {
             config.tavily_api_key.clone().map(|key| {
@@ -671,5 +705,35 @@ impl SourceProvider for FakeSourceProvider {
         Ok((0..max_results)
             .map(|idx| Source::new(format!("{url}/page-{idx}"), "tavily"))
             .collect())
+    }
+}
+
+#[cfg(test)]
+mod transport_dispatch_tests {
+    use super::*;
+    use crate::config::Transport;
+
+    #[test]
+    fn service_constructs_for_chat_completions_transport() {
+        let config = Config::from_env_map([
+            ("OPENAI_COMPATIBLE_API_URL", "https://example.com/v1"),
+            ("OPENAI_COMPATIBLE_API_KEY", "sk-fake"),
+            ("OPENAI_COMPATIBLE_MODEL", "grok-4.3-fast"),
+            ("TAVILY_API_KEY", "fake-tavily"),
+        ]);
+        assert_eq!(config.transport, Transport::ChatCompletions);
+        let svc = SearchService::new(config).expect("service should build");
+        // Smoke: just ensure construction doesn't blow up. The actual provider
+        // type is hidden behind Arc<dyn AiProvider>; we verify behavior in the
+        // ignored e2e probe (Task 7) and adapter unit tests (Tasks 3-4).
+        drop(svc);
+    }
+
+    #[test]
+    fn service_rejects_chat_completions_without_url() {
+        let config = Config::from_env_map([("OPENAI_COMPATIBLE_API_KEY", "sk-fake")]);
+        // url missing -> falls back to Responses transport, which then needs
+        // GROK_SEARCH_API_KEY which is also missing -> MissingConfig.
+        assert!(SearchService::new(config).is_err());
     }
 }

--- a/src/service.rs
+++ b/src/service.rs
@@ -41,6 +41,13 @@ impl AiProvider for GrokResponsesProvider {
 }
 
 #[async_trait]
+impl AiProvider for crate::providers::openai_compatible::OpenAICompatProvider {
+    async fn search(&self, request: &SearchRequest) -> Result<SearchResponse> {
+        crate::providers::openai_compatible::OpenAICompatProvider::search(self, request).await
+    }
+}
+
+#[async_trait]
 impl SourceProvider for TavilyProvider {
     async fn search_sources(
         &self,

--- a/tests/integration_compat.rs
+++ b/tests/integration_compat.rs
@@ -1,0 +1,48 @@
+//! End-to-end probe for the OpenAI-compatible transport. Skipped by default
+//! because it hits live HTTP — run with:
+//!
+//!   GROK_SEARCH_E2E_CHAT_URL=https://your-gateway/v1\
+//!   GROK_SEARCH_E2E_CHAT_KEY=sk-... \
+//!   GROK_SEARCH_E2E_CHAT_MODEL=grok-4.3-fast \
+//!   cargo test --test integration_compat -- --ignored --nocapture
+//!
+//! The probe asserts a non-empty response and at least one source. Use it as a
+//! contract regression check when swapping gateways or upgrading providers.
+
+use grok_search_rs::model::search::{ContentBlock, SearchMessage, SearchRequest, SearchTool};
+use grok_search_rs::providers::openai_compatible::OpenAICompatProvider;
+use std::time::Duration;
+
+#[tokio::test(flavor = "current_thread")]
+#[ignore]
+async fn chat_completions_e2e_returns_text_and_sources() {
+    let url = std::env::var("GROK_SEARCH_E2E_CHAT_URL")
+        .expect("set GROK_SEARCH_E2E_CHAT_URL to run this test");
+    let key = std::env::var("GROK_SEARCH_E2E_CHAT_KEY")
+        .expect("set GROK_SEARCH_E2E_CHAT_KEY to run this test");
+    let model = std::env::var("GROK_SEARCH_E2E_CHAT_MODEL")
+        .unwrap_or_else(|_| "grok-4.3-fast".to_string());
+
+    let provider = OpenAICompatProvider::new(url, key, &model, true, Duration::from_secs(60));
+    let req = SearchRequest {
+        model: model.clone(),
+        system: None,
+        messages: vec![SearchMessage {
+            role: "user".into(),
+            content: vec![ContentBlock::text(
+                "What date did xAI release Grok 4.1 Fast? Answer briefly with a citation.",
+            )],
+        }],
+        tools: vec![SearchTool::web_search()],
+    };
+
+    let resp = provider.search(&req).await.expect("e2e search");
+    assert!(!resp.content.trim().is_empty(), "content was empty");
+    assert!(
+        !resp.sources.is_empty(),
+        "expected at least one source, got 0; content was: {}",
+        resp.content
+    );
+    eprintln!("content: {}", resp.content);
+    eprintln!("sources: {} entries", resp.sources.len());
+}

--- a/tests/integration_service.rs
+++ b/tests/integration_service.rs
@@ -1,0 +1,48 @@
+//! End-to-end probe through the full `SearchService` for the OpenAI-compatible
+//! transport. Skipped by default — run with:
+//!
+//!   GROK_SEARCH_E2E_CHAT_URL=https://api.modelverse.cn/v1 \
+//!   GROK_SEARCH_E2E_CHAT_KEY=... \
+//!   GROK_SEARCH_E2E_CHAT_MODEL=grok-4-1-fast-reasoning \
+//!   cargo test --test integration_service -- --ignored --nocapture
+
+use grok_search_rs::config::{Config, Transport};
+use grok_search_rs::model::tool::WebSearchInput;
+use grok_search_rs::service::SearchService;
+
+#[tokio::test(flavor = "current_thread")]
+#[ignore]
+async fn full_service_web_search_via_chat_completions() {
+    let url = std::env::var("GROK_SEARCH_E2E_CHAT_URL").expect("set GROK_SEARCH_E2E_CHAT_URL");
+    let key = std::env::var("GROK_SEARCH_E2E_CHAT_KEY").expect("set GROK_SEARCH_E2E_CHAT_KEY");
+    let model = std::env::var("GROK_SEARCH_E2E_CHAT_MODEL")
+        .unwrap_or_else(|_| "grok-4.3-fast".to_string());
+
+    let config = Config::from_env_map([
+        ("OPENAI_COMPATIBLE_API_URL", url.as_str()),
+        ("OPENAI_COMPATIBLE_API_KEY", key.as_str()),
+        ("OPENAI_COMPATIBLE_MODEL", model.as_str()),
+        ("TAVILY_ENABLED", "false"),
+        ("FIRECRAWL_ENABLED", "false"),
+    ]);
+    assert_eq!(config.transport, Transport::ChatCompletions);
+
+    let svc = SearchService::new(config).expect("service");
+    let out = svc
+        .web_search(WebSearchInput {
+            query: "What date did xAI release Grok 4.1 Fast? Answer with a citation.".into(),
+            platform: None,
+            recency_days: None,
+            include_domains: vec![],
+            exclude_domains: vec![],
+            extra_sources: None,
+            model: None,
+        })
+        .await
+        .expect("web_search");
+
+    assert!(!out.content.trim().is_empty(), "content empty");
+    eprintln!("content head: {}", &out.content.chars().take(200).collect::<String>());
+    eprintln!("sources_count: {}", out.sources_count);
+    eprintln!("session_id: {}", out.session_id);
+}

--- a/tests/openai_compatible_adapter.rs
+++ b/tests/openai_compatible_adapter.rs
@@ -133,3 +133,30 @@ fn errors_when_content_empty_and_no_sources() {
     let raw = json!({ "choices": [{ "message": { "content": "" } }] });
     assert!(parse_chat_completions(&raw).is_err());
 }
+
+use grok_search_rs::providers::openai_compatible::OpenAICompatProvider;
+use std::time::Duration;
+
+#[test]
+fn provider_endpoint_appends_chat_completions() {
+    let p = OpenAICompatProvider::new(
+        "https://example.com/v1",
+        "sk-fake",
+        "grok-4.3-fast",
+        true,
+        Duration::from_secs(5),
+    );
+    assert_eq!(p.endpoint(), "https://example.com/v1/chat/completions");
+}
+
+#[test]
+fn provider_endpoint_strips_trailing_slash() {
+    let p = OpenAICompatProvider::new(
+        "https://example.com/v1/",
+        "sk-fake",
+        "grok-4.3-fast",
+        true,
+        Duration::from_secs(5),
+    );
+    assert_eq!(p.endpoint(), "https://example.com/v1/chat/completions");
+}

--- a/tests/openai_compatible_adapter.rs
+++ b/tests/openai_compatible_adapter.rs
@@ -1,0 +1,43 @@
+use grok_search_rs::adapters::chat_completions_request::to_chat_completions_payload;
+use grok_search_rs::model::search::{ContentBlock, SearchMessage, SearchRequest, SearchTool};
+use serde_json::json;
+
+fn sample_request() -> SearchRequest {
+    SearchRequest {
+        model: "grok-4.3-fast".into(),
+        system: None,
+        messages: vec![SearchMessage {
+            role: "user".into(),
+            content: vec![ContentBlock::text("hello")],
+        }],
+        tools: vec![SearchTool::web_search()],
+    }
+}
+
+#[test]
+fn payload_includes_tools_when_web_search_enabled() {
+    let payload = to_chat_completions_payload(&sample_request(), "grok-4.3-fast", true);
+    assert_eq!(payload["model"], "grok-4.3-fast");
+    assert_eq!(payload["stream"], false);
+    assert_eq!(payload["tools"], json!([{ "type": "web_search" }]));
+    assert_eq!(payload["messages"][0]["role"], "system");
+    assert_eq!(payload["messages"][1]["role"], "user");
+    assert_eq!(payload["messages"][1]["content"], "hello");
+}
+
+#[test]
+fn payload_omits_tools_when_disabled() {
+    let payload = to_chat_completions_payload(&sample_request(), "grok-4.3-fast", false);
+    assert!(
+        payload.get("tools").is_none(),
+        "tools must be absent when disabled"
+    );
+}
+
+#[test]
+fn user_system_overrides_default_hint() {
+    let mut req = sample_request();
+    req.system = Some("You are a cat.".into());
+    let payload = to_chat_completions_payload(&req, "grok-4.3-fast", true);
+    assert_eq!(payload["messages"][0]["content"], "You are a cat.");
+}

--- a/tests/openai_compatible_adapter.rs
+++ b/tests/openai_compatible_adapter.rs
@@ -160,3 +160,120 @@ fn provider_endpoint_strips_trailing_slash() {
     );
     assert_eq!(p.endpoint(), "https://example.com/v1/chat/completions");
 }
+
+#[test]
+fn provider_endpoint_normalizes_root_url_to_v1() {
+    // P2 fix: root URLs without `/v1` previously yielded the wrong endpoint.
+    let p = OpenAICompatProvider::new(
+        "https://api.openai.com",
+        "sk-fake",
+        "gpt-x",
+        true,
+        Duration::from_secs(5),
+    );
+    assert_eq!(p.endpoint(), "https://api.openai.com/v1/chat/completions");
+}
+
+#[test]
+fn provider_endpoint_normalizes_full_endpoint_input() {
+    // P2 fix: passing a full endpoint URL must not double-suffix.
+    let p = OpenAICompatProvider::new(
+        "https://gw.example/v1/chat/completions",
+        "sk-fake",
+        "grok-4.3-fast",
+        true,
+        Duration::from_secs(5),
+    );
+    assert_eq!(p.endpoint(), "https://gw.example/v1/chat/completions");
+}
+
+#[test]
+fn extracts_openai_nested_url_citation_annotations() {
+    // P1 fix: real OpenAI annotations nest the URL under `url_citation`.
+    let raw = json!({
+        "choices": [{
+            "message": {
+                "content": "Body.",
+                "annotations": [
+                    {
+                        "type": "url_citation",
+                        "url_citation": {
+                            "url": "https://nested.example/a",
+                            "title": "Nested A",
+                            "start_index": 0,
+                            "end_index": 4
+                        }
+                    }
+                ]
+            }
+        }]
+    });
+    let resp = parse_chat_completions(&raw).expect("parse");
+    assert_eq!(resp.sources.len(), 1, "got {:?}", resp.sources);
+    assert_eq!(resp.sources[0].url, "https://nested.example/a");
+    assert_eq!(resp.sources[0].title.as_deref(), Some("Nested A"));
+}
+
+#[test]
+fn extracts_array_form_message_content() {
+    // P2 fix: structured content parts must concatenate into the response text.
+    let raw = json!({
+        "choices": [{
+            "message": {
+                "content": [
+                    { "type": "text", "text": "Hello, " },
+                    { "type": "output_text", "text": "world." }
+                ]
+            }
+        }],
+        "search_sources": [{ "url": "https://s.example/x", "title": "X" }]
+    });
+    let resp = parse_chat_completions(&raw).expect("parse");
+    assert_eq!(resp.content, "Hello, \nworld.");
+    assert_eq!(resp.sources.len(), 1);
+}
+
+#[test]
+fn inline_scanner_recovers_after_malformed_citation() {
+    // P2 fix: a single malformed `[[1]](no-close` previously aborted the scan,
+    // dropping every subsequent valid citation.
+    let raw = json!({
+        "choices": [{
+            "message": {
+                "content": "first[[1]](https://broken.example/a then later[[2]](https://ok.example/b)."
+            }
+        }]
+    });
+    let resp = parse_chat_completions(&raw).expect("parse");
+    let urls: Vec<_> = resp.sources.iter().map(|s| s.url.as_str()).collect();
+    assert!(urls.contains(&"https://ok.example/b"), "got {urls:?}");
+}
+
+use grok_search_rs::error::Result as GrokResult;
+use grok_search_rs::model::search::SearchResponse;
+
+fn fake_provider_search(_req: &SearchRequest) -> GrokResult<SearchResponse> {
+    Ok(SearchResponse {
+        content: String::new(),
+        sources: vec![],
+    })
+}
+
+#[test]
+fn provider_request_model_overrides_self_model() {
+    // P1 fix: When SearchRequest.model is non-empty it must take precedence
+    // over the provider default. We assert the payload built for the wire,
+    // since search() itself is async + I/O-bound.
+    use grok_search_rs::adapters::chat_completions_request::to_chat_completions_payload;
+
+    let mut req = sample_request();
+    req.model = "grok-4-1-fast-reasoning".into();
+    let chosen = if req.model.trim().is_empty() {
+        "fallback-default"
+    } else {
+        req.model.as_str()
+    };
+    let payload = to_chat_completions_payload(&req, chosen, true);
+    assert_eq!(payload["model"], "grok-4-1-fast-reasoning");
+    let _ = fake_provider_search; // silence dead_code if ever orphaned
+}

--- a/tests/openai_compatible_adapter.rs
+++ b/tests/openai_compatible_adapter.rs
@@ -41,3 +41,95 @@ fn user_system_overrides_default_hint() {
     let payload = to_chat_completions_payload(&req, "grok-4.3-fast", true);
     assert_eq!(payload["messages"][0]["content"], "You are a cat.");
 }
+
+use grok_search_rs::adapters::chat_completions_response::parse_chat_completions;
+
+#[test]
+fn extracts_openai_style_annotations() {
+    let raw = json!({
+        "choices": [{
+            "message": {
+                "content": "Result text.",
+                "annotations": [
+                    { "type": "url_citation", "url": "https://a.example/1", "title": "A" },
+                    { "type": "url_citation", "url": "https://b.example/2" }
+                ]
+            }
+        }]
+    });
+    let resp = parse_chat_completions(&raw).expect("parse");
+    assert_eq!(resp.content, "Result text.");
+    assert_eq!(resp.sources.len(), 2);
+    assert_eq!(resp.sources[0].url, "https://a.example/1");
+    assert_eq!(resp.sources[0].title.as_deref(), Some("A"));
+}
+
+#[test]
+fn extracts_perplexity_style_message_citations() {
+    let raw = json!({
+        "choices": [{
+            "message": {
+                "content": "Body.",
+                "citations": ["https://x.example", { "url": "https://y.example", "title": "Y" }]
+            }
+        }]
+    });
+    let resp = parse_chat_completions(&raw).expect("parse");
+    assert_eq!(resp.sources.len(), 2);
+    assert_eq!(resp.sources[1].title.as_deref(), Some("Y"));
+}
+
+#[test]
+fn extracts_top_level_search_sources() {
+    let raw = json!({
+        "choices": [{ "message": { "content": "ok." } }],
+        "search_sources": [
+            { "url": "https://m.example/a", "title": "MA", "type": "web" },
+            { "url": "https://m.example/b", "title": "MB", "type": "web" }
+        ]
+    });
+    let resp = parse_chat_completions(&raw).expect("parse");
+    assert_eq!(resp.sources.len(), 2);
+    assert_eq!(resp.sources[0].url, "https://m.example/a");
+}
+
+#[test]
+fn extracts_inline_bracket_citations_from_content() {
+    let raw = json!({
+        "choices": [{
+            "message": { "content": "fact[[1]](https://c.example/p1) and[[2]](https://c.example/p2)." }
+        }]
+    });
+    let resp = parse_chat_completions(&raw).expect("parse");
+    let urls: Vec<_> = resp.sources.iter().map(|s| s.url.as_str()).collect();
+    assert!(urls.contains(&"https://c.example/p1"));
+    assert!(urls.contains(&"https://c.example/p2"));
+}
+
+#[test]
+fn merges_and_dedupes_across_all_paths() {
+    let raw = json!({
+        "choices": [{
+            "message": {
+                "content": "see[[1]](https://dup.example/x) more.",
+                "annotations": [
+                    { "type": "url_citation", "url": "https://dup.example/x", "title": "Dup" }
+                ],
+                "citations": ["https://uniq.example/m"]
+            }
+        }],
+        "search_sources": [{ "url": "https://uniq.example/n", "title": "N" }]
+    });
+    let resp = parse_chat_completions(&raw).expect("parse");
+    let urls: Vec<_> = resp.sources.iter().map(|s| s.url.as_str()).collect();
+    assert_eq!(urls.len(), 3, "got {urls:?}");
+    assert!(urls.contains(&"https://dup.example/x"));
+    assert!(urls.contains(&"https://uniq.example/m"));
+    assert!(urls.contains(&"https://uniq.example/n"));
+}
+
+#[test]
+fn errors_when_content_empty_and_no_sources() {
+    let raw = json!({ "choices": [{ "message": { "content": "" } }] });
+    assert!(parse_chat_completions(&raw).is_err());
+}


### PR DESCRIPTION
## Summary

- 新增第二条上游通道：`POST /v1/chat/completions`，与原 `/v1/responses` 并存且互斥
- 由新增 env 三件套 `OPENAI_COMPATIBLE_API_URL / _KEY / _MODEL` 激活；若 `GROK_SEARCH_API_KEY` 同时存在则 Responses 路优先（向后兼容零迁移）
- 信源四路并联抽取：OpenAI `annotations` / Perplexity `citations` / marybrown `search_sources` / 正文 `[[n]](url)` 兜底
- `x_search_enabled` 在新通道下静默忽略并启动期 warn 一行

## 设计与决策

- 复用既有 `trait AiProvider`（位于 `src/service.rs:20`），新增 `OpenAICompatProvider` 实现之；在 `SearchService::new` 内按 `Config.transport` `match` 分派——零新 trait、零 `Box<dyn>` 额外开销、零新依赖
- `dedupe_sources` 上提到 `src/adapters/sources.rs` 共享，两个 response adapter 共用
- 正文 `[[n]](url)` 抽取手写扫描器，避免引入 `regex` crate
- spec：`docs/superpowers/specs/2026-05-16-openai-compatible-transport-design.md`
- plan：`docs/superpowers/plans/2026-05-16-openai-compatible-transport.md`

## 文件变更

- 新增：`src/adapters/{chat_completions_request,chat_completions_response,sources}.rs`、`src/providers/openai_compatible.rs`
- 修改：`src/config.rs`（+ `Transport` enum + 3 字段 + `decide_transport`）、`src/service.rs`（dispatch）、`src/adapters/grok_responses_response.rs`（switch to shared dedupe）、`README.md`、`CHANGELOG.md`、`.env.example`、CONFIG_TEMPLATE
- 测试：`tests/openai_compatible_adapter.rs`（11 tests）、`tests/integration_compat.rs`（1 ignored e2e）、`tests/integration_service.rs`（1 ignored e2e through full SearchService）

## Test Plan

- [x] `cargo test` — 全部绿（59 passed + 2 ignored，零失败）
- [x] `cargo build --release` — 干净无 warning
- [x] e2e probe (modelverse / chat-completions)：单 provider 层 — 联网命中 2025-11-19 实时事实 + 1 source
- [x] e2e probe (modelverse / chat-completions)：完整 `SearchService::new` → `web_search` 入口 — transport=ChatCompletions、内容正确、sources_count=1、session_id 落盘
- [ ] e2e probe (marybrown / chat-completions)：HTTP 完成但上游账号池 429，待网关恢复后复测

## 兼容性

- 既有 `GROK_*` 用户无需任何变更；`Transport` 默认值为 `Responses`
- 新增字段与配置文件段以 `openai_compatible_*` 命名，与既有 `grok_*` 不冲突