### PR TITLE
[codex] fix SSE stream completion handling

### DIFF
--- a/src/providers/http.rs
+++ b/src/providers/http.rs
@@ -77,6 +77,7 @@ async fn read_sse_json(response: &mut Response, label: &str) -> Result<Value> {
     let mut output_text = String::new();
     let mut chat_content = String::new();
     let mut last_json = None;
+    let mut chat_metadata = None;
 
     while let Some(chunk) = response
         .chunk()
@@ -90,23 +91,27 @@ async fn read_sse_json(response: &mut Response, label: &str) -> Result<Value> {
             buffer = rest.to_vec();
             let event = parse_sse_event(&event, label)?;
 
-            if event.name.as_deref().is_some_and(is_completion_event_name) && event.data.is_none() {
-                return finish_sse_json(label, last_json, output_text, chat_content);
+            let data = event.data.as_deref().map(str::trim);
+            if event.name.as_deref().is_some_and(is_completion_event_name)
+                && data.map(str::is_empty).unwrap_or(true)
+            {
+                return finish_sse_json(label, last_json, chat_metadata, output_text, chat_content);
             }
 
-            let Some(data) = event.data.as_deref().map(str::trim) else {
+            let Some(data) = data else {
                 continue;
             };
             if data.is_empty() {
                 continue;
             }
             if data == "[DONE]" {
-                return finish_sse_json(label, last_json, output_text, chat_content);
+                return finish_sse_json(label, last_json, chat_metadata, output_text, chat_content);
             }
             let value: Value = serde_json::from_str(data).map_err(|err| {
                 GrokSearchError::Parse(format!("invalid {label} SSE JSON: {err}"))
             })?;
             collect_stream_delta(&value, &mut output_text, &mut chat_content);
+            accumulate_chat_metadata(&mut chat_metadata, &value);
 
             if value.get("type").and_then(Value::as_str) == Some("response.completed") {
                 if let Some(response) = value.get("response") {
@@ -122,7 +127,7 @@ async fn read_sse_json(response: &mut Response, label: &str) -> Result<Value> {
         }
     }
 
-    finish_sse_json(label, last_json, output_text, chat_content)
+    finish_sse_json(label, last_json, chat_metadata, output_text, chat_content)
 }
 
 struct SseEvent {
@@ -137,6 +142,9 @@ fn split_sse_event(buffer: &[u8]) -> Option<(&[u8], &[u8])> {
     if let Some(index) = find_bytes(buffer, b"\r\n\r\n") {
         return Some((&buffer[..index], &buffer[index + 4..]));
     }
+    if let Some(index) = find_bytes(buffer, b"\r\r") {
+        return Some((&buffer[..index], &buffer[index + 2..]));
+    }
     None
 }
 
@@ -149,10 +157,10 @@ fn find_bytes(haystack: &[u8], needle: &[u8]) -> Option<usize> {
 fn parse_sse_event(event: &[u8], label: &str) -> Result<SseEvent> {
     let event = std::str::from_utf8(event)
         .map_err(|err| GrokSearchError::Parse(format!("invalid {label} SSE UTF-8: {err}")))?;
+    let event = event.strip_prefix('\u{feff}').unwrap_or(event);
     let mut name = None;
     let mut lines = Vec::new();
-    for line in event.lines() {
-        let line = line.trim_end_matches('\r');
+    for line in event.split(['\n', '\r']) {
         if let Some(event_name) = line.strip_prefix("event:") {
             name = Some(event_name.trim_start().to_string());
             continue;
@@ -179,8 +187,76 @@ fn is_completion_event_name(name: &str) -> bool {
     )
 }
 
-fn synthesize_chat_json(last_json: Option<Value>, chat_content: String) -> Value {
-    let mut raw = last_json.unwrap_or_else(|| serde_json::json!({}));
+fn accumulate_chat_metadata(acc: &mut Option<Value>, value: &Value) {
+    if value.get("choices").is_none()
+        && value.get("citations").is_none()
+        && value.get("search_sources").is_none()
+    {
+        return;
+    }
+
+    if acc.is_none() {
+        *acc = Some(serde_json::json!({}));
+    }
+    let Some(raw) = acc.as_mut().and_then(Value::as_object_mut) else {
+        return;
+    };
+
+    for key in ["citations", "search_sources"] {
+        if let Some(items) = value.get(key) {
+            append_json_array(raw, key, items);
+        }
+    }
+
+    for pointer in [
+        "/choices/0/message/annotations",
+        "/choices/0/message/citations",
+        "/choices/0/delta/annotations",
+        "/choices/0/delta/citations",
+    ] {
+        let Some(items) = value.pointer(pointer) else {
+            continue;
+        };
+        let key = pointer.rsplit('/').next().unwrap_or_default();
+        let choices = raw
+            .entry("choices".to_string())
+            .or_insert_with(|| serde_json::json!([{ "delta": {} }]));
+        if choices.as_array().map(Vec::is_empty).unwrap_or(true) {
+            *choices = serde_json::json!([{ "delta": {} }]);
+        }
+        if let Some(delta) = choices
+            .pointer_mut("/0/delta")
+            .and_then(Value::as_object_mut)
+        {
+            append_json_array(delta, key, items);
+        }
+    }
+}
+
+fn append_json_array(map: &mut serde_json::Map<String, Value>, key: &str, value: &Value) {
+    let entry = map
+        .entry(key.to_string())
+        .or_insert_with(|| Value::Array(Vec::new()));
+    if !entry.is_array() {
+        *entry = Value::Array(Vec::new());
+    }
+    let Some(out) = entry.as_array_mut() else {
+        return;
+    };
+    match value {
+        Value::Array(items) => out.extend(items.iter().cloned()),
+        other => out.push(other.clone()),
+    }
+}
+
+fn synthesize_chat_json(
+    last_json: Option<Value>,
+    chat_metadata: Option<Value>,
+    chat_content: String,
+) -> Value {
+    let mut raw = chat_metadata
+        .or(last_json)
+        .unwrap_or_else(|| serde_json::json!({}));
     if !raw.is_object() {
         raw = serde_json::json!({});
     }
@@ -247,6 +323,7 @@ fn collect_stream_delta(value: &Value, output_text: &mut String, chat_content: &
 fn finish_sse_json(
     label: &str,
     last_json: Option<Value>,
+    chat_metadata: Option<Value>,
     output_text: String,
     chat_content: String,
 ) -> Result<Value> {
@@ -254,7 +331,7 @@ fn finish_sse_json(
         return Ok(serde_json::json!({ "output_text": output_text }));
     }
     if !chat_content.is_empty() {
-        return Ok(synthesize_chat_json(last_json, chat_content));
+        return Ok(synthesize_chat_json(last_json, chat_metadata, chat_content));
     }
     last_json.ok_or_else(|| {
         GrokSearchError::Parse(format!("{label} SSE stream ended without JSON data"))

--- a/src/providers/http.rs
+++ b/src/providers/http.rs
@@ -1,4 +1,4 @@
-use reqwest::Client;
+use reqwest::{Client, Response};
 use serde_json::Value;
 use std::time::Duration;
 
@@ -30,7 +30,7 @@ pub async fn post_json(
     body: &Value,
     label: &str,
 ) -> Result<Value> {
-    let response = client
+    let mut response = client
         .post(endpoint)
         .bearer_auth(api_key)
         .json(body)
@@ -45,6 +45,17 @@ pub async fn post_json(
         })?;
 
     let status = response.status();
+    let content_type = response
+        .headers()
+        .get(reqwest::header::CONTENT_TYPE)
+        .and_then(|value| value.to_str().ok())
+        .unwrap_or_default()
+        .to_ascii_lowercase();
+
+    if status.is_success() && content_type.starts_with("text/event-stream") {
+        return read_sse_json(&mut response, label).await;
+    }
+
     let bytes = response
         .bytes()
         .await
@@ -59,4 +70,124 @@ pub async fn post_json(
 
     serde_json::from_slice(&bytes)
         .map_err(|err| GrokSearchError::Parse(format!("invalid {label} JSON: {err}")))
+}
+
+async fn read_sse_json(response: &mut Response, label: &str) -> Result<Value> {
+    let mut buffer = String::new();
+    let mut output_text = String::new();
+    let mut chat_content = String::new();
+    let mut last_json = None;
+
+    while let Some(chunk) = response
+        .chunk()
+        .await
+        .map_err(|err| GrokSearchError::Provider(format!("{label} stream read failed: {err}")))?
+    {
+        let text = String::from_utf8_lossy(&chunk);
+        buffer.push_str(&text);
+
+        while let Some((event, rest)) = split_sse_event(&buffer) {
+            let event = event.to_string();
+            buffer = rest.to_string();
+            let Some(data) = collect_sse_data(&event) else {
+                continue;
+            };
+            let data = data.trim();
+            if data.is_empty() {
+                continue;
+            }
+            if data == "[DONE]" {
+                return finish_sse_json(label, last_json, output_text, chat_content);
+            }
+
+            let value: Value = serde_json::from_str(data).map_err(|err| {
+                GrokSearchError::Parse(format!("invalid {label} SSE JSON: {err}"))
+            })?;
+            collect_stream_delta(&value, &mut output_text, &mut chat_content);
+
+            if value.get("type").and_then(Value::as_str) == Some("response.completed") {
+                if let Some(response) = value.get("response") {
+                    return Ok(response.clone());
+                }
+                if !output_text.is_empty() {
+                    return Ok(serde_json::json!({ "output_text": output_text }));
+                }
+                return Ok(value);
+            }
+
+            last_json = Some(value);
+        }
+    }
+
+    finish_sse_json(label, last_json, output_text, chat_content)
+}
+
+fn split_sse_event(buffer: &str) -> Option<(&str, &str)> {
+    if let Some(index) = buffer.find("\n\n") {
+        return Some((&buffer[..index], &buffer[index + 2..]));
+    }
+    if let Some(index) = buffer.find("\r\n\r\n") {
+        return Some((&buffer[..index], &buffer[index + 4..]));
+    }
+    None
+}
+
+fn collect_sse_data(event: &str) -> Option<String> {
+    let mut lines = Vec::new();
+    for line in event.lines() {
+        let line = line.trim_end_matches('\r');
+        if let Some(data) = line.strip_prefix("data:") {
+            lines.push(data.trim_start());
+        }
+    }
+    if lines.is_empty() {
+        None
+    } else {
+        Some(lines.join("\n"))
+    }
+}
+
+fn collect_stream_delta(value: &Value, output_text: &mut String, chat_content: &mut String) {
+    if value.get("type").and_then(Value::as_str) == Some("response.output_text.delta") {
+        if let Some(delta) = value.get("delta").and_then(Value::as_str) {
+            output_text.push_str(delta);
+        }
+    }
+
+    if let Some(content) = value.pointer("/choices/0/delta/content") {
+        match content {
+            Value::String(text) => chat_content.push_str(text),
+            Value::Array(parts) => {
+                for part in parts {
+                    if let Some(text) = part
+                        .get("text")
+                        .or_else(|| part.get("content"))
+                        .and_then(Value::as_str)
+                    {
+                        chat_content.push_str(text);
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+fn finish_sse_json(
+    label: &str,
+    last_json: Option<Value>,
+    output_text: String,
+    chat_content: String,
+) -> Result<Value> {
+    if !output_text.is_empty() {
+        return Ok(serde_json::json!({ "output_text": output_text }));
+    }
+    if !chat_content.is_empty() {
+        return Ok(serde_json::json!({
+            "choices": [{ "message": { "content": chat_content } }]
+        }));
+    }
+    last_json.ok_or_else(|| {
+        GrokSearchError::Parse(format!("{label} SSE stream ended without JSON data"))
+    })
 }

--- a/src/providers/http.rs
+++ b/src/providers/http.rs
@@ -73,7 +73,7 @@ pub async fn post_json(
 }
 
 async fn read_sse_json(response: &mut Response, label: &str) -> Result<Value> {
-    let mut buffer = String::new();
+    let mut buffer = Vec::new();
     let mut output_text = String::new();
     let mut chat_content = String::new();
     let mut last_json = None;
@@ -83,23 +83,26 @@ async fn read_sse_json(response: &mut Response, label: &str) -> Result<Value> {
         .await
         .map_err(|err| GrokSearchError::Provider(format!("{label} stream read failed: {err}")))?
     {
-        let text = String::from_utf8_lossy(&chunk);
-        buffer.push_str(&text);
+        buffer.extend_from_slice(&chunk);
 
         while let Some((event, rest)) = split_sse_event(&buffer) {
-            let event = event.to_string();
-            buffer = rest.to_string();
-            let Some(data) = collect_sse_data(&event) else {
+            let event = event.to_vec();
+            buffer = rest.to_vec();
+            let event = parse_sse_event(&event, label)?;
+
+            if event.name.as_deref().is_some_and(is_completion_event_name) && event.data.is_none() {
+                return finish_sse_json(label, last_json, output_text, chat_content);
+            }
+
+            let Some(data) = event.data.as_deref().map(str::trim) else {
                 continue;
             };
-            let data = data.trim();
             if data.is_empty() {
                 continue;
             }
             if data == "[DONE]" {
                 return finish_sse_json(label, last_json, output_text, chat_content);
             }
-
             let value: Value = serde_json::from_str(data).map_err(|err| {
                 GrokSearchError::Parse(format!("invalid {label} SSE JSON: {err}"))
             })?;
@@ -122,28 +125,96 @@ async fn read_sse_json(response: &mut Response, label: &str) -> Result<Value> {
     finish_sse_json(label, last_json, output_text, chat_content)
 }
 
-fn split_sse_event(buffer: &str) -> Option<(&str, &str)> {
-    if let Some(index) = buffer.find("\n\n") {
+struct SseEvent {
+    name: Option<String>,
+    data: Option<String>,
+}
+
+fn split_sse_event(buffer: &[u8]) -> Option<(&[u8], &[u8])> {
+    if let Some(index) = find_bytes(buffer, b"\n\n") {
         return Some((&buffer[..index], &buffer[index + 2..]));
     }
-    if let Some(index) = buffer.find("\r\n\r\n") {
+    if let Some(index) = find_bytes(buffer, b"\r\n\r\n") {
         return Some((&buffer[..index], &buffer[index + 4..]));
     }
     None
 }
 
-fn collect_sse_data(event: &str) -> Option<String> {
+fn find_bytes(haystack: &[u8], needle: &[u8]) -> Option<usize> {
+    haystack
+        .windows(needle.len())
+        .position(|window| window == needle)
+}
+
+fn parse_sse_event(event: &[u8], label: &str) -> Result<SseEvent> {
+    let event = std::str::from_utf8(event)
+        .map_err(|err| GrokSearchError::Parse(format!("invalid {label} SSE UTF-8: {err}")))?;
+    let mut name = None;
     let mut lines = Vec::new();
     for line in event.lines() {
         let line = line.trim_end_matches('\r');
+        if let Some(event_name) = line.strip_prefix("event:") {
+            name = Some(event_name.trim_start().to_string());
+            continue;
+        }
         if let Some(data) = line.strip_prefix("data:") {
             lines.push(data.trim_start());
         }
     }
-    if lines.is_empty() {
-        None
+
+    Ok(SseEvent {
+        name,
+        data: if lines.is_empty() {
+            None
+        } else {
+            Some(lines.join("\n"))
+        },
+    })
+}
+
+fn is_completion_event_name(name: &str) -> bool {
+    matches!(
+        name,
+        "done" | "end" | "complete" | "completed" | "response.completed"
+    )
+}
+
+fn synthesize_chat_json(last_json: Option<Value>, chat_content: String) -> Value {
+    let mut raw = last_json.unwrap_or_else(|| serde_json::json!({}));
+    if !raw.is_object() {
+        raw = serde_json::json!({});
+    }
+
+    let message = raw
+        .pointer("/choices/0/message")
+        .cloned()
+        .unwrap_or_else(|| serde_json::json!({}));
+    let delta = raw
+        .pointer("/choices/0/delta")
+        .cloned()
+        .unwrap_or_else(|| serde_json::json!({}));
+
+    let mut message = match message {
+        Value::Object(map) => map,
+        _ => serde_json::Map::new(),
+    };
+    if let Value::Object(delta) = delta {
+        for key in ["annotations", "citations"] {
+            if !message.contains_key(key) {
+                if let Some(value) = delta.get(key) {
+                    message.insert(key.to_string(), value.clone());
+                }
+            }
+        }
+    }
+    message.insert("content".to_string(), Value::String(chat_content));
+
+    let choice = serde_json::json!({ "message": Value::Object(message) });
+    if let Some(object) = raw.as_object_mut() {
+        object.insert("choices".to_string(), Value::Array(vec![choice]));
+        raw
     } else {
-        Some(lines.join("\n"))
+        serde_json::json!({ "choices": [choice] })
     }
 }
 
@@ -183,9 +254,7 @@ fn finish_sse_json(
         return Ok(serde_json::json!({ "output_text": output_text }));
     }
     if !chat_content.is_empty() {
-        return Ok(serde_json::json!({
-            "choices": [{ "message": { "content": chat_content } }]
-        }));
+        return Ok(synthesize_chat_json(last_json, chat_content));
     }
     last_json.ok_or_else(|| {
         GrokSearchError::Parse(format!("{label} SSE stream ended without JSON data"))

--- a/src/providers/http.rs
+++ b/src/providers/http.rs
@@ -89,41 +89,30 @@ async fn read_sse_json(response: &mut Response, label: &str) -> Result<Value> {
         while let Some((event, rest)) = split_sse_event(&buffer) {
             let event = event.to_vec();
             buffer = rest.to_vec();
-            let event = parse_sse_event(&event, label)?;
-
-            let data = event.data.as_deref().map(str::trim);
-            if event.name.as_deref().is_some_and(is_completion_event_name)
-                && data.map(str::is_empty).unwrap_or(true)
-            {
-                return finish_sse_json(label, last_json, chat_metadata, output_text, chat_content);
-            }
-
-            let Some(data) = data else {
-                continue;
-            };
-            if data.is_empty() {
-                continue;
-            }
-            if data == "[DONE]" {
-                return finish_sse_json(label, last_json, chat_metadata, output_text, chat_content);
-            }
-            let value: Value = serde_json::from_str(data).map_err(|err| {
-                GrokSearchError::Parse(format!("invalid {label} SSE JSON: {err}"))
-            })?;
-            collect_stream_delta(&value, &mut output_text, &mut chat_content);
-            accumulate_chat_metadata(&mut chat_metadata, &value);
-
-            if value.get("type").and_then(Value::as_str) == Some("response.completed") {
-                if let Some(response) = value.get("response") {
-                    return Ok(response.clone());
-                }
-                if !output_text.is_empty() {
-                    return Ok(serde_json::json!({ "output_text": output_text }));
-                }
+            if let Some(value) = process_sse_event(
+                &event,
+                label,
+                &mut last_json,
+                &mut chat_metadata,
+                &mut output_text,
+                &mut chat_content,
+            )? {
                 return Ok(value);
             }
+        }
+    }
 
-            last_json = Some(value);
+    if !buffer.is_empty() {
+        let event = std::mem::take(&mut buffer);
+        if let Some(value) = process_sse_event(
+            &event,
+            label,
+            &mut last_json,
+            &mut chat_metadata,
+            &mut output_text,
+            &mut chat_content,
+        )? {
+            return Ok(value);
         }
     }
 
@@ -184,6 +173,105 @@ fn is_completion_event_name(name: &str) -> bool {
         name,
         "done" | "end" | "complete" | "completed" | "response.completed"
     )
+}
+
+fn process_sse_event(
+    event: &[u8],
+    label: &str,
+    last_json: &mut Option<Value>,
+    chat_metadata: &mut Option<Value>,
+    output_text: &mut String,
+    chat_content: &mut String,
+) -> Result<Option<Value>> {
+    let event = parse_sse_event(event, label)?;
+    let named_completion = event.name.as_deref().is_some_and(is_completion_event_name);
+    let data = event.data.as_deref().map(str::trim);
+
+    if named_completion && data.map(str::is_empty).unwrap_or(true) {
+        return finish_sse_state(label, last_json, chat_metadata, output_text, chat_content)
+            .map(Some);
+    }
+
+    let Some(data) = data else {
+        return Ok(None);
+    };
+    if data.is_empty() {
+        return Ok(None);
+    }
+    if data == "[DONE]" {
+        return finish_sse_state(label, last_json, chat_metadata, output_text, chat_content)
+            .map(Some);
+    }
+
+    let value: Value = serde_json::from_str(data)
+        .map_err(|err| GrokSearchError::Parse(format!("invalid {label} SSE JSON: {err}")))?;
+    collect_stream_delta(&value, output_text, chat_content);
+    accumulate_chat_metadata(chat_metadata, &value);
+
+    if let Some(kind) = response_terminal_error_type(&value) {
+        return Err(GrokSearchError::Provider(format!(
+            "{label} stream ended with {kind}: {}",
+            response_terminal_error_detail(&value)
+        )));
+    }
+
+    if value.get("type").and_then(Value::as_str) == Some("response.completed") {
+        if let Some(response) = value.get("response") {
+            return Ok(Some(response.clone()));
+        }
+        if !output_text.is_empty() {
+            return Ok(Some(
+                serde_json::json!({ "output_text": output_text.clone() }),
+            ));
+        }
+        return Ok(Some(value));
+    }
+
+    if named_completion {
+        *last_json = Some(value);
+        return finish_sse_state(label, last_json, chat_metadata, output_text, chat_content)
+            .map(Some);
+    }
+
+    *last_json = Some(value);
+    Ok(None)
+}
+
+fn finish_sse_state(
+    label: &str,
+    last_json: &mut Option<Value>,
+    chat_metadata: &mut Option<Value>,
+    output_text: &mut String,
+    chat_content: &mut String,
+) -> Result<Value> {
+    finish_sse_json(
+        label,
+        last_json.take(),
+        chat_metadata.take(),
+        std::mem::take(output_text),
+        std::mem::take(chat_content),
+    )
+}
+
+fn response_terminal_error_type(value: &Value) -> Option<&str> {
+    match value.get("type").and_then(Value::as_str) {
+        Some("response.failed" | "response.incomplete") => {
+            value.get("type").and_then(Value::as_str)
+        }
+        _ => None,
+    }
+}
+
+fn response_terminal_error_detail(value: &Value) -> String {
+    value
+        .pointer("/error/message")
+        .or_else(|| value.pointer("/response/error/message"))
+        .or_else(|| value.get("error"))
+        .map(|detail| match detail {
+            Value::String(text) => text.clone(),
+            other => other.to_string(),
+        })
+        .unwrap_or_else(|| value.to_string())
 }
 
 fn accumulate_chat_metadata(acc: &mut Option<Value>, value: &Value) {

--- a/src/providers/http.rs
+++ b/src/providers/http.rs
@@ -136,16 +136,15 @@ struct SseEvent {
 }
 
 fn split_sse_event(buffer: &[u8]) -> Option<(&[u8], &[u8])> {
-    if let Some(index) = find_bytes(buffer, b"\n\n") {
-        return Some((&buffer[..index], &buffer[index + 2..]));
-    }
-    if let Some(index) = find_bytes(buffer, b"\r\n\r\n") {
-        return Some((&buffer[..index], &buffer[index + 4..]));
-    }
-    if let Some(index) = find_bytes(buffer, b"\r\r") {
-        return Some((&buffer[..index], &buffer[index + 2..]));
-    }
-    None
+    let delimiter = [
+        b"\n\n".as_slice(),
+        b"\r\n\r\n".as_slice(),
+        b"\r\r".as_slice(),
+    ]
+    .into_iter()
+    .filter_map(|delimiter| find_bytes(buffer, delimiter).map(|index| (index, delimiter.len())))
+    .min_by_key(|(index, _)| *index)?;
+    Some((&buffer[..delimiter.0], &buffer[delimiter.0 + delimiter.1..]))
 }
 
 fn find_bytes(haystack: &[u8], needle: &[u8]) -> Option<usize> {
@@ -331,6 +330,9 @@ fn finish_sse_json(
         return Ok(serde_json::json!({ "output_text": output_text }));
     }
     if !chat_content.is_empty() {
+        return Ok(synthesize_chat_json(last_json, chat_metadata, chat_content));
+    }
+    if chat_metadata.is_some() {
         return Ok(synthesize_chat_json(last_json, chat_metadata, chat_content));
     }
     last_json.ok_or_else(|| {

--- a/tests/sse_bug_repro.rs
+++ b/tests/sse_bug_repro.rs
@@ -120,6 +120,75 @@ event: done\n\n"
 }
 
 #[tokio::test]
+async fn post_json_returns_when_done_event_has_empty_data() {
+    let chunks = vec![b"event: response.output_text.delta\n\
+data: {\"type\":\"response.output_text.delta\",\"delta\":\"empty data done\"}\n\n\
+event: done\n\
+data:\n\n"
+        .to_vec()];
+    let base = spawn_sse_server(false, chunks).await;
+    let client = build_client(Duration::from_secs(5));
+
+    let raw = post_json(
+        &client,
+        &format!("{}/v1/responses", base),
+        "dummy-key",
+        &json!({"model": "grok-4-fast", "input": "test", "stream": false}),
+        "Grok Responses",
+    )
+    .await
+    .expect("event: done with empty data should terminate the SSE stream");
+
+    assert_eq!(raw["output_text"], "empty data done");
+}
+
+#[tokio::test]
+async fn post_json_splits_cr_only_sse_events() {
+    let chunks = vec![b"event: response.output_text.delta\r\
+data: {\"type\":\"response.output_text.delta\",\"delta\":\"cr done\"}\r\r\
+event: done\r\r"
+        .to_vec()];
+    let base = spawn_sse_server(false, chunks).await;
+    let client = build_client(Duration::from_secs(5));
+
+    let raw = post_json(
+        &client,
+        &format!("{}/v1/responses", base),
+        "dummy-key",
+        &json!({"model": "grok-4-fast", "input": "test", "stream": false}),
+        "Grok Responses",
+    )
+    .await
+    .expect("CR-only SSE frame delimiters should be recognized");
+
+    assert_eq!(raw["output_text"], "cr done");
+}
+
+#[tokio::test]
+async fn post_json_strips_initial_sse_bom() {
+    let chunks = vec![
+        "\u{feff}data: {\"type\":\"response.output_text.delta\",\"delta\":\"bom ok\"}\n\n\
+event: done\n\n"
+            .as_bytes()
+            .to_vec(),
+    ];
+    let base = spawn_sse_server(false, chunks).await;
+    let client = build_client(Duration::from_secs(5));
+
+    let raw = post_json(
+        &client,
+        &format!("{}/v1/responses", base),
+        "dummy-key",
+        &json!({"model": "grok-4-fast", "input": "test", "stream": false}),
+        "Grok Responses",
+    )
+    .await
+    .expect("initial SSE BOM should not hide the first data field");
+
+    assert_eq!(raw["output_text"], "bom ok");
+}
+
+#[tokio::test]
 async fn post_json_decodes_sse_utf8_after_full_event_boundary() {
     let body = "event: response.output_text.delta\n\
 data: {\"type\":\"response.output_text.delta\",\"delta\":\"你好\"}\n\n\
@@ -152,6 +221,7 @@ data: {\"type\":\"response.completed\"}\n\n";
 async fn post_json_preserves_chat_stream_metadata() {
     let chunks = vec![
         b"data: {\"choices\":[{\"delta\":{\"content\":\"answer\",\"annotations\":[{\"type\":\"url_citation\",\"url\":\"https://example.com/a\",\"title\":\"A\"}]}}],\"search_sources\":[{\"url\":\"https://example.com/b\",\"title\":\"B\"}]}\n\n\
+data: {\"choices\":[{\"finish_reason\":\"stop\"}]}\n\n\
 event: done\n\n"
             .to_vec(),
     ];

--- a/tests/sse_bug_repro.rs
+++ b/tests/sse_bug_repro.rs
@@ -9,6 +9,18 @@ use grok_search_rs::providers::http::{build_client, post_json};
 use serde_json::json;
 
 async fn spawn_sse_server(expected_stream: bool, chunks: Vec<Vec<u8>>) -> String {
+    spawn_sse_server_with_mode(expected_stream, chunks, true).await
+}
+
+async fn spawn_closing_sse_server(expected_stream: bool, chunks: Vec<Vec<u8>>) -> String {
+    spawn_sse_server_with_mode(expected_stream, chunks, false).await
+}
+
+async fn spawn_sse_server_with_mode(
+    expected_stream: bool,
+    chunks: Vec<Vec<u8>>,
+    keep_open: bool,
+) -> String {
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();
 
@@ -41,9 +53,13 @@ async fn spawn_sse_server(expected_stream: bool, chunks: Vec<Vec<u8>>) -> String
                     let _ = sock.write_all(&chunk).await;
                 }
 
-                // 不 shutdown：服务端保持连接，客户端必须在 completed 后主动结束读取。
-                let mut one = [0u8; 1];
-                let _ = sock.read(&mut one).await;
+                if keep_open {
+                    // 不 shutdown：服务端保持连接，客户端必须在 completed 后主动结束读取。
+                    let mut one = [0u8; 1];
+                    let _ = sock.read(&mut one).await;
+                } else {
+                    let _ = sock.shutdown().await;
+                }
             });
         }
     });
@@ -140,6 +156,29 @@ data:\n\n"
     .expect("event: done with empty data should terminate the SSE stream");
 
     assert_eq!(raw["output_text"], "empty data done");
+}
+
+#[tokio::test]
+async fn post_json_returns_when_done_event_has_json_payload() {
+    let chunks = vec![b"event: response.output_text.delta\n\
+data: {\"type\":\"response.output_text.delta\",\"delta\":\"json done\"}\n\n\
+event: done\n\
+data: {}\n\n"
+        .to_vec()];
+    let base = spawn_sse_server(false, chunks).await;
+    let client = build_client(Duration::from_secs(5));
+
+    let raw = post_json(
+        &client,
+        &format!("{}/v1/responses", base),
+        "dummy-key",
+        &json!({"model": "grok-4-fast", "input": "test", "stream": false}),
+        "Grok Responses",
+    )
+    .await
+    .expect("event: done with JSON payload should terminate the SSE stream");
+
+    assert_eq!(raw["output_text"], "json done");
 }
 
 #[tokio::test]
@@ -242,6 +281,51 @@ event: done\n\n"
         .collect();
     assert!(urls.contains(&"https://example.com/meta"));
     assert!(urls.contains(&"https://example.com/source"));
+}
+
+#[tokio::test]
+async fn post_json_parses_trailing_sse_event_at_eof() {
+    let chunks = vec![
+        b"data: {\"type\":\"response.output_text.delta\",\"delta\":\"trailing eof\"}".to_vec(),
+    ];
+    let base = spawn_closing_sse_server(false, chunks).await;
+    let client = build_client(Duration::from_secs(5));
+
+    let raw = post_json(
+        &client,
+        &format!("{}/v1/responses", base),
+        "dummy-key",
+        &json!({"model": "grok-4-fast", "input": "test", "stream": false}),
+        "Grok Responses",
+    )
+    .await
+    .expect("EOF should flush the final SSE event even without blank-line delimiter");
+
+    assert_eq!(raw["output_text"], "trailing eof");
+}
+
+#[tokio::test]
+async fn post_json_errors_on_response_failed_terminal_event() {
+    let chunks = vec![b"event: response.failed\n\
+data: {\"type\":\"response.failed\",\"error\":{\"message\":\"upstream failed\"}}\n\n"
+        .to_vec()];
+    let base = spawn_sse_server(false, chunks).await;
+    let client = build_client(Duration::from_secs(5));
+
+    let err = post_json(
+        &client,
+        &format!("{}/v1/responses", base),
+        "dummy-key",
+        &json!({"model": "grok-4-fast", "input": "test", "stream": false}),
+        "Grok Responses",
+    )
+    .await
+    .expect_err("terminal response.failed event should surface as provider error");
+
+    assert!(
+        err.to_string().contains("response.failed") && err.to_string().contains("upstream failed"),
+        "unexpected error: {err}"
+    );
 }
 
 #[tokio::test]

--- a/tests/sse_bug_repro.rs
+++ b/tests/sse_bug_repro.rs
@@ -165,6 +165,30 @@ event: done\r\r"
 }
 
 #[tokio::test]
+async fn post_json_uses_earliest_mixed_sse_delimiter() {
+    let chunks = vec![
+        b"data: {\"type\":\"response.output_text.delta\",\"delta\":\"first\"}\r\n\r\n\
+data: {\"type\":\"response.output_text.delta\",\"delta\":\" second\"}\n\n\
+event: done\n\n"
+            .to_vec(),
+    ];
+    let base = spawn_sse_server(false, chunks).await;
+    let client = build_client(Duration::from_secs(5));
+
+    let raw = post_json(
+        &client,
+        &format!("{}/v1/responses", base),
+        "dummy-key",
+        &json!({"model": "grok-4-fast", "input": "test", "stream": false}),
+        "Grok Responses",
+    )
+    .await
+    .expect("mixed SSE delimiters should split at the earliest event boundary");
+
+    assert_eq!(raw["output_text"], "first second");
+}
+
+#[tokio::test]
 async fn post_json_strips_initial_sse_bom() {
     let chunks = vec![
         "\u{feff}data: {\"type\":\"response.output_text.delta\",\"delta\":\"bom ok\"}\n\n\
@@ -186,6 +210,38 @@ event: done\n\n"
     .expect("initial SSE BOM should not hide the first data field");
 
     assert_eq!(raw["output_text"], "bom ok");
+}
+
+#[tokio::test]
+async fn post_json_preserves_metadata_only_chat_stream() {
+    let chunks = vec![
+        b"data: {\"choices\":[{\"delta\":{\"annotations\":[{\"type\":\"url_citation\",\"url\":\"https://example.com/meta\",\"title\":\"Meta\"}]}}],\"search_sources\":[{\"url\":\"https://example.com/source\",\"title\":\"Source\"}]}\n\n\
+data: {\"choices\":[{\"finish_reason\":\"stop\"}]}\n\n\
+event: done\n\n"
+            .to_vec(),
+    ];
+    let base = spawn_sse_server(true, chunks).await;
+    let client = build_client(Duration::from_secs(5));
+
+    let raw = post_json(
+        &client,
+        &format!("{}/v1/chat/completions", base),
+        "dummy-key",
+        &json!({"model": "grok-4-fast", "messages": [], "stream": true}),
+        "OpenAI-compatible",
+    )
+    .await
+    .expect("metadata-only chat SSE should preserve source provenance");
+
+    let parsed = parse_chat_completions(&raw).expect("metadata-only chat response has sources");
+    assert!(parsed.content.is_empty());
+    let urls: Vec<_> = parsed
+        .sources
+        .iter()
+        .map(|source| source.url.as_str())
+        .collect();
+    assert!(urls.contains(&"https://example.com/meta"));
+    assert!(urls.contains(&"https://example.com/source"));
 }
 
 #[tokio::test]

--- a/tests/sse_bug_repro.rs
+++ b/tests/sse_bug_repro.rs
@@ -4,15 +4,17 @@ use std::time::Duration;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpListener;
 
+use grok_search_rs::adapters::chat_completions_response::parse_chat_completions;
 use grok_search_rs::providers::http::{build_client, post_json};
 use serde_json::json;
 
-async fn spawn_sse_server(expected_stream: bool) -> String {
+async fn spawn_sse_server(expected_stream: bool, chunks: Vec<Vec<u8>>) -> String {
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();
 
     tokio::spawn(async move {
         loop {
+            let chunks = chunks.clone();
             let (mut sock, _) = match listener.accept().await {
                 Ok(s) => s,
                 Err(_) => return,
@@ -31,18 +33,13 @@ async fn spawn_sse_server(expected_stream: bool) -> String {
                     return;
                 }
 
-                let body = b"event: response.created\n\
-data: {\"type\":\"response.created\"}\n\n\
-event: response.output_text.delta\n\
-data: {\"type\":\"response.output_text.delta\",\"delta\":\"streamed answer\"}\n\n\
-event: response.completed\n\
-data: {\"type\":\"response.completed\"}\n\n";
-
                 let resp = "HTTP/1.1 200 OK\r\n\
                      Content-Type: text/event-stream\r\n\
                      Connection: keep-alive\r\n\r\n";
                 let _ = sock.write_all(resp.as_bytes()).await;
-                let _ = sock.write_all(body).await;
+                for chunk in chunks {
+                    let _ = sock.write_all(&chunk).await;
+                }
 
                 // 不 shutdown：服务端保持连接，客户端必须在 completed 后主动结束读取。
                 let mut one = [0u8; 1];
@@ -54,9 +51,19 @@ data: {\"type\":\"response.completed\"}\n\n";
     format!("http://{}", addr)
 }
 
+fn responses_chunks() -> Vec<Vec<u8>> {
+    vec![b"event: response.created\n\
+data: {\"type\":\"response.created\"}\n\n\
+event: response.output_text.delta\n\
+data: {\"type\":\"response.output_text.delta\",\"delta\":\"streamed answer\"}\n\n\
+event: response.completed\n\
+data: {\"type\":\"response.completed\"}\n\n"
+        .to_vec()]
+}
+
 #[tokio::test]
 async fn post_json_returns_when_stream_true_sse_completed_without_connection_close() {
-    let base = spawn_sse_server(true).await;
+    let base = spawn_sse_server(true, responses_chunks()).await;
     let client = build_client(Duration::from_secs(5));
 
     let raw = post_json(
@@ -74,7 +81,7 @@ async fn post_json_returns_when_stream_true_sse_completed_without_connection_clo
 
 #[tokio::test]
 async fn post_json_returns_when_stream_false_still_gets_sse() {
-    let base = spawn_sse_server(false).await;
+    let base = spawn_sse_server(false, responses_chunks()).await;
     let client = build_client(Duration::from_secs(5));
 
     let raw = post_json(
@@ -88,4 +95,86 @@ async fn post_json_returns_when_stream_false_still_gets_sse() {
     .expect("SSE stream should be normalized even when stream:false is ignored");
 
     assert_eq!(raw["output_text"], "streamed answer");
+}
+
+#[tokio::test]
+async fn post_json_returns_when_done_event_has_no_data() {
+    let chunks = vec![b"event: response.output_text.delta\n\
+data: {\"type\":\"response.output_text.delta\",\"delta\":\"done marker\"}\n\n\
+event: done\n\n"
+        .to_vec()];
+    let base = spawn_sse_server(false, chunks).await;
+    let client = build_client(Duration::from_secs(5));
+
+    let raw = post_json(
+        &client,
+        &format!("{}/v1/responses", base),
+        "dummy-key",
+        &json!({"model": "grok-4-fast", "input": "test", "stream": false}),
+        "Grok Responses",
+    )
+    .await
+    .expect("event: done without data should terminate the SSE stream");
+
+    assert_eq!(raw["output_text"], "done marker");
+}
+
+#[tokio::test]
+async fn post_json_decodes_sse_utf8_after_full_event_boundary() {
+    let body = "event: response.output_text.delta\n\
+data: {\"type\":\"response.output_text.delta\",\"delta\":\"你好\"}\n\n\
+event: response.completed\n\
+data: {\"type\":\"response.completed\"}\n\n";
+    let bytes = body.as_bytes();
+    let split = bytes
+        .windows("你好".len())
+        .position(|window| window == "你好".as_bytes())
+        .expect("test body contains multibyte text")
+        + 1;
+    let chunks = vec![bytes[..split].to_vec(), bytes[split..].to_vec()];
+    let base = spawn_sse_server(false, chunks).await;
+    let client = build_client(Duration::from_secs(5));
+
+    let raw = post_json(
+        &client,
+        &format!("{}/v1/responses", base),
+        "dummy-key",
+        &json!({"model": "grok-4-fast", "input": "test", "stream": false}),
+        "Grok Responses",
+    )
+    .await
+    .expect("SSE UTF-8 should be decoded after full event buffering");
+
+    assert_eq!(raw["output_text"], "你好");
+}
+
+#[tokio::test]
+async fn post_json_preserves_chat_stream_metadata() {
+    let chunks = vec![
+        b"data: {\"choices\":[{\"delta\":{\"content\":\"answer\",\"annotations\":[{\"type\":\"url_citation\",\"url\":\"https://example.com/a\",\"title\":\"A\"}]}}],\"search_sources\":[{\"url\":\"https://example.com/b\",\"title\":\"B\"}]}\n\n\
+event: done\n\n"
+            .to_vec(),
+    ];
+    let base = spawn_sse_server(true, chunks).await;
+    let client = build_client(Duration::from_secs(5));
+
+    let raw = post_json(
+        &client,
+        &format!("{}/v1/chat/completions", base),
+        "dummy-key",
+        &json!({"model": "grok-4-fast", "messages": [], "stream": true}),
+        "OpenAI-compatible",
+    )
+    .await
+    .expect("chat SSE should be normalized into a metadata-preserving response");
+
+    let parsed = parse_chat_completions(&raw).expect("chat response should preserve sources");
+    assert_eq!(parsed.content, "answer");
+    let urls: Vec<_> = parsed
+        .sources
+        .iter()
+        .map(|source| source.url.as_str())
+        .collect();
+    assert!(urls.contains(&"https://example.com/a"));
+    assert!(urls.contains(&"https://example.com/b"));
 }

--- a/tests/sse_bug_repro.rs
+++ b/tests/sse_bug_repro.rs
@@ -1,0 +1,91 @@
+// 复现/回归：上游返回 SSE，并且发完 completed 后不主动关闭连接。
+
+use std::time::Duration;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpListener;
+
+use grok_search_rs::providers::http::{build_client, post_json};
+use serde_json::json;
+
+async fn spawn_sse_server(expected_stream: bool) -> String {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    tokio::spawn(async move {
+        loop {
+            let (mut sock, _) = match listener.accept().await {
+                Ok(s) => s,
+                Err(_) => return,
+            };
+            tokio::spawn(async move {
+                let mut buf = [0u8; 4096];
+                let n = sock.read(&mut buf).await.unwrap_or(0);
+                let request = String::from_utf8_lossy(&buf[..n]);
+                let expected = format!(r#""stream":{}"#, expected_stream);
+                if !request.contains(&expected) {
+                    let _ = sock
+                        .write_all(
+                            b"HTTP/1.1 400 Bad Request\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+                        )
+                        .await;
+                    return;
+                }
+
+                let body = b"event: response.created\n\
+data: {\"type\":\"response.created\"}\n\n\
+event: response.output_text.delta\n\
+data: {\"type\":\"response.output_text.delta\",\"delta\":\"streamed answer\"}\n\n\
+event: response.completed\n\
+data: {\"type\":\"response.completed\"}\n\n";
+
+                let resp = "HTTP/1.1 200 OK\r\n\
+                     Content-Type: text/event-stream\r\n\
+                     Connection: keep-alive\r\n\r\n";
+                let _ = sock.write_all(resp.as_bytes()).await;
+                let _ = sock.write_all(body).await;
+
+                // 不 shutdown：服务端保持连接，客户端必须在 completed 后主动结束读取。
+                let mut one = [0u8; 1];
+                let _ = sock.read(&mut one).await;
+            });
+        }
+    });
+
+    format!("http://{}", addr)
+}
+
+#[tokio::test]
+async fn post_json_returns_when_stream_true_sse_completed_without_connection_close() {
+    let base = spawn_sse_server(true).await;
+    let client = build_client(Duration::from_secs(5));
+
+    let raw = post_json(
+        &client,
+        &format!("{}/v1/responses", base),
+        "dummy-key",
+        &json!({"model": "grok-4-fast", "input": "test", "stream": true}),
+        "Grok Responses",
+    )
+    .await
+    .expect("SSE stream should be normalized into JSON");
+
+    assert_eq!(raw["output_text"], "streamed answer");
+}
+
+#[tokio::test]
+async fn post_json_returns_when_stream_false_still_gets_sse() {
+    let base = spawn_sse_server(false).await;
+    let client = build_client(Duration::from_secs(5));
+
+    let raw = post_json(
+        &client,
+        &format!("{}/v1/responses", base),
+        "dummy-key",
+        &json!({"model": "grok-4-fast", "input": "test", "stream": false}),
+        "Grok Responses",
+    )
+    .await
+    .expect("SSE stream should be normalized even when stream:false is ignored");
+
+    assert_eq!(raw["output_text"], "streamed answer");
+}


### PR DESCRIPTION
## Summary
- handle successful `text/event-stream` responses in `post_json` without waiting for upstream connection close
- normalize Responses and chat-completions SSE deltas into the existing JSON parsing path
- add regression coverage for both `stream:true` and ignored `stream:false` SSE responses that keep the socket open

## Root Cause
Some compatible gateways return SSE even when the request asks for non-streaming JSON, and may keep the HTTP connection open after `response.completed`. The previous `response.bytes().await` path waited for EOF, so those gateways could hang until timeout.

## Validation
- `rustfmt --check src/providers/http.rs tests/sse_bug_repro.rs`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --test sse_bug_repro -- --nocapture`
- `cargo test --lib --tests`

Note: full `cargo fmt --check` still reports pre-existing formatting differences outside this PR scope.

Closes #5