### PR TITLE
[codex] Add Grok OAuth auth mode

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,9 @@
 # Grok Responses-compatible gateway. Provide root URL or /v1; endpoint is normalized automatically.
+# Auth modes:
+#   api_key: use GROK_SEARCH_API_KEY
+#   oauth: run `grok-search-rs login`, then set GROK_SEARCH_AUTH_MODE=oauth
+GROK_SEARCH_AUTH_MODE=api_key
+# GROK_SEARCH_AUTH_FILE=C:\Users\you\.config\grok-search-rs\auth.json
 GROK_SEARCH_API_KEY=your-grok-compatible-key
 GROK_SEARCH_URL=https://api.x.ai
 GROK_SEARCH_MODEL=grok-4-1-fast-reasoning

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -264,13 +264,17 @@ version = "0.1.12"
 dependencies = [
  "anyhow",
  "async-trait",
+ "base64",
+ "getrandom 0.3.4",
  "reqwest",
+ "ring",
  "serde",
  "serde_json",
  "tempfile",
  "thiserror",
  "tokio",
  "toml",
+ "url",
  "uuid",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,10 @@ thiserror = "2"
 tokio = { version = "1", features = ["io-std", "io-util", "macros", "rt", "sync"] }
 toml = { version = "0.8", default-features = false, features = ["parse"] }
 uuid = { version = "1", features = ["v4"] }
+base64 = "0.22"
+getrandom = "0.3"
+ring = "0.17"
+url = "2"
 
 [dev-dependencies]
 tempfile = "3"

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 
 - 🔎 **Live web search** with cited sources, cached for follow‑up `get_sources` calls.
 - 🔀 **Two transports** — native xAI Responses (`/v1/responses`) **or** any OpenAI‑compatible chat‑completions gateway (`/v1/chat/completions`). Pick by env vars; no flag.
+- 🔐 **Optional Grok OAuth mode** — `login/status/logout` commands store a local xAI OAuth token for Responses auth, so the MCP server can run without `GROK_SEARCH_API_KEY`.
 - 📥 **Tavily fetch / map** for full‑text extraction and link discovery, with **Firecrawl** as automatic fallback.
 - 🐦 **Optional X/Twitter search** via `x_search` (Responses transport only).
 - 🩺 **`doctor`** — connectivity probe + redacted config in one tool call.
@@ -71,13 +72,37 @@ Pick **one** transport group. Both Tavily and Firecrawl keys are shared across t
 
 | Variable | Default | Purpose |
 |---|---|---|
-| `GROK_SEARCH_API_KEY` | — *(required)* | Bearer token for the Grok / xAI gateway. |
+| `GROK_SEARCH_AUTH_MODE` | `api_key` | `api_key` uses `GROK_SEARCH_API_KEY`; `oauth` uses the local token from `grok-search-rs login`. |
+| `GROK_SEARCH_API_KEY` | — *(required in `api_key` mode)* | Bearer token for the Grok / xAI gateway. |
+| `GROK_SEARCH_AUTH_FILE` | `<home>/.config/grok-search-rs/auth.json` | Optional OAuth token file override. |
 | `GROK_SEARCH_URL` | `https://api.x.ai` | Root, `/v1`, or full‑endpoint URL. |
 | `GROK_SEARCH_MODEL` | `grok-4-1-fast-reasoning` | Model name. |
 | `GROK_SEARCH_WEB_SEARCH` | `true` | Offer `web_search` tool to Grok. |
 | `GROK_SEARCH_X_SEARCH` | `false` | Offer `x_search` tool (X/Twitter) to Grok. |
 
 Verified upstreams: **xAI** (`https://api.x.ai`, both tools), **Modelverse** (`https://api.modelverse.cn`, `x_search` depends on relay).
+
+OAuth mode is a single-binary flow:
+
+```bash
+grok-search-rs login
+grok-search-rs status
+grok-search-rs logout
+```
+
+Then configure your MCP client with:
+
+```toml
+[mcp_servers.grok-search-rs]
+command = "grok-search-rs"
+
+[mcp_servers.grok-search-rs.env]
+GROK_SEARCH_AUTH_MODE = "oauth"
+GROK_SEARCH_MODEL = "grok-4.3"
+GROK_SEARCH_WEB_SEARCH = "true"
+```
+
+OAuth mode reuses Hermes' xAI OAuth client id and stores `auth.json` locally. That may violate xAI terms or affect your account; do not share the token file. If xAI changes or blocks that OAuth flow, switch back to `api_key` mode.
 
 ### B. OpenAI‑compatible chat/completions
 
@@ -111,9 +136,10 @@ Notes:
 
 ### Selection rules at startup
 
-1. If `GROK_SEARCH_API_KEY` is set → **Responses** transport.
-2. Else if both `OPENAI_COMPATIBLE_API_URL` and `OPENAI_COMPATIBLE_API_KEY` are set → **ChatCompletions** transport.
-3. Else → server fails with a clear `MissingConfig` error.
+1. If `GROK_SEARCH_AUTH_MODE=oauth` → **Responses** transport with the local OAuth token.
+2. Else if `GROK_SEARCH_API_KEY` is set → **Responses** transport with a static Bearer key.
+3. Else if both `OPENAI_COMPATIBLE_API_URL` and `OPENAI_COMPATIBLE_API_KEY` are set → **ChatCompletions** transport.
+4. Else → server fails with a clear `MissingConfig` error.
 
 ### Global config file
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -5,7 +5,8 @@ GrokSearch-rs is a Rust MCP server that keeps the original GrokSearch product bo
 ```text
 MCP client
   -> src/mcp.rs
-  -> src/service.rs
+      -> src/service.rs
+      -> credential provider: static API key or xAI OAuth token
       -> Grok Responses provider: /v1/responses with web_search and optional x_search
       -> Tavily provider: search / extract / map
       -> Firecrawl provider: search / scrape fallback
@@ -30,6 +31,13 @@ The service builds an internal search request and sends one Responses payload:
 | Grok Responses | `{GROK_SEARCH_URL normalized to /v1}/responses` | `{"type":"web_search"}` plus optional `{"type":"x_search"}` |
 
 The provider returns normalized assistant content and normalized `Source` values. Empty content or missing native sources are treated as unverifiable for `web_search`.
+
+Authentication is separated from the Responses provider:
+
+- `api_key` mode returns the configured `GROK_SEARCH_API_KEY` as a static Bearer token.
+- `oauth` mode reads the local auth file, refreshes the access token when it is near expiry, and returns the fresh Bearer token for the same `/v1/responses` request body.
+
+OAuth login is not a service boundary. `grok-search-rs login` temporarily listens on `127.0.0.1:56121` for the browser callback, stores the token file, then exits. Normal MCP operation remains stdio only.
 
 ## Source Provenance
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -12,7 +12,9 @@ The config file is optional; missing files are skipped silently. See the [Config
 
 | Variable | Default | Description |
 |---|---|---|
-| `GROK_SEARCH_API_KEY` | required | Bearer token for the configured Grok-compatible gateway. |
+| `GROK_SEARCH_AUTH_MODE` | `api_key` | `api_key` uses `GROK_SEARCH_API_KEY`; `oauth` uses the local token file created by `grok-search-rs login`. |
+| `GROK_SEARCH_API_KEY` | required in `api_key` mode | Bearer token for the configured Grok-compatible gateway. |
+| `GROK_SEARCH_AUTH_FILE` | `<home>/.config/grok-search-rs/auth.json` | Optional OAuth token file override. |
 | `GROK_SEARCH_URL` | `https://api.x.ai` | Root URL, `/v1` base URL, or endpoint-like URL. The service normalizes it to a `/v1` base. |
 | `GROK_SEARCH_MODEL` | `grok-4-1-fast-reasoning` | Model sent in the Responses payload. |
 | `GROK_SEARCH_WEB_SEARCH` | `true` | Sends Responses `{"type":"web_search"}`. |
@@ -30,6 +32,32 @@ GROK_SEARCH_X_SEARCH=false
 ```
 
 The example above calls `https://api.modelverse.cn/v1/responses`.
+
+### OAuth mode
+
+OAuth mode keeps the normal Responses payload and only changes where the Bearer token comes from. The binary handles login and MCP stdio; it does not start a background HTTP proxy.
+
+```bash
+grok-search-rs login
+grok-search-rs status
+grok-search-rs logout
+```
+
+`login` opens xAI OAuth in a browser, listens once on `http://127.0.0.1:56121/callback`, and writes `access_token`, `refresh_token`, `id_token`, `token_endpoint`, `base_url`, and `last_refresh` to `auth.json`. `status` prints token presence, expiry, and the auth file path without printing the token. `logout` removes the local auth file.
+
+OAuth mode reuses Hermes' xAI OAuth client id. This may violate xAI terms or create account risk, and Windows stores the token as a normal local file. Do not share the token file.
+
+Minimal Codex config:
+
+```toml
+[mcp_servers.grok-search-rs]
+command = "grok-search-rs"
+
+[mcp_servers.grok-search-rs.env]
+GROK_SEARCH_AUTH_MODE = "oauth"
+GROK_SEARCH_MODEL = "grok-4.3"
+GROK_SEARCH_WEB_SEARCH = "true"
+```
 
 ## Tavily
 
@@ -87,6 +115,8 @@ Unknown keys are rejected by the loader — typos surface as parse errors instea
 |---|---|
 | `grok_api_url` | `GROK_SEARCH_URL` |
 | `grok_api_key` | `GROK_SEARCH_API_KEY` |
+| `grok_auth_mode` | `GROK_SEARCH_AUTH_MODE` |
+| `grok_auth_file` | `GROK_SEARCH_AUTH_FILE` |
 | `grok_model` | `GROK_SEARCH_MODEL` |
 | `web_search_enabled` | `GROK_SEARCH_WEB_SEARCH` |
 | `x_search_enabled` | `GROK_SEARCH_X_SEARCH` |
@@ -110,11 +140,20 @@ tavily_api_key = "tvly-..."
 grok_model     = "grok-4-1-fast-reasoning"
 ```
 
+Example — OAuth mode:
+
+```toml
+grok_auth_mode = "oauth"
+grok_model     = "grok-4.3"
+```
+
 Example — full reference:
 
 ```toml
 grok_api_url          = "https://api.x.ai"
 grok_api_key          = "xai-..."
+grok_auth_mode        = "api_key"
+# grok_auth_file      = "C:\\Users\\chen\\.config\\grok-search-rs\\auth.json"
 grok_model            = "grok-4-1-fast-reasoning"
 web_search_enabled    = true
 x_search_enabled      = false

--- a/src/config.rs
+++ b/src/config.rs
@@ -447,10 +447,17 @@ fn bool_literal(value: &str) -> bool {
 fn auth_mode_value(map: &HashMap<String, String>) -> AuthMode {
     match map
         .get("GROK_SEARCH_AUTH_MODE")
-        .map(|value| value.trim().to_ascii_lowercase())
-        .as_deref()
+        .map(|value| (value.trim(), value.trim().to_ascii_lowercase()))
     {
-        Some("oauth") => AuthMode::OAuth,
+        Some((_, value)) if value == "api_key" || value.is_empty() => AuthMode::ApiKey,
+        Some((_, value)) if value == "oauth" => AuthMode::OAuth,
+        Some((raw, _)) => {
+            eprintln!(
+                "unknown GROK_SEARCH_AUTH_MODE=\"{}\"; falling back to api_key. Valid values: api_key, oauth.",
+                raw
+            );
+            AuthMode::ApiKey
+        }
         _ => AuthMode::ApiKey,
     }
 }
@@ -524,7 +531,10 @@ mod transport_field_tests {
             Some("https://example.com/v1")
         );
         assert_eq!(cfg.openai_compatible_api_key.as_deref(), Some("sk-fake"));
-        assert_eq!(cfg.openai_compatible_model.as_deref(), Some("grok-4.3-fast"));
+        assert_eq!(
+            cfg.openai_compatible_model.as_deref(),
+            Some("grok-4.3-fast")
+        );
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -10,10 +10,18 @@ pub enum Transport {
     ChatCompletions,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AuthMode {
+    ApiKey,
+    OAuth,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Config {
     pub grok_api_url: String,
     pub grok_api_key: Option<String>,
+    pub grok_auth_mode: AuthMode,
+    pub grok_auth_file: Option<PathBuf>,
     pub grok_model: String,
     pub web_search_enabled: bool,
     pub x_search_enabled: bool,
@@ -41,6 +49,8 @@ pub struct Config {
 struct ConfigFile {
     grok_api_url: Option<String>,
     grok_api_key: Option<String>,
+    grok_auth_mode: Option<String>,
+    grok_auth_file: Option<String>,
     grok_model: Option<String>,
     web_search_enabled: Option<bool>,
     x_search_enabled: Option<bool>,
@@ -72,6 +82,8 @@ impl ConfigFile {
         };
         insert("GROK_SEARCH_URL", self.grok_api_url);
         insert("GROK_SEARCH_API_KEY", self.grok_api_key);
+        insert("GROK_SEARCH_AUTH_MODE", self.grok_auth_mode);
+        insert("GROK_SEARCH_AUTH_FILE", self.grok_auth_file);
         insert("GROK_SEARCH_MODEL", self.grok_model);
         insert(
             "GROK_SEARCH_WEB_SEARCH",
@@ -163,6 +175,12 @@ impl Config {
         Self {
             grok_api_url: normalize_v1_base(&get(&map, "GROK_SEARCH_URL", "https://api.x.ai")),
             grok_api_key: map.get("GROK_SEARCH_API_KEY").cloned(),
+            grok_auth_mode: auth_mode_value(&map),
+            grok_auth_file: map
+                .get("GROK_SEARCH_AUTH_FILE")
+                .cloned()
+                .filter(|v| !v.is_empty())
+                .map(PathBuf::from),
             grok_model: get(&map, "GROK_SEARCH_MODEL", "grok-4-1-fast-reasoning"),
             web_search_enabled: bool_value(&map, "GROK_SEARCH_WEB_SEARCH", true),
             x_search_enabled: bool_value(&map, "GROK_SEARCH_X_SEARCH", false),
@@ -203,9 +221,14 @@ impl Config {
 
     pub fn redacted_diagnostics(&self) -> String {
         format!(
-            "grok_api_url={} grok_api_key={} grok_model={} web_search_enabled={} x_search_enabled={} tavily_api_key={} firecrawl_api_key={} default_extra_sources={} fallback_sources={} timeout_seconds={}",
+            "grok_api_url={} grok_api_key={} grok_auth_mode={:?} grok_auth_file={} grok_model={} web_search_enabled={} x_search_enabled={} tavily_api_key={} firecrawl_api_key={} default_extra_sources={} fallback_sources={} timeout_seconds={}",
             self.grok_api_url,
             redact(self.grok_api_key.as_deref()),
+            self.grok_auth_mode,
+            self.grok_auth_file
+                .as_ref()
+                .map(|p| p.display().to_string())
+                .unwrap_or_else(|| "default".to_string()),
             self.grok_model,
             self.web_search_enabled,
             self.x_search_enabled,
@@ -254,6 +277,26 @@ fn resolve_home_dir(env: &HashMap<String, String>) -> Option<PathBuf> {
 pub fn config_path() -> Option<PathBuf> {
     let env: HashMap<String, String> = std::env::vars().collect();
     resolve_config_path(&env)
+}
+
+pub fn auth_path() -> Option<PathBuf> {
+    auth_path_for(std::env::vars())
+}
+
+pub fn auth_path_for<I, K, V>(env_vars: I) -> Option<PathBuf>
+where
+    I: IntoIterator<Item = (K, V)>,
+    K: Into<String>,
+    V: Into<String>,
+{
+    let env: HashMap<String, String> = env_vars
+        .into_iter()
+        .map(|(k, v)| (k.into(), v.into()))
+        .collect();
+    if let Some(explicit) = env.get("GROK_SEARCH_AUTH_FILE").filter(|v| !v.is_empty()) {
+        return Some(PathBuf::from(explicit));
+    }
+    resolve_config_path(&env).map(|path| path.with_file_name("auth.json"))
 }
 
 /// Test-friendly variant of [`config_path`] that takes an explicit env map.
@@ -307,6 +350,8 @@ pub const CONFIG_TEMPLATE: &str = r#"# grok-search-rs global configuration
 
 # ── Required ──────────────────────────────────────────────────
 # grok_api_key   = "xai-..."          # xAI / Grok key   https://x.ai/api
+# grok_auth_mode = "api_key"          # api_key | oauth
+# grok_auth_file = "C:\\Users\\you\\.config\\grok-search-rs\\auth.json"
 # tavily_api_key = "tvly-..."         # Tavily key       https://tavily.com
 
 # ── Common knobs ──────────────────────────────────────────────
@@ -399,6 +444,17 @@ fn bool_literal(value: &str) -> bool {
     matches!(value.to_ascii_lowercase().as_str(), "1" | "true" | "yes")
 }
 
+fn auth_mode_value(map: &HashMap<String, String>) -> AuthMode {
+    match map
+        .get("GROK_SEARCH_AUTH_MODE")
+        .map(|value| value.trim().to_ascii_lowercase())
+        .as_deref()
+    {
+        Some("oauth") => AuthMode::OAuth,
+        _ => AuthMode::ApiKey,
+    }
+}
+
 fn u64_value(map: &HashMap<String, String>, key: &str, default: u64) -> u64 {
     map.get(key)
         .and_then(|value| value.parse::<u64>().ok())
@@ -419,6 +475,9 @@ fn optional_positive_usize(map: &HashMap<String, String>, key: &str) -> Option<u
 }
 
 fn decide_transport(map: &HashMap<String, String>) -> Transport {
+    if auth_mode_value(map) == AuthMode::OAuth {
+        return Transport::Responses;
+    }
     let grok_key_set = map
         .get("GROK_SEARCH_API_KEY")
         .map(|v| !v.is_empty())

--- a/src/config.rs
+++ b/src/config.rs
@@ -171,11 +171,12 @@ impl Config {
             .into_iter()
             .map(|(k, v)| (k.into(), v.into()))
             .collect();
+        let grok_auth_mode = auth_mode_value(&map);
 
         Self {
             grok_api_url: normalize_v1_base(&get(&map, "GROK_SEARCH_URL", "https://api.x.ai")),
             grok_api_key: map.get("GROK_SEARCH_API_KEY").cloned(),
-            grok_auth_mode: auth_mode_value(&map),
+            grok_auth_mode,
             grok_auth_file: map
                 .get("GROK_SEARCH_AUTH_FILE")
                 .cloned()
@@ -215,7 +216,7 @@ impl Config {
                 .get("OPENAI_COMPATIBLE_MODEL")
                 .cloned()
                 .filter(|v| !v.is_empty()),
-            transport: decide_transport(&map),
+            transport: decide_transport(&map, grok_auth_mode),
         }
     }
 
@@ -481,8 +482,8 @@ fn optional_positive_usize(map: &HashMap<String, String>, key: &str) -> Option<u
         .filter(|value| *value > 0)
 }
 
-fn decide_transport(map: &HashMap<String, String>) -> Transport {
-    if auth_mode_value(map) == AuthMode::OAuth {
+fn decide_transport(map: &HashMap<String, String>, auth_mode: AuthMode) -> Transport {
+    if auth_mode == AuthMode::OAuth {
         return Transport::Responses;
     }
     let grok_key_set = map

--- a/src/credentials.rs
+++ b/src/credentials.rs
@@ -1,0 +1,59 @@
+use std::path::PathBuf;
+
+use async_trait::async_trait;
+use reqwest::Client;
+
+use crate::error::{GrokSearchError, Result};
+use crate::oauth::token_store;
+
+#[async_trait]
+pub trait CredentialProvider: Send + Sync {
+    async fn bearer_token(&self) -> Result<String>;
+    fn label(&self) -> &'static str;
+}
+
+pub struct StaticApiKeyCredential {
+    api_key: String,
+}
+
+impl StaticApiKeyCredential {
+    pub fn new(api_key: String) -> Self {
+        Self { api_key }
+    }
+}
+
+#[async_trait]
+impl CredentialProvider for StaticApiKeyCredential {
+    async fn bearer_token(&self) -> Result<String> {
+        if self.api_key.trim().is_empty() {
+            return Err(GrokSearchError::MissingConfig("GROK_SEARCH_API_KEY"));
+        }
+        Ok(self.api_key.clone())
+    }
+
+    fn label(&self) -> &'static str {
+        "api_key"
+    }
+}
+
+pub struct OAuthCredential {
+    client: Client,
+    auth_path: PathBuf,
+}
+
+impl OAuthCredential {
+    pub fn new(client: Client, auth_path: PathBuf) -> Self {
+        Self { client, auth_path }
+    }
+}
+
+#[async_trait]
+impl CredentialProvider for OAuthCredential {
+    async fn bearer_token(&self) -> Result<String> {
+        token_store::get_access_token(&self.client, &self.auth_path).await
+    }
+
+    fn label(&self) -> &'static str {
+        "oauth"
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -12,6 +12,8 @@ pub enum GrokSearchError {
     Timeout(String),
     #[error("provider error: {0}")]
     Provider(String),
+    #[error("oauth error: {0}")]
+    OAuth(String),
     #[error("parse error: {0}")]
     Parse(String),
 }
@@ -30,6 +32,8 @@ impl GrokSearchError {
             GrokSearchError::Timeout(_) => -32002,
             // -32001 (server-defined) upstream / provider failure
             GrokSearchError::Provider(_) => -32001,
+            // -32005 (server-defined) OAuth setup / refresh failure
+            GrokSearchError::OAuth(_) => -32005,
             // -32003 (server-defined) missing config
             GrokSearchError::MissingConfig(_) => -32003,
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,11 @@
 pub mod adapters;
 pub mod cache;
 pub mod config;
+pub mod credentials;
 pub mod error;
 pub mod logging;
 pub mod mcp;
 pub mod model;
+pub mod oauth;
 pub mod providers;
 pub mod service;

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,10 @@ async fn main() -> anyhow::Result<()> {
     // CLI shim: handle --version, --init before MCP server mode.
     let args: Vec<String> = std::env::args().skip(1).collect();
 
-    if args.iter().any(|a| a == "--version" || a == "-V" || a == "-v") {
+    if args
+        .iter()
+        .any(|a| a == "--version" || a == "-V" || a == "-v")
+    {
         println!("grok-search-rs {}", env!("CARGO_PKG_VERSION"));
         return Ok(());
     }
@@ -65,7 +68,10 @@ fn run_status(cfg: &Config) -> anyhow::Result<()> {
     let status = grok_search_rs::oauth::token_store::auth_status(&path);
     println!("grok-search-rs OAuth status");
     println!("  Auth file: {}", status.path.display());
-    println!("  Authenticated: {}", if status.authenticated { "yes" } else { "no" });
+    println!(
+        "  Authenticated: {}",
+        if status.authenticated { "yes" } else { "no" }
+    );
     println!(
         "  Refresh token: {}",
         if status.refresh_token_present {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 use std::io::{IsTerminal, Write};
 
-use grok_search_rs::config::{self, Config, InitOutcome};
+use grok_search_rs::config::{self, AuthMode, Config, InitOutcome};
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> anyhow::Result<()> {
@@ -16,12 +16,30 @@ async fn main() -> anyhow::Result<()> {
         return run_init();
     }
 
+    if args.first().map(String::as_str) == Some("login") {
+        let cfg = Config::load();
+        return run_login(&cfg).await;
+    }
+
+    if args.first().map(String::as_str) == Some("status") {
+        let cfg = Config::load();
+        return run_status(&cfg);
+    }
+
+    if args.first().map(String::as_str) == Some("logout") {
+        let cfg = Config::load();
+        return run_logout(&cfg);
+    }
+
     let cfg = Config::load();
 
     // Detect interactive run with missing credentials and print a friendly
     // onboarding guide instead of a cryptic error. MCP clients always pipe
     // stdio, so a TTY here means the user ran the binary directly.
-    if cfg.grok_api_key.is_none() && std::io::stdin().is_terminal() {
+    if cfg.grok_auth_mode == AuthMode::ApiKey
+        && cfg.grok_api_key.is_none()
+        && std::io::stdin().is_terminal()
+    {
         print_setup_guide();
         return Ok(());
     }
@@ -29,6 +47,63 @@ async fn main() -> anyhow::Result<()> {
     let service = grok_search_rs::service::SearchService::new(cfg)?;
     grok_search_rs::mcp::run_stdio(service).await?;
     Ok(())
+}
+
+async fn run_login(cfg: &Config) -> anyhow::Result<()> {
+    let path = resolve_auth_path(cfg)?;
+    let store = grok_search_rs::oauth::login::login(&path, true).await?;
+    println!("Login successful.");
+    println!("Auth file: {}", path.display());
+    if let Some(exp) = grok_search_rs::oauth::token_store::jwt_exp(&store.access_token) {
+        println!("Access token expires at unix time: {exp}");
+    }
+    Ok(())
+}
+
+fn run_status(cfg: &Config) -> anyhow::Result<()> {
+    let path = resolve_auth_path(cfg)?;
+    let status = grok_search_rs::oauth::token_store::auth_status(&path);
+    println!("grok-search-rs OAuth status");
+    println!("  Auth file: {}", status.path.display());
+    println!("  Authenticated: {}", if status.authenticated { "yes" } else { "no" });
+    println!(
+        "  Refresh token: {}",
+        if status.refresh_token_present {
+            "present"
+        } else {
+            "missing"
+        }
+    );
+    println!(
+        "  Access expires at: {}",
+        status
+            .access_expires_at
+            .map(|value| value.to_string())
+            .unwrap_or_else(|| "unknown".to_string())
+    );
+    println!(
+        "  Base URL: {}",
+        status.base_url.unwrap_or_else(|| "unknown".to_string())
+    );
+    Ok(())
+}
+
+fn run_logout(cfg: &Config) -> anyhow::Result<()> {
+    let path = resolve_auth_path(cfg)?;
+    let removed = grok_search_rs::oauth::token_store::delete_token_store(&path)?;
+    if removed {
+        println!("Removed OAuth token file: {}", path.display());
+    } else {
+        println!("No OAuth token file found: {}", path.display());
+    }
+    Ok(())
+}
+
+fn resolve_auth_path(cfg: &Config) -> anyhow::Result<std::path::PathBuf> {
+    cfg.grok_auth_file
+        .clone()
+        .or_else(config::auth_path)
+        .ok_or_else(|| anyhow::anyhow!("cannot resolve OAuth auth path; set GROK_SEARCH_AUTH_FILE"))
 }
 
 /// Scaffold the global config file. Idempotent: existing files are reported
@@ -63,6 +138,11 @@ Required keys
   GROK_SEARCH_API_KEY   xAI / Grok-compatible key   (https://x.ai/api)
   TAVILY_API_KEY        Tavily fetch + map          (https://tavily.com)
   FIRECRAWL_API_KEY     optional fetch fallback     (https://firecrawl.dev)
+
+OAuth alternative
+  grok-search-rs login
+  Set GROK_SEARCH_AUTH_MODE=oauth in your MCP env or config.
+  OAuth mode reuses Hermes' xAI client_id and may carry account / terms risk.
 
 One-line install (Claude Code)
   claude mcp add-json grok-search-rs --scope user '{

--- a/src/oauth/constants.rs
+++ b/src/oauth/constants.rs
@@ -1,0 +1,9 @@
+pub const XAI_OAUTH_ISSUER: &str = "https://auth.x.ai";
+pub const XAI_OAUTH_DISCOVERY_URL: &str = "https://auth.x.ai/.well-known/openid-configuration";
+pub const XAI_OAUTH_CLIENT_ID: &str = "b1a00492-073a-47ea-816f-4c329264a828";
+pub const XAI_OAUTH_SCOPE: &str = "openid profile email offline_access grok-cli:access api:access";
+pub const XAI_OAUTH_REDIRECT_HOST: &str = "127.0.0.1";
+pub const XAI_OAUTH_REDIRECT_PORT: u16 = 56121;
+pub const XAI_OAUTH_REDIRECT_PATH: &str = "/callback";
+pub const XAI_ACCESS_TOKEN_REFRESH_SKEW_SECONDS: u64 = 120;
+pub const DEFAULT_XAI_OAUTH_BASE_URL: &str = "https://api.x.ai/v1";

--- a/src/oauth/login.rs
+++ b/src/oauth/login.rs
@@ -10,9 +10,8 @@ use url::Url;
 
 use crate::error::{GrokSearchError, Result};
 use crate::oauth::constants::{
-    DEFAULT_XAI_OAUTH_BASE_URL, XAI_OAUTH_CLIENT_ID, XAI_OAUTH_DISCOVERY_URL,
-    XAI_OAUTH_ISSUER, XAI_OAUTH_REDIRECT_HOST, XAI_OAUTH_REDIRECT_PATH,
-    XAI_OAUTH_REDIRECT_PORT, XAI_OAUTH_SCOPE,
+    DEFAULT_XAI_OAUTH_BASE_URL, XAI_OAUTH_CLIENT_ID, XAI_OAUTH_DISCOVERY_URL, XAI_OAUTH_ISSUER,
+    XAI_OAUTH_REDIRECT_HOST, XAI_OAUTH_REDIRECT_PATH, XAI_OAUTH_REDIRECT_PORT, XAI_OAUTH_SCOPE,
 };
 use crate::oauth::pkce::{pkce_pair, random_url_token};
 use crate::oauth::token_store::{save_token_store, TokenStore};
@@ -39,8 +38,8 @@ pub async fn login(auth_path: &Path, open_browser: bool) -> Result<TokenStore> {
         "http://{}:{}{}",
         XAI_OAUTH_REDIRECT_HOST, XAI_OAUTH_REDIRECT_PORT, XAI_OAUTH_REDIRECT_PATH
     );
-    let listener = TcpListener::bind((XAI_OAUTH_REDIRECT_HOST, XAI_OAUTH_REDIRECT_PORT))
-        .map_err(|err| {
+    let listener =
+        TcpListener::bind((XAI_OAUTH_REDIRECT_HOST, XAI_OAUTH_REDIRECT_PORT)).map_err(|err| {
             GrokSearchError::OAuth(format!(
                 "oauth_callback_bind_failed: cannot listen on {redirect_uri}: {err}"
             ))
@@ -81,14 +80,7 @@ pub async fn login(auth_path: &Path, open_browser: bool) -> Result<TokenStore> {
     let code = callback.code.ok_or_else(|| {
         GrokSearchError::OAuth("oauth_code_missing: callback did not include code".to_string())
     })?;
-    let store = exchange_code(
-        &client,
-        &discovery,
-        &code,
-        &verifier,
-        &redirect_uri,
-    )
-    .await?;
+    let store = exchange_code(&client, &discovery, &code, &verifier, &redirect_uri).await?;
     save_token_store(auth_path, &store)?;
     Ok(store)
 }
@@ -131,7 +123,7 @@ fn authorize_url(
         .append_pair("state", state)
         .append_pair("nonce", nonce)
         .append_pair("plan", "generic")
-        .append_pair("referrer", "hermes-agent");
+        .append_pair("referrer", "grok-search-rs");
     Ok(url)
 }
 
@@ -167,12 +159,10 @@ async fn exchange_code(
     }
     let payload = serde_json::from_str::<Value>(&text)
         .map_err(|err| GrokSearchError::OAuth(format!("oauth_token_parse_failed: {err}")))?;
-    let access_token = string_field(&payload, "access_token").ok_or_else(|| {
-        GrokSearchError::OAuth("oauth_token_missing_access_token".to_string())
-    })?;
-    let refresh_token = string_field(&payload, "refresh_token").ok_or_else(|| {
-        GrokSearchError::OAuth("oauth_token_missing_refresh_token".to_string())
-    })?;
+    let access_token = string_field(&payload, "access_token")
+        .ok_or_else(|| GrokSearchError::OAuth("oauth_token_missing_access_token".to_string()))?;
+    let refresh_token = string_field(&payload, "refresh_token")
+        .ok_or_else(|| GrokSearchError::OAuth("oauth_token_missing_refresh_token".to_string()))?;
     Ok(TokenStore {
         access_token,
         refresh_token,
@@ -198,11 +188,9 @@ fn wait_for_callback(listener: &TcpListener, timeout: Duration) -> Result<Callba
                     GrokSearchError::OAuth(format!("oauth_callback_stream_failed: {err}"))
                 })?;
                 let mut buf = [0u8; 4096];
-                let n = stream
-                    .read(&mut buf)
-                    .map_err(|err| {
-                        GrokSearchError::OAuth(format!("oauth_callback_read_failed: {err}"))
-                    })?;
+                let n = stream.read(&mut buf).map_err(|err| {
+                    GrokSearchError::OAuth(format!("oauth_callback_read_failed: {err}"))
+                })?;
                 let request = String::from_utf8_lossy(&buf[..n]);
                 let line = request.lines().next().unwrap_or_default();
                 let callback = parse_callback_line(line)?;
@@ -325,8 +313,7 @@ mod tests {
 
     #[test]
     fn callback_line_extracts_code_and_state() {
-        let callback =
-            parse_callback_line("GET /callback?code=abc&state=xyz HTTP/1.1").unwrap();
+        let callback = parse_callback_line("GET /callback?code=abc&state=xyz HTTP/1.1").unwrap();
         assert_eq!(callback.code.as_deref(), Some("abc"));
         assert_eq!(callback.state.as_deref(), Some("xyz"));
     }

--- a/src/oauth/login.rs
+++ b/src/oauth/login.rs
@@ -1,0 +1,333 @@
+use std::io::{Read, Write};
+use std::net::TcpListener;
+use std::path::Path;
+use std::time::{Duration, Instant};
+
+use reqwest::Client;
+use serde::Deserialize;
+use serde_json::Value;
+use url::Url;
+
+use crate::error::{GrokSearchError, Result};
+use crate::oauth::constants::{
+    DEFAULT_XAI_OAUTH_BASE_URL, XAI_OAUTH_CLIENT_ID, XAI_OAUTH_DISCOVERY_URL,
+    XAI_OAUTH_ISSUER, XAI_OAUTH_REDIRECT_HOST, XAI_OAUTH_REDIRECT_PATH,
+    XAI_OAUTH_REDIRECT_PORT, XAI_OAUTH_SCOPE,
+};
+use crate::oauth::pkce::{pkce_pair, random_url_token};
+use crate::oauth::token_store::{save_token_store, TokenStore};
+
+#[derive(Debug, Clone, Deserialize)]
+struct Discovery {
+    authorization_endpoint: String,
+    token_endpoint: String,
+}
+
+pub async fn login(auth_path: &Path, open_browser: bool) -> Result<TokenStore> {
+    eprintln!("WARNING: OAuth mode reuses Hermes' xAI OAuth client_id.");
+    eprintln!("This may violate xAI terms or affect your account. Use at your own risk.");
+
+    let client = Client::builder()
+        .timeout(Duration::from_secs(30))
+        .build()
+        .map_err(|err| GrokSearchError::OAuth(format!("oauth_client_failed: {err}")))?;
+    let discovery = discover(&client).await?;
+    validate_auth_endpoint(&discovery.authorization_endpoint)?;
+    validate_token_endpoint(&discovery.token_endpoint)?;
+
+    let redirect_uri = format!(
+        "http://{}:{}{}",
+        XAI_OAUTH_REDIRECT_HOST, XAI_OAUTH_REDIRECT_PORT, XAI_OAUTH_REDIRECT_PATH
+    );
+    let listener = TcpListener::bind((XAI_OAUTH_REDIRECT_HOST, XAI_OAUTH_REDIRECT_PORT))
+        .map_err(|err| {
+            GrokSearchError::OAuth(format!(
+                "oauth_callback_bind_failed: cannot listen on {redirect_uri}: {err}"
+            ))
+        })?;
+    listener
+        .set_nonblocking(true)
+        .map_err(|err| GrokSearchError::OAuth(format!("oauth_callback_failed: {err}")))?;
+
+    let (verifier, challenge) = pkce_pair();
+    let state = random_url_token(16);
+    let nonce = random_url_token(16);
+    let authorize_url = authorize_url(
+        &discovery.authorization_endpoint,
+        &redirect_uri,
+        &challenge,
+        &state,
+        &nonce,
+    )?;
+
+    println!("Open this URL to authorize with xAI:");
+    println!("{authorize_url}");
+    println!();
+    println!("Waiting for callback on {redirect_uri}");
+
+    if open_browser {
+        match open_authorize_url(authorize_url.as_str()) {
+            Ok(_) => println!("Browser opened for xAI authorization."),
+            Err(_) => println!("Could not open a browser automatically; open the URL above."),
+        }
+    }
+
+    let callback = wait_for_callback(&listener, Duration::from_secs(180))?;
+    if callback.state.as_deref() != Some(state.as_str()) {
+        return Err(GrokSearchError::OAuth(
+            "oauth_state_mismatch: callback state did not match".to_string(),
+        ));
+    }
+    let code = callback.code.ok_or_else(|| {
+        GrokSearchError::OAuth("oauth_code_missing: callback did not include code".to_string())
+    })?;
+    let store = exchange_code(
+        &client,
+        &discovery,
+        &code,
+        &verifier,
+        &redirect_uri,
+    )
+    .await?;
+    save_token_store(auth_path, &store)?;
+    Ok(store)
+}
+
+async fn discover(client: &Client) -> Result<Discovery> {
+    let response = client
+        .get(XAI_OAUTH_DISCOVERY_URL)
+        .header("Accept", "application/json")
+        .send()
+        .await
+        .map_err(|err| GrokSearchError::OAuth(format!("oauth_discovery_failed: {err}")))?;
+    let status = response.status();
+    if !status.is_success() {
+        return Err(GrokSearchError::OAuth(format!(
+            "oauth_discovery_failed: HTTP {status}"
+        )));
+    }
+    response
+        .json::<Discovery>()
+        .await
+        .map_err(|err| GrokSearchError::OAuth(format!("oauth_discovery_parse_failed: {err}")))
+}
+
+fn authorize_url(
+    authorization_endpoint: &str,
+    redirect_uri: &str,
+    code_challenge: &str,
+    state: &str,
+    nonce: &str,
+) -> Result<Url> {
+    let mut url = Url::parse(authorization_endpoint)
+        .map_err(|err| GrokSearchError::OAuth(format!("oauth_authorize_url_invalid: {err}")))?;
+    url.query_pairs_mut()
+        .append_pair("response_type", "code")
+        .append_pair("client_id", XAI_OAUTH_CLIENT_ID)
+        .append_pair("redirect_uri", redirect_uri)
+        .append_pair("scope", XAI_OAUTH_SCOPE)
+        .append_pair("code_challenge", code_challenge)
+        .append_pair("code_challenge_method", "S256")
+        .append_pair("state", state)
+        .append_pair("nonce", nonce)
+        .append_pair("plan", "generic")
+        .append_pair("referrer", "hermes-agent");
+    Ok(url)
+}
+
+async fn exchange_code(
+    client: &Client,
+    discovery: &Discovery,
+    code: &str,
+    verifier: &str,
+    redirect_uri: &str,
+) -> Result<TokenStore> {
+    let response = client
+        .post(&discovery.token_endpoint)
+        .header("Accept", "application/json")
+        .form(&[
+            ("grant_type", "authorization_code"),
+            ("code", code),
+            ("redirect_uri", redirect_uri),
+            ("client_id", XAI_OAUTH_CLIENT_ID),
+            ("code_verifier", verifier),
+        ])
+        .send()
+        .await
+        .map_err(|err| GrokSearchError::OAuth(format!("oauth_token_exchange_failed: {err}")))?;
+    let status = response.status();
+    let text = response
+        .text()
+        .await
+        .map_err(|err| GrokSearchError::OAuth(format!("oauth_token_body_failed: {err}")))?;
+    if !status.is_success() {
+        return Err(GrokSearchError::OAuth(format!(
+            "oauth_token_exchange_failed: upstream returned HTTP {status}"
+        )));
+    }
+    let payload = serde_json::from_str::<Value>(&text)
+        .map_err(|err| GrokSearchError::OAuth(format!("oauth_token_parse_failed: {err}")))?;
+    let access_token = string_field(&payload, "access_token").ok_or_else(|| {
+        GrokSearchError::OAuth("oauth_token_missing_access_token".to_string())
+    })?;
+    let refresh_token = string_field(&payload, "refresh_token").ok_or_else(|| {
+        GrokSearchError::OAuth("oauth_token_missing_refresh_token".to_string())
+    })?;
+    Ok(TokenStore {
+        access_token,
+        refresh_token,
+        id_token: string_field(&payload, "id_token").unwrap_or_default(),
+        token_endpoint: discovery.token_endpoint.clone(),
+        base_url: DEFAULT_XAI_OAUTH_BASE_URL.to_string(),
+        last_refresh: unix_now().to_string(),
+    })
+}
+
+#[derive(Debug)]
+struct Callback {
+    code: Option<String>,
+    state: Option<String>,
+}
+
+fn wait_for_callback(listener: &TcpListener, timeout: Duration) -> Result<Callback> {
+    let deadline = Instant::now() + timeout;
+    loop {
+        match listener.accept() {
+            Ok((mut stream, _addr)) => {
+                stream.set_nonblocking(false).map_err(|err| {
+                    GrokSearchError::OAuth(format!("oauth_callback_stream_failed: {err}"))
+                })?;
+                let mut buf = [0u8; 4096];
+                let n = stream
+                    .read(&mut buf)
+                    .map_err(|err| {
+                        GrokSearchError::OAuth(format!("oauth_callback_read_failed: {err}"))
+                    })?;
+                let request = String::from_utf8_lossy(&buf[..n]);
+                let line = request.lines().next().unwrap_or_default();
+                let callback = parse_callback_line(line)?;
+                let body = "xAI login complete. You can close this tab.";
+                let response = format!(
+                    "HTTP/1.1 200 OK\r\nContent-Type: text/plain; charset=utf-8\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                    body.len(),
+                    body
+                );
+                let _ = stream.write_all(response.as_bytes());
+                return Ok(callback);
+            }
+            Err(err) if err.kind() == std::io::ErrorKind::WouldBlock => {
+                if Instant::now() >= deadline {
+                    return Err(GrokSearchError::OAuth(
+                        "oauth_callback_timeout: no callback received within 180 seconds"
+                            .to_string(),
+                    ));
+                }
+                std::thread::sleep(Duration::from_millis(100));
+            }
+            Err(err) => {
+                return Err(GrokSearchError::OAuth(format!(
+                    "oauth_callback_accept_failed: {err}"
+                )));
+            }
+        }
+    }
+}
+
+fn parse_callback_line(line: &str) -> Result<Callback> {
+    let mut parts = line.split_whitespace();
+    let method = parts.next().unwrap_or_default();
+    let target = parts.next().unwrap_or_default();
+    if method != "GET" || target.is_empty() {
+        return Err(GrokSearchError::OAuth(
+            "oauth_callback_invalid_request".to_string(),
+        ));
+    }
+    let url = Url::parse(&format!("http://localhost{target}"))
+        .map_err(|err| GrokSearchError::OAuth(format!("oauth_callback_url_invalid: {err}")))?;
+    let code = url
+        .query_pairs()
+        .find(|(key, _)| key == "code")
+        .map(|(_, value)| value.to_string());
+    let state = url
+        .query_pairs()
+        .find(|(key, _)| key == "state")
+        .map(|(_, value)| value.to_string());
+    Ok(Callback { code, state })
+}
+
+fn string_field(value: &Value, key: &str) -> Option<String> {
+    value
+        .get(key)
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+}
+
+fn validate_auth_endpoint(endpoint: &str) -> Result<()> {
+    if endpoint.starts_with(&format!("{XAI_OAUTH_ISSUER}/")) {
+        Ok(())
+    } else {
+        Err(GrokSearchError::OAuth(
+            "oauth_discovery_invalid_authorization_endpoint".to_string(),
+        ))
+    }
+}
+
+fn validate_token_endpoint(endpoint: &str) -> Result<()> {
+    if endpoint.starts_with(&format!("{XAI_OAUTH_ISSUER}/")) {
+        Ok(())
+    } else {
+        Err(GrokSearchError::OAuth(
+            "oauth_discovery_invalid_token_endpoint".to_string(),
+        ))
+    }
+}
+
+fn unix_now() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|duration| duration.as_secs())
+        .unwrap_or(0)
+}
+
+fn open_authorize_url(url: &str) -> std::io::Result<()> {
+    #[cfg(target_os = "windows")]
+    {
+        std::process::Command::new("rundll32.exe")
+            .args(["url.dll,FileProtocolHandler", url])
+            .spawn()?;
+        return Ok(());
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        std::process::Command::new("open").arg(url).spawn()?;
+        return Ok(());
+    }
+
+    #[cfg(all(unix, not(target_os = "macos")))]
+    {
+        std::process::Command::new("xdg-open").arg(url).spawn()?;
+        return Ok(());
+    }
+
+    #[allow(unreachable_code)]
+    Err(std::io::Error::new(
+        std::io::ErrorKind::Unsupported,
+        "opening a browser is not supported on this platform",
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn callback_line_extracts_code_and_state() {
+        let callback =
+            parse_callback_line("GET /callback?code=abc&state=xyz HTTP/1.1").unwrap();
+        assert_eq!(callback.code.as_deref(), Some("abc"));
+        assert_eq!(callback.state.as_deref(), Some("xyz"));
+    }
+}

--- a/src/oauth/mod.rs
+++ b/src/oauth/mod.rs
@@ -1,0 +1,4 @@
+pub mod constants;
+pub mod login;
+pub mod pkce;
+pub mod token_store;

--- a/src/oauth/pkce.rs
+++ b/src/oauth/pkce.rs
@@ -1,0 +1,29 @@
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use base64::Engine;
+use ring::digest::{digest, SHA256};
+
+pub fn random_url_token(bytes: usize) -> String {
+    let mut data = vec![0u8; bytes];
+    getrandom::fill(&mut data).expect("secure randomness must be available for OAuth PKCE");
+    URL_SAFE_NO_PAD.encode(data)
+}
+
+pub fn pkce_pair() -> (String, String) {
+    let verifier = random_url_token(32);
+    let challenge = URL_SAFE_NO_PAD.encode(digest(&SHA256, verifier.as_bytes()).as_ref());
+    (verifier, challenge)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pkce_challenge_is_s256_url_safe_no_pad() {
+        let (verifier, challenge) = pkce_pair();
+        assert!(verifier.len() >= 43);
+        assert_eq!(challenge.len(), 43);
+        assert!(!challenge.contains('='));
+        assert!(challenge.chars().all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_'));
+    }
+}

--- a/src/oauth/pkce.rs
+++ b/src/oauth/pkce.rs
@@ -24,6 +24,8 @@ mod tests {
         assert!(verifier.len() >= 43);
         assert_eq!(challenge.len(), 43);
         assert!(!challenge.contains('='));
-        assert!(challenge.chars().all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_'));
+        assert!(challenge
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_'));
     }
 }

--- a/src/oauth/token_store.rs
+++ b/src/oauth/token_store.rs
@@ -1,0 +1,269 @@
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use base64::Engine;
+use reqwest::Client;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::error::{GrokSearchError, Result};
+use crate::oauth::constants::{
+    DEFAULT_XAI_OAUTH_BASE_URL, XAI_ACCESS_TOKEN_REFRESH_SKEW_SECONDS, XAI_OAUTH_CLIENT_ID,
+    XAI_OAUTH_ISSUER,
+};
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct TokenStore {
+    pub access_token: String,
+    pub refresh_token: String,
+    #[serde(default)]
+    pub id_token: String,
+    pub token_endpoint: String,
+    #[serde(default = "default_base_url")]
+    pub base_url: String,
+    #[serde(default)]
+    pub last_refresh: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AuthStatus {
+    pub path: PathBuf,
+    pub authenticated: bool,
+    pub access_expires_at: Option<u64>,
+    pub refresh_token_present: bool,
+    pub base_url: Option<String>,
+}
+
+fn default_base_url() -> String {
+    DEFAULT_XAI_OAUTH_BASE_URL.to_string()
+}
+
+pub fn load_token_store(path: &Path) -> Result<Option<TokenStore>> {
+    if !path.exists() {
+        return Ok(None);
+    }
+    let body = std::fs::read_to_string(path)
+        .map_err(|err| GrokSearchError::OAuth(format!("oauth_token_read_failed: {err}")))?;
+    let store = serde_json::from_str::<TokenStore>(&body)
+        .map_err(|err| GrokSearchError::OAuth(format!("oauth_token_parse_failed: {err}")))?;
+    Ok(Some(store))
+}
+
+pub fn save_token_store(path: &Path, store: &TokenStore) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .map_err(|err| GrokSearchError::OAuth(format!("oauth_token_dir_failed: {err}")))?;
+    }
+    let payload = serde_json::to_string_pretty(store)
+        .map_err(|err| GrokSearchError::OAuth(format!("oauth_token_serialize_failed: {err}")))?;
+    let tmp = path.with_file_name(format!(
+        "{}.tmp.{}",
+        path.file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or("auth.json"),
+        uuid::Uuid::new_v4().simple()
+    ));
+    std::fs::write(&tmp, payload)
+        .map_err(|err| GrokSearchError::OAuth(format!("oauth_token_write_failed: {err}")))?;
+    commit_token_file(&tmp, path)?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600));
+    }
+    Ok(())
+}
+
+fn commit_token_file(tmp: &Path, path: &Path) -> Result<()> {
+    match std::fs::rename(tmp, path) {
+        Ok(_) => Ok(()),
+        Err(first_err) if path.exists() => {
+            std::fs::remove_file(path).map_err(|err| {
+                GrokSearchError::OAuth(format!("oauth_token_commit_failed: {err}"))
+            })?;
+            std::fs::rename(tmp, path).map_err(|err| {
+                GrokSearchError::OAuth(format!(
+                    "oauth_token_commit_failed: {err}; previous commit error: {first_err}"
+                ))
+            })
+        }
+        Err(err) => Err(GrokSearchError::OAuth(format!(
+            "oauth_token_commit_failed: {err}"
+        ))),
+    }
+}
+
+pub fn delete_token_store(path: &Path) -> Result<bool> {
+    if !path.exists() {
+        return Ok(false);
+    }
+    std::fs::remove_file(path)
+        .map_err(|err| GrokSearchError::OAuth(format!("oauth_logout_failed: {err}")))?;
+    Ok(true)
+}
+
+pub fn auth_status(path: &Path) -> AuthStatus {
+    let store = load_token_store(path).ok().flatten();
+    let access = store.as_ref().map(|s| s.access_token.as_str()).unwrap_or("");
+    AuthStatus {
+        path: path.to_path_buf(),
+        authenticated: !access.is_empty(),
+        access_expires_at: jwt_exp(access),
+        refresh_token_present: store
+            .as_ref()
+            .map(|s| !s.refresh_token.is_empty())
+            .unwrap_or(false),
+        base_url: store
+            .as_ref()
+            .map(|s| s.base_url.clone())
+            .filter(|s| !s.is_empty()),
+    }
+}
+
+pub async fn get_access_token(client: &Client, path: &Path) -> Result<String> {
+    let mut store = load_token_store(path)?.ok_or_else(|| {
+        GrokSearchError::OAuth(
+            "oauth_not_logged_in: run `grok-search-rs login` before using OAuth mode".to_string(),
+        )
+    })?;
+    if store.access_token.is_empty() {
+        return Err(GrokSearchError::OAuth(
+            "oauth_not_logged_in: stored token is empty; run `grok-search-rs login`".to_string(),
+        ));
+    }
+    if token_is_expiring(&store.access_token, XAI_ACCESS_TOKEN_REFRESH_SKEW_SECONDS) {
+        refresh_token(client, path, &mut store).await?;
+    }
+    Ok(store.access_token)
+}
+
+pub fn jwt_exp(access_token: &str) -> Option<u64> {
+    let payload = access_token.split('.').nth(1)?;
+    let decoded = URL_SAFE_NO_PAD.decode(payload.as_bytes()).ok()?;
+    let value = serde_json::from_slice::<Value>(&decoded).ok()?;
+    value.get("exp")?.as_u64()
+}
+
+pub fn token_is_expiring(access_token: &str, skew_seconds: u64) -> bool {
+    let Some(exp) = jwt_exp(access_token) else {
+        return false;
+    };
+    exp <= now_unix().saturating_add(skew_seconds)
+}
+
+async fn refresh_token(client: &Client, path: &Path, store: &mut TokenStore) -> Result<()> {
+    if store.refresh_token.is_empty() || store.token_endpoint.is_empty() {
+        return Err(GrokSearchError::OAuth(
+            "oauth_refresh_missing_token: run `grok-search-rs login` again".to_string(),
+        ));
+    }
+    if !store
+        .token_endpoint
+        .starts_with(&format!("{XAI_OAUTH_ISSUER}/"))
+    {
+        return Err(GrokSearchError::OAuth(
+            "oauth_refresh_invalid_endpoint: token endpoint is not auth.x.ai".to_string(),
+        ));
+    }
+
+    let response = client
+        .post(&store.token_endpoint)
+        .header("Accept", "application/json")
+        .form(&[
+            ("grant_type", "refresh_token"),
+            ("client_id", XAI_OAUTH_CLIENT_ID),
+            ("refresh_token", store.refresh_token.as_str()),
+        ])
+        .send()
+        .await
+        .map_err(|err| GrokSearchError::OAuth(format!("oauth_refresh_failed: {err}")))?;
+
+    let status = response.status();
+    let body = response
+        .text()
+        .await
+        .map_err(|err| GrokSearchError::OAuth(format!("oauth_refresh_body_failed: {err}")))?;
+    if !status.is_success() {
+        return Err(GrokSearchError::OAuth(format!(
+            "oauth_refresh_failed: upstream returned HTTP {status}"
+        )));
+    }
+    let payload = serde_json::from_str::<Value>(&body)
+        .map_err(|err| GrokSearchError::OAuth(format!("oauth_refresh_parse_failed: {err}")))?;
+    let access_token = payload
+        .get("access_token")
+        .and_then(Value::as_str)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| {
+            GrokSearchError::OAuth(
+                "oauth_refresh_missing_access_token: run `grok-search-rs login` again".to_string(),
+            )
+        })?;
+
+    store.access_token = access_token.to_string();
+    if let Some(refresh) = payload.get("refresh_token").and_then(Value::as_str) {
+        if !refresh.is_empty() {
+            store.refresh_token = refresh.to_string();
+        }
+    }
+    if let Some(id_token) = payload.get("id_token").and_then(Value::as_str) {
+        store.id_token = id_token.to_string();
+    }
+    store.last_refresh = now_unix().to_string();
+    save_token_store(path, store)
+}
+
+fn now_unix() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_secs())
+        .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+    use base64::Engine;
+
+    fn fake_jwt(exp: u64) -> String {
+        let payload = URL_SAFE_NO_PAD.encode(format!(r#"{{"exp":{exp}}}"#));
+        format!("header.{payload}.sig")
+    }
+
+    #[test]
+    fn parses_jwt_exp() {
+        assert_eq!(jwt_exp(&fake_jwt(12345)), Some(12345));
+    }
+
+    #[test]
+    fn detects_expiring_tokens() {
+        assert!(token_is_expiring(&fake_jwt(1), 120));
+        assert!(!token_is_expiring(&fake_jwt(now_unix() + 10_000), 120));
+    }
+
+    #[test]
+    fn damaged_token_file_returns_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("auth.json");
+        std::fs::write(&path, "{not json").unwrap();
+        assert!(load_token_store(&path).is_err());
+    }
+
+    #[test]
+    fn save_and_load_token_store_round_trips() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("auth.json");
+        let store = TokenStore {
+            access_token: "access".into(),
+            refresh_token: "refresh".into(),
+            id_token: "id".into(),
+            token_endpoint: "https://auth.x.ai/token".into(),
+            base_url: DEFAULT_XAI_OAUTH_BASE_URL.into(),
+            last_refresh: "now".into(),
+        };
+        save_token_store(&path, &store).unwrap();
+        assert_eq!(load_token_store(&path).unwrap(), Some(store));
+    }
+}

--- a/src/oauth/token_store.rs
+++ b/src/oauth/token_store.rs
@@ -1,5 +1,6 @@
 use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
+use std::{fs, io::Write};
 
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use base64::Engine;
@@ -51,10 +52,7 @@ pub fn load_token_store(path: &Path) -> Result<Option<TokenStore>> {
 }
 
 pub fn save_token_store(path: &Path, store: &TokenStore) -> Result<()> {
-    if let Some(parent) = path.parent() {
-        std::fs::create_dir_all(parent)
-            .map_err(|err| GrokSearchError::OAuth(format!("oauth_token_dir_failed: {err}")))?;
-    }
+    ensure_token_parent_dir(path)?;
     let payload = serde_json::to_string_pretty(store)
         .map_err(|err| GrokSearchError::OAuth(format!("oauth_token_serialize_failed: {err}")))?;
     let tmp = path.with_file_name(format!(
@@ -64,14 +62,86 @@ pub fn save_token_store(path: &Path, store: &TokenStore) -> Result<()> {
             .unwrap_or("auth.json"),
         uuid::Uuid::new_v4().simple()
     ));
-    std::fs::write(&tmp, payload)
-        .map_err(|err| GrokSearchError::OAuth(format!("oauth_token_write_failed: {err}")))?;
+    write_token_tmp(&tmp, &payload)?;
     commit_token_file(&tmp, path)?;
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        let _ = std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600));
+    set_owner_only_file_permissions(path)?;
+    Ok(())
+}
+
+fn ensure_token_parent_dir(path: &Path) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        create_owner_only_dir(parent)?;
+        set_owner_only_dir_permissions(parent)?;
     }
+    Ok(())
+}
+
+#[cfg(unix)]
+fn create_owner_only_dir(parent: &Path) -> Result<()> {
+    use std::os::unix::fs::DirBuilderExt;
+
+    fs::DirBuilder::new()
+        .recursive(true)
+        .mode(0o700)
+        .create(parent)
+        .map_err(|err| GrokSearchError::OAuth(format!("oauth_token_dir_failed: {err}")))
+}
+
+#[cfg(not(unix))]
+fn create_owner_only_dir(parent: &Path) -> Result<()> {
+    fs::create_dir_all(parent)
+        .map_err(|err| GrokSearchError::OAuth(format!("oauth_token_dir_failed: {err}")))
+}
+
+#[cfg(unix)]
+fn set_owner_only_dir_permissions(path: &Path) -> Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+
+    fs::set_permissions(path, fs::Permissions::from_mode(0o700))
+        .map_err(|err| GrokSearchError::OAuth(format!("oauth_token_dir_chmod_failed: {err}")))
+}
+
+#[cfg(not(unix))]
+fn set_owner_only_dir_permissions(_path: &Path) -> Result<()> {
+    Ok(())
+}
+
+#[cfg(unix)]
+fn write_token_tmp(tmp: &Path, payload: &str) -> Result<()> {
+    use std::os::unix::fs::OpenOptionsExt;
+
+    let mut file = fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .mode(0o600)
+        .open(tmp)
+        .map_err(|err| GrokSearchError::OAuth(format!("oauth_token_write_failed: {err}")))?;
+    file.write_all(payload.as_bytes())
+        .map_err(|err| GrokSearchError::OAuth(format!("oauth_token_write_failed: {err}")))?;
+    set_owner_only_file_permissions(tmp)
+}
+
+#[cfg(not(unix))]
+fn write_token_tmp(tmp: &Path, payload: &str) -> Result<()> {
+    let mut file = fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(tmp)
+        .map_err(|err| GrokSearchError::OAuth(format!("oauth_token_write_failed: {err}")))?;
+    file.write_all(payload.as_bytes())
+        .map_err(|err| GrokSearchError::OAuth(format!("oauth_token_write_failed: {err}")))
+}
+
+#[cfg(unix)]
+fn set_owner_only_file_permissions(path: &Path) -> Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+
+    fs::set_permissions(path, fs::Permissions::from_mode(0o600))
+        .map_err(|err| GrokSearchError::OAuth(format!("oauth_token_chmod_failed: {err}")))
+}
+
+#[cfg(not(unix))]
+fn set_owner_only_file_permissions(_path: &Path) -> Result<()> {
     Ok(())
 }
 
@@ -105,7 +175,10 @@ pub fn delete_token_store(path: &Path) -> Result<bool> {
 
 pub fn auth_status(path: &Path) -> AuthStatus {
     let store = load_token_store(path).ok().flatten();
-    let access = store.as_ref().map(|s| s.access_token.as_str()).unwrap_or("");
+    let access = store
+        .as_ref()
+        .map(|s| s.access_token.as_str())
+        .unwrap_or("");
     AuthStatus {
         path: path.to_path_buf(),
         authenticated: !access.is_empty(),

--- a/src/providers/grok.rs
+++ b/src/providers/grok.rs
@@ -1,16 +1,18 @@
 use crate::adapters::grok_responses_request::to_grok_responses_payload;
 use crate::adapters::grok_responses_response::parse_grok_responses;
+use crate::credentials::{CredentialProvider, StaticApiKeyCredential};
 use crate::error::Result;
 use crate::model::search::{SearchRequest, SearchResponse};
 use crate::providers::http::{build_client, post_json};
 use reqwest::Client;
+use std::sync::Arc;
 use std::time::Duration;
 
 #[derive(Clone)]
 pub struct GrokResponsesProvider {
     client: Client,
     api_url: String,
-    api_key: String,
+    credential: Arc<dyn CredentialProvider>,
     require_web_search: bool,
     include_x_search: bool,
 }
@@ -43,10 +45,26 @@ impl GrokResponsesProvider {
         require_web_search: bool,
         include_x_search: bool,
     ) -> Self {
+        Self::with_credential_client(
+            client,
+            api_url,
+            Arc::new(StaticApiKeyCredential::new(api_key.into())),
+            require_web_search,
+            include_x_search,
+        )
+    }
+
+    pub fn with_credential_client(
+        client: Client,
+        api_url: impl Into<String>,
+        credential: Arc<dyn CredentialProvider>,
+        require_web_search: bool,
+        include_x_search: bool,
+    ) -> Self {
         Self {
             client,
             api_url: api_url.into().trim_end_matches('/').to_string(),
-            api_key: api_key.into(),
+            credential,
             require_web_search,
             include_x_search,
         }
@@ -59,10 +77,11 @@ impl GrokResponsesProvider {
     pub async fn search(&self, request: &SearchRequest) -> Result<SearchResponse> {
         let payload =
             to_grok_responses_payload(request, self.require_web_search, self.include_x_search)?;
+        let token = self.credential.bearer_token().await?;
         let raw = post_json(
             &self.client,
             &self.endpoint(),
-            &self.api_key,
+            &token,
             &payload,
             "Grok Responses",
         )

--- a/src/service.rs
+++ b/src/service.rs
@@ -5,7 +5,8 @@ use tokio::sync::Mutex;
 use uuid::Uuid;
 
 use crate::cache::SourceCache;
-use crate::config::Config;
+use crate::config::{AuthMode, Config};
+use crate::credentials::{OAuthCredential, StaticApiKeyCredential};
 use crate::error::{GrokSearchError, Result};
 use crate::model::search::{
     ContentBlock, SearchFilters, SearchMessage, SearchRequest, SearchResponse, SearchTool,
@@ -111,14 +112,32 @@ impl SearchService {
 
         let ai: Arc<dyn AiProvider> = match config.transport {
             Transport::Responses => {
-                let grok_key = config
-                    .grok_api_key
-                    .clone()
-                    .ok_or(GrokSearchError::MissingConfig("GROK_SEARCH_API_KEY"))?;
-                Arc::new(GrokResponsesProvider::with_client(
+                let credential: Arc<dyn crate::credentials::CredentialProvider> =
+                    match config.grok_auth_mode {
+                        AuthMode::ApiKey => Arc::new(StaticApiKeyCredential::new(
+                            config
+                                .grok_api_key
+                                .clone()
+                                .ok_or(GrokSearchError::MissingConfig("GROK_SEARCH_API_KEY"))?,
+                        )),
+                        AuthMode::OAuth => {
+                            let auth_path = config
+                                .grok_auth_file
+                                .clone()
+                                .or_else(crate::config::auth_path)
+                                .ok_or_else(|| {
+                                    GrokSearchError::OAuth(
+                                        "oauth_auth_path_unavailable: set GROK_SEARCH_AUTH_FILE"
+                                            .to_string(),
+                                    )
+                                })?;
+                            Arc::new(OAuthCredential::new(http.clone(), auth_path))
+                        }
+                    };
+                Arc::new(GrokResponsesProvider::with_credential_client(
                     http.clone(),
                     config.grok_api_url.clone(),
-                    grok_key,
+                    credential,
                     config.web_search_enabled,
                     config.x_search_enabled,
                 ))
@@ -484,6 +503,16 @@ impl SearchService {
             "grok": {
                 "api_url": ai_api_url,
                 "model": self.default_model,
+                "auth_mode": match self.config.grok_auth_mode {
+                    AuthMode::ApiKey => "api_key",
+                    AuthMode::OAuth => "oauth",
+                },
+                "auth_file": self.config
+                    .grok_auth_file
+                    .clone()
+                    .or_else(crate::config::auth_path)
+                    .map(|path| path.display().to_string())
+                    .unwrap_or_else(|| "unavailable".to_string()),
                 "web_search_enabled": self.config.web_search_enabled,
                 "x_search_enabled": ai_x_search_enabled,
                 "reachable": grok_probe.ok,

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -1,6 +1,6 @@
 use std::fs;
 
-use grok_search_rs::config::{self, Config, InitOutcome};
+use grok_search_rs::config::{self, AuthMode, Config, InitOutcome, Transport};
 use tempfile::tempdir;
 
 #[test]
@@ -19,6 +19,43 @@ fn config_reads_grok_search_responses_defaults() {
     assert_eq!(cfg.default_extra_sources, 3);
     assert_eq!(cfg.fallback_sources, 5);
     assert_eq!(cfg.timeout.as_secs(), 60);
+    assert_eq!(cfg.grok_auth_mode, AuthMode::ApiKey);
+}
+
+#[test]
+fn config_reads_oauth_auth_mode_from_env() {
+    let cfg = Config::from_env_map([("GROK_SEARCH_AUTH_MODE", "oauth")]);
+
+    assert_eq!(cfg.grok_auth_mode, AuthMode::OAuth);
+    assert_eq!(cfg.transport, Transport::Responses);
+}
+
+#[test]
+fn oauth_transport_wins_over_openai_compatible_config() {
+    let cfg = Config::from_env_map([
+        ("GROK_SEARCH_AUTH_MODE", "oauth"),
+        ("OPENAI_COMPATIBLE_API_URL", "https://example.com/v1"),
+        ("OPENAI_COMPATIBLE_API_KEY", "sk-fake"),
+    ]);
+
+    assert_eq!(cfg.grok_auth_mode, AuthMode::OAuth);
+    assert_eq!(cfg.transport, Transport::Responses);
+}
+
+#[test]
+fn config_reads_auth_file_override() {
+    let cfg = Config::from_env_map([
+        ("GROK_SEARCH_AUTH_MODE", "oauth"),
+        ("GROK_SEARCH_AUTH_FILE", "C:\\Users\\chen\\.config\\grok-search-rs\\auth.json"),
+    ]);
+
+    assert_eq!(cfg.grok_auth_mode, AuthMode::OAuth);
+    assert_eq!(
+        cfg.grok_auth_file,
+        Some(std::path::PathBuf::from(
+            "C:\\Users\\chen\\.config\\grok-search-rs\\auth.json"
+        ))
+    );
 }
 
 #[test]
@@ -197,6 +234,8 @@ fn config_file_supports_all_documented_keys() {
         r#"
 grok_api_url          = "https://api.modelverse.cn"
 grok_api_key          = "xai-full"
+grok_auth_mode        = "oauth"
+grok_auth_file        = 'C:\Users\chen\.config\grok-search-rs\auth.json'
 grok_model            = "grok-9000"
 web_search_enabled    = false
 x_search_enabled      = true
@@ -219,6 +258,13 @@ timeout_seconds       = 30
 
     assert_eq!(cfg.grok_api_url, "https://api.modelverse.cn/v1");
     assert_eq!(cfg.grok_api_key.as_deref(), Some("xai-full"));
+    assert_eq!(cfg.grok_auth_mode, AuthMode::OAuth);
+    assert_eq!(
+        cfg.grok_auth_file,
+        Some(std::path::PathBuf::from(
+            "C:\\Users\\chen\\.config\\grok-search-rs\\auth.json"
+        ))
+    );
     assert_eq!(cfg.grok_model, "grok-9000");
     assert!(!cfg.web_search_enabled);
     assert!(cfg.x_search_enabled);
@@ -341,6 +387,38 @@ fn config_path_prefers_home_over_userprofile_when_both_set() {
         "HOME should win, got {}",
         path.display()
     );
+}
+
+#[test]
+fn auth_path_uses_config_sibling_by_default() {
+    let path = config::auth_path_for([("HOME", "/home/alice")])
+        .expect("HOME must produce auth path");
+    let expected = std::path::PathBuf::from("/home/alice")
+        .join(".config")
+        .join("grok-search-rs")
+        .join("auth.json");
+    assert_eq!(path, expected);
+}
+
+#[test]
+fn auth_path_falls_back_to_userprofile_when_home_missing() {
+    let path = config::auth_path_for([("USERPROFILE", "C:\\Users\\chen")])
+        .expect("USERPROFILE must produce auth path");
+    let expected = std::path::PathBuf::from("C:\\Users\\chen")
+        .join(".config")
+        .join("grok-search-rs")
+        .join("auth.json");
+    assert_eq!(path, expected);
+}
+
+#[test]
+fn auth_path_honors_explicit_override() {
+    let path = config::auth_path_for([
+        ("GROK_SEARCH_AUTH_FILE", "/tmp/auth.json"),
+        ("HOME", "/home/ignored"),
+    ])
+    .expect("explicit override must resolve");
+    assert_eq!(path, std::path::PathBuf::from("/tmp/auth.json"));
 }
 
 #[test]

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -31,6 +31,13 @@ fn config_reads_oauth_auth_mode_from_env() {
 }
 
 #[test]
+fn unknown_auth_mode_falls_back_to_api_key() {
+    let cfg = Config::from_env_map([("GROK_SEARCH_AUTH_MODE", "something_else")]);
+
+    assert_eq!(cfg.grok_auth_mode, AuthMode::ApiKey);
+}
+
+#[test]
 fn oauth_transport_wins_over_openai_compatible_config() {
     let cfg = Config::from_env_map([
         ("GROK_SEARCH_AUTH_MODE", "oauth"),
@@ -46,7 +53,10 @@ fn oauth_transport_wins_over_openai_compatible_config() {
 fn config_reads_auth_file_override() {
     let cfg = Config::from_env_map([
         ("GROK_SEARCH_AUTH_MODE", "oauth"),
-        ("GROK_SEARCH_AUTH_FILE", "C:\\Users\\chen\\.config\\grok-search-rs\\auth.json"),
+        (
+            "GROK_SEARCH_AUTH_FILE",
+            "C:\\Users\\chen\\.config\\grok-search-rs\\auth.json",
+        ),
     ]);
 
     assert_eq!(cfg.grok_auth_mode, AuthMode::OAuth);
@@ -355,8 +365,8 @@ fn config_path_explicit_override_wins_over_home() {
 
 #[test]
 fn config_path_uses_home_on_unix_layout() {
-    let path = config::config_path_for([("HOME", "/home/alice")])
-        .expect("HOME must produce a path");
+    let path =
+        config::config_path_for([("HOME", "/home/alice")]).expect("HOME must produce a path");
     let expected = std::path::PathBuf::from("/home/alice")
         .join(".config")
         .join("grok-search-rs")
@@ -377,11 +387,9 @@ fn config_path_falls_back_to_userprofile_when_home_missing() {
 
 #[test]
 fn config_path_prefers_home_over_userprofile_when_both_set() {
-    let path = config::config_path_for([
-        ("HOME", "/home/alice"),
-        ("USERPROFILE", "C:\\Users\\chen"),
-    ])
-    .expect("must resolve");
+    let path =
+        config::config_path_for([("HOME", "/home/alice"), ("USERPROFILE", "C:\\Users\\chen")])
+            .expect("must resolve");
     assert!(
         path.starts_with("/home/alice"),
         "HOME should win, got {}",
@@ -391,8 +399,8 @@ fn config_path_prefers_home_over_userprofile_when_both_set() {
 
 #[test]
 fn auth_path_uses_config_sibling_by_default() {
-    let path = config::auth_path_for([("HOME", "/home/alice")])
-        .expect("HOME must produce auth path");
+    let path =
+        config::auth_path_for([("HOME", "/home/alice")]).expect("HOME must produce auth path");
     let expected = std::path::PathBuf::from("/home/alice")
         .join(".config")
         .join("grok-search-rs")


### PR DESCRIPTION
## Summary

Adds an optional Grok OAuth authentication mode alongside the existing API key flow.

- add `login`, `status`, and `logout` CLI commands for loopback OAuth login
- add `GROK_SEARCH_AUTH_MODE=api_key|oauth` and `GROK_SEARCH_AUTH_FILE` support
- introduce a credential provider abstraction so Grok Responses can use either static API keys or refreshed OAuth access tokens
- add OAuth token storage, JWT expiry parsing, refresh handling, and PKCE helpers
- document the OAuth mode, local auth file, and the risk of reusing the Hermes xAI OAuth client id

## Validation

- `cargo test`
- `cargo clippy --all-targets -- -D warnings`
- `git diff --cached --check`

## Notes

OAuth mode is intentionally opt-in and leaves API key mode as the default behavior.