### PR TITLE
fix(config): resolve config path on native Windows shells

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to GrokSearch-rs are documented here.
 
+## Unreleased
+
+### Added
+
+- 跨平台配置路径解析：Windows（PowerShell / cmd）下自动回退到 `%USERPROFILE%\.config\grok-search-rs\config.toml`，无需再手动设置 `$env:HOME`。Unix / macOS / Git Bash 沿用 `$HOME/.config/...`，行为零变化。`grok-search-rs --init` 在三平台均一键直跑。
+- `config::config_path_for(env_map)` 公共测试入口，便于注入式断言跨平台路径解析。
+
+### Fixed
+
+- Windows 下 `grok-search-rs --init` 报错 `cannot resolve config path: HOME is unset...` —— 根因是 PowerShell/cmd 默认无 `HOME` 变量，现已改为优先 `HOME`、回退 `USERPROFILE`，错误信息同步更新。
+
 ## 0.1.10 - 2026-05-16
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -299,17 +299,25 @@ GROK_SEARCH_X_SEARCH=true       # optional
 
 ### 🗂 Global config file (set once, reuse across clients)
 
-Tired of duplicating `env` blocks in every client's MCP config? Run `grok-search-rs --init` to scaffold `~/.config/grok-search-rs/config.toml`, fill in your keys, and every client can shrink to just `{"command": "grok-search-rs"}`.
+Tired of duplicating `env` blocks in every client's MCP config? Run `grok-search-rs --init` to scaffold `<home>/.config/grok-search-rs/config.toml`, fill in your keys, and every client can shrink to just `{"command": "grok-search-rs"}`. Works the same on macOS, Linux, and Windows — no shell variables to set.
 
 ```bash
 grok-search-rs --init       # scaffold template (idempotent, never overwrites)
 $EDITOR ~/.config/grok-search-rs/config.toml
 ```
 
+PowerShell:
+
+```powershell
+grok-search-rs --init
+notepad $env:USERPROFILE\.config\grok-search-rs\config.toml
+```
+
 **Path** (auto‑detected):
 
-1. `$GROK_SEARCH_CONFIG` — explicit override path.
-2. `~/.config/grok-search-rs/config.toml` — default.
+1. `$GROK_SEARCH_CONFIG` — explicit override path (any platform).
+2. `$HOME/.config/grok-search-rs/config.toml` — Unix, macOS, Git Bash.
+3. `%USERPROFILE%\.config\grok-search-rs\config.toml` — native Windows shells.
 
 **Precedence**: client `env` block **>** config file **>** built‑in defaults. So a per‑client `env` can still override the file when you want a one‑off model.
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -3,7 +3,7 @@
 GrokSearch-rs reads configuration from two sources, merged with the following precedence:
 
 1. **Process environment variables** (highest — what your MCP client passes in `env`).
-2. **Global TOML config file** — `$GROK_SEARCH_CONFIG` if set, otherwise `~/.config/grok-search-rs/config.toml`.
+2. **Global TOML config file** — `$GROK_SEARCH_CONFIG` if set, otherwise `<home>/.config/grok-search-rs/config.toml` on every platform. `<home>` is `$HOME` on Unix / Git Bash, `%USERPROFILE%` on native Windows shells (PowerShell, cmd).
 3. **Built-in defaults** (lowest).
 
 The config file is optional; missing files are skipped silently. See the [Config file](#config-file) section below for the TOML schema. The AI provider contract is intentionally narrow: configure a Grok/OpenAI-compatible root URL and the server calls `/v1/responses`.
@@ -59,7 +59,15 @@ The example above calls `https://api.modelverse.cn/v1/responses`.
 
 ## Config file
 
-Drop a TOML file at `~/.config/grok-search-rs/config.toml` (or any path pointed to by `GROK_SEARCH_CONFIG`) to set defaults once and skip the per-client `env` block. Process env still wins, so individual clients can override any field at runtime.
+Drop a TOML file at `<home>/.config/grok-search-rs/config.toml` (or any path pointed to by `GROK_SEARCH_CONFIG`) to set defaults once and skip the per-client `env` block. Process env still wins, so individual clients can override any field at runtime.
+
+Resolved per platform:
+
+- **macOS / Linux**: `$HOME/.config/grok-search-rs/config.toml` — e.g. `/Users/alice/.config/grok-search-rs/config.toml`.
+- **Windows (PowerShell / cmd)**: `%USERPROFILE%\.config\grok-search-rs\config.toml` — e.g. `C:\Users\chen\.config\grok-search-rs\config.toml`.
+- **Windows (Git Bash / MSYS)**: same as Unix — `$HOME/.config/grok-search-rs/config.toml`.
+
+`grok-search-rs --init` picks the right path automatically; no platform-specific shell setup required.
 
 ### Scaffolding the file — `--init`
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -103,7 +103,9 @@ impl ConfigFile {
 
 impl Config {
     /// Load config with full precedence chain: process env > config file > defaults.
-    /// Config file path: `$GROK_SEARCH_CONFIG` if set, else `~/.config/grok-search-rs/config.toml`.
+    /// Config file path: `$GROK_SEARCH_CONFIG` if set, else
+    /// `<home>/.config/grok-search-rs/config.toml`, where `<home>` is `$HOME`
+    /// on Unix / Git Bash and `%USERPROFILE%` on native Windows shells.
     /// Missing or unparseable files are skipped silently (env-only mode).
     pub fn load() -> Self {
         Self::load_from(std::env::vars())
@@ -191,20 +193,53 @@ fn resolve_config_path(env: &HashMap<String, String>) -> Option<PathBuf> {
     if let Some(explicit) = env.get("GROK_SEARCH_CONFIG").filter(|v| !v.is_empty()) {
         return Some(PathBuf::from(explicit));
     }
-    let home = env.get("HOME").filter(|v| !v.is_empty())?;
+    let home = resolve_home_dir(env)?;
     Some(
-        Path::new(home)
-            .join(".config")
+        home.join(".config")
             .join("grok-search-rs")
             .join("config.toml"),
     )
 }
 
-/// Resolved config file path using process env (`$GROK_SEARCH_CONFIG` or
-/// `~/.config/grok-search-rs/config.toml`). `None` when `HOME` is unset and no
-/// explicit path is provided.
+/// Cross-platform home directory resolution. Reads `$HOME` first (Unix and
+/// Git Bash / MSYS on Windows both set it), then falls back to
+/// `%USERPROFILE%` for native Windows shells (PowerShell, cmd) where `HOME`
+/// is not part of the default environment. Env-driven so tests can inject
+/// either layout without touching real process env.
+fn resolve_home_dir(env: &HashMap<String, String>) -> Option<PathBuf> {
+    if let Some(home) = env.get("HOME").filter(|v| !v.is_empty()) {
+        return Some(PathBuf::from(home));
+    }
+    if let Some(profile) = env.get("USERPROFILE").filter(|v| !v.is_empty()) {
+        return Some(PathBuf::from(profile));
+    }
+    None
+}
+
+/// Resolved config file path using process env. Precedence:
+/// 1. `$GROK_SEARCH_CONFIG` (any platform, explicit override)
+/// 2. `$HOME/.config/grok-search-rs/config.toml` (Unix / Git Bash)
+/// 3. `%USERPROFILE%\.config\grok-search-rs\config.toml` (native Windows)
+///
+/// Returns `None` only when none of the above are set.
 pub fn config_path() -> Option<PathBuf> {
     let env: HashMap<String, String> = std::env::vars().collect();
+    resolve_config_path(&env)
+}
+
+/// Test-friendly variant of [`config_path`] that takes an explicit env map.
+/// Lets integration tests assert path resolution across platforms without
+/// mutating process-global env state.
+pub fn config_path_for<I, K, V>(env_vars: I) -> Option<PathBuf>
+where
+    I: IntoIterator<Item = (K, V)>,
+    K: Into<String>,
+    V: Into<String>,
+{
+    let env: HashMap<String, String> = env_vars
+        .into_iter()
+        .map(|(k, v)| (k.into(), v.into()))
+        .collect();
     resolve_config_path(&env)
 }
 
@@ -232,7 +267,10 @@ pub fn write_template(path: &Path) -> std::io::Result<InitOutcome> {
 /// Embedded TOML template. All keys are commented so an empty scaffold cannot
 /// silently override built-in defaults; the user uncomments only what they need.
 pub const CONFIG_TEMPLATE: &str = r#"# grok-search-rs global configuration
-# Path: ~/.config/grok-search-rs/config.toml  (or $GROK_SEARCH_CONFIG)
+# Default path:
+#   Unix / macOS / Git Bash:   $HOME/.config/grok-search-rs/config.toml
+#   Windows (PowerShell/cmd):  %USERPROFILE%\.config\grok-search-rs\config.toml
+# Override anywhere with $GROK_SEARCH_CONFIG=/abs/path/to/config.toml
 #
 # Precedence: process env > this file > built-in defaults.
 # All keys below are commented out; uncomment and fill what you need.

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,7 +36,8 @@ async fn main() -> anyhow::Result<()> {
 fn run_init() -> anyhow::Result<()> {
     let path = config::config_path().ok_or_else(|| {
         anyhow::anyhow!(
-            "cannot resolve config path: HOME is unset and GROK_SEARCH_CONFIG is not provided"
+            "cannot resolve config path: set GROK_SEARCH_CONFIG to an explicit file path, \
+             or ensure HOME (Unix / Git Bash) or USERPROFILE (Windows) is set"
         )
     })?;
     match config::write_template(&path)? {

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -295,3 +295,56 @@ fn config_path_honors_explicit_env_override() {
         assert!(p.ends_with("config.toml"));
     }
 }
+
+#[test]
+fn config_path_explicit_override_wins_over_home() {
+    let path = config::config_path_for([
+        ("GROK_SEARCH_CONFIG", "/tmp/custom/grok.toml"),
+        ("HOME", "/home/ignored"),
+        ("USERPROFILE", "C:\\Users\\ignored"),
+    ])
+    .expect("explicit override must resolve");
+    assert_eq!(path, std::path::PathBuf::from("/tmp/custom/grok.toml"));
+}
+
+#[test]
+fn config_path_uses_home_on_unix_layout() {
+    let path = config::config_path_for([("HOME", "/home/alice")])
+        .expect("HOME must produce a path");
+    let expected = std::path::PathBuf::from("/home/alice")
+        .join(".config")
+        .join("grok-search-rs")
+        .join("config.toml");
+    assert_eq!(path, expected);
+}
+
+#[test]
+fn config_path_falls_back_to_userprofile_when_home_missing() {
+    let path = config::config_path_for([("USERPROFILE", "C:\\Users\\chen")])
+        .expect("USERPROFILE must produce a path on Windows-style env");
+    let expected = std::path::PathBuf::from("C:\\Users\\chen")
+        .join(".config")
+        .join("grok-search-rs")
+        .join("config.toml");
+    assert_eq!(path, expected);
+}
+
+#[test]
+fn config_path_prefers_home_over_userprofile_when_both_set() {
+    let path = config::config_path_for([
+        ("HOME", "/home/alice"),
+        ("USERPROFILE", "C:\\Users\\chen"),
+    ])
+    .expect("must resolve");
+    assert!(
+        path.starts_with("/home/alice"),
+        "HOME should win, got {}",
+        path.display()
+    );
+}
+
+#[test]
+fn config_path_none_when_no_env_set() {
+    let env: [(&str, &str); 0] = [];
+    assert!(config::config_path_for(env).is_none());
+}


### PR DESCRIPTION
## Summary
- Windows (PowerShell / cmd) 下默认无 `HOME` 环境变量，导致 `grok-search-rs --init` 报错 `cannot resolve config path: HOME is unset...`，且 MCP 客户端 spawn 子进程加载配置时同样静默走 env-only 模式。
- 修复：`resolve_home_dir` 在 `HOME` 缺失时回退到 `USERPROFILE`，所有平台保持统一的 `<home>/.config/grok-search-rs/config.toml` 路径布局。
- macOS / Linux / Git Bash 行为完全不变；零新依赖。

## Changes
- `src/config.rs` — 新增 `resolve_home_dir` helper、公共 `config_path_for(env_map)` 测试入口；`CONFIG_TEMPLATE` 注释标注三平台路径。
- `src/main.rs` — `--init` 错误提示扩写为三选一：`GROK_SEARCH_CONFIG` / `HOME` (Unix/Git Bash) / `USERPROFILE` (Windows)。
- `tests/config.rs` — 5 个新单测：explicit override、Unix HOME、Windows USERPROFILE 回退、HOME 优先级、全空 None。
- `README.md` / `docs/CONFIGURATION.md` / `CHANGELOG.md` — 文档同步三平台路径说明，附 PowerShell 示例。

## Test plan
- [x] `cargo test` 全绿（含 5 个新增 config_path 单测）
- [x] macOS 现有路径解析行为零回归（HOME → `~/.config/grok-search-rs/config.toml`）
- [x] 注入 `USERPROFILE` 模拟 Windows env，断言落到 `C:\Users\...\.config\grok-search-rs\config.toml`
- [x] `GROK_SEARCH_CONFIG` 显式覆盖优先级最高
- [ ] 真机 Windows 端 `grok-search-rs --init` 验证（待 reviewer 在 Windows 跑一次）

## Compatibility
- 既有 macOS / Linux 用户路径完全不变。
- 既有 Windows workaround（在 MCP 客户端 env 中塞 `"HOME": "C:\\Users\\..."`）继续兼容——`HOME` 优先级最高。
- 零新增 crate 依赖。

🤖 Generated with [Claude Code](https://claude.com/claude-code)