### PR TITLE
feat(service): 细分 web_search 降级原因(grok_timeout / grok_auth_error / grok_parse_error)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to GrokSearch-rs are documented here.
 
 ## Unreleased
 
+### Changed
+
+- **`web_search` 降级原因细分。** Grok 调用失败时 `fallback_reason` 不再一律
+  归为 `grok_provider_error`,而是按错误类型区分:`grok_timeout`(超时)、
+  `grok_auth_error`(鉴权)、`grok_parse_error`(响应解析失败),其余仍为
+  `grok_provider_error`,便于排查降级到底是限流/超时还是上游故障。
+
 ## 0.1.14 - 2026-06-05
 
 ### Added

--- a/src/service.rs
+++ b/src/service.rs
@@ -343,7 +343,7 @@ impl SearchService {
 
         let response = match grok_result {
             Ok(response) => response,
-            Err(_) => {
+            Err(err) => {
                 return self
                     .finalize_fallback(
                         deadline,
@@ -354,7 +354,7 @@ impl SearchService {
                         },
                         raw_sources,
                         raw_origin,
-                        "grok_provider_error",
+                        grok_error_reason(&err),
                         include_content,
                     )
                     .await;
@@ -785,6 +785,20 @@ fn fallback_label(origin: RawSourceOrigin) -> &'static str {
         RawSourceOrigin::Primary => "tavily_fallback",
         RawSourceOrigin::Fallback => "firecrawl_enrichment",
         RawSourceOrigin::None => "tavily_fallback",
+    }
+}
+
+/// Maps a failed Grok call to a stable `fallback_reason` identifier. Kept at
+/// enum-variant granularity on purpose: distinguishing timeout / auth / parse
+/// from a generic provider failure is the diagnostically useful axis, while
+/// sub-parsing HTTP status codes out of `Provider(String)` would be fragile.
+/// `Provider` (and any other variant) preserves the legacy `grok_provider_error`.
+fn grok_error_reason(err: &GrokSearchError) -> &'static str {
+    match err {
+        GrokSearchError::Timeout(_) => "grok_timeout",
+        GrokSearchError::OAuth(_) => "grok_auth_error",
+        GrokSearchError::Parse(_) => "grok_parse_error",
+        _ => "grok_provider_error",
     }
 }
 

--- a/tests/service_contract.rs
+++ b/tests/service_contract.rs
@@ -137,6 +137,68 @@ async fn web_search_uses_env_default_extra_sources_after_grok_success() {
         .any(|source| source.provider == "tavily_enrichment"));
 }
 
+struct TimeoutAiProvider;
+
+#[async_trait]
+impl AiProvider for TimeoutAiProvider {
+    async fn search(&self, _request: &SearchRequest) -> Result<SearchResponse> {
+        Err(GrokSearchError::Timeout("upstream timed out".to_string()))
+    }
+}
+
+struct ProviderErrAiProvider;
+
+#[async_trait]
+impl AiProvider for ProviderErrAiProvider {
+    async fn search(&self, _request: &SearchRequest) -> Result<SearchResponse> {
+        Err(GrokSearchError::Provider("HTTP 500".to_string()))
+    }
+}
+
+// A failing Grok call surfaces the specific error kind as fallback_reason
+// (timeout vs the legacy generic provider error), so degraded responses are
+// diagnosable rather than collapsed into one catch-all code.
+#[tokio::test]
+async fn web_search_fallback_reason_reflects_grok_error_kind() {
+    let timeout_service = SearchService::fake_custom(
+        Some(Arc::new(TimeoutAiProvider)),
+        Arc::new(CountingSourceProvider::default()),
+        None,
+        [] as [(&str, &str); 0],
+    );
+    let timeout_output = timeout_service
+        .web_search(WebSearchInput {
+            query: "anything".to_string(),
+            ..Default::default()
+        })
+        .await
+        .expect("fallback output");
+    assert!(timeout_output.fallback_used);
+    assert_eq!(
+        timeout_output.fallback_reason,
+        Some("grok_timeout".to_string())
+    );
+
+    let provider_service = SearchService::fake_custom(
+        Some(Arc::new(ProviderErrAiProvider)),
+        Arc::new(CountingSourceProvider::default()),
+        None,
+        [] as [(&str, &str); 0],
+    );
+    let provider_output = provider_service
+        .web_search(WebSearchInput {
+            query: "anything".to_string(),
+            ..Default::default()
+        })
+        .await
+        .expect("fallback output");
+    assert!(provider_output.fallback_used);
+    assert_eq!(
+        provider_output.fallback_reason,
+        Some("grok_provider_error".to_string())
+    );
+}
+
 #[tokio::test]
 async fn web_search_falls_back_to_tavily_when_grok_has_no_sources() {
     let source_provider = CountingSourceProvider::default();


### PR DESCRIPTION
## 背景

排查时发现:`web_search` 在 Grok 调用失败降级到 source fallback 时,`fallback_reason` 一律写死为 `grok_provider_error`,无论真实原因是超时、鉴权失败还是上游故障。底层 `GrokSearchError` 的具体类型在 [service.rs:346](src/service.rs#L346) 的 `Err(_)` 处被丢弃,导致降级问题无法自助诊断。

(起因是一次 `"Claude Code"` 查询连续返回 `grok_provider_error`,被误判为"内容审查";实测同查询可正常返回,实为上游 `api.modelverse.cn` 的瞬时故障。本 PR 不修复该瞬时故障,只让其可诊断。)

## 改动

按 `GrokSearchError` **枚举变体粒度**映射出稳定的 reason 标识符:

| 错误变体 | fallback_reason |
|---|---|
| `Timeout` | `grok_timeout` |
| `OAuth` | `grok_auth_error` |
| `Parse` | `grok_parse_error` |
| `Provider` 及其余 | `grok_provider_error`(向后兼容) |

**有意不做**:`Provider(String)` 内部的 HTTP 429 / `response.incomplete` 不再细分——需字符串匹配,脆弱且属过度设计。未改 `GrokSearchError` 枚举与 JSON-RPC code 映射。

## 验证

- 新增测试 `web_search_fallback_reason_reflects_grok_error_kind`:断言 timeout→`grok_timeout`、provider→`grok_provider_error`。
- `cargo test` 全绿,`cargo clippy --all-targets` 无警告。

🤖 Generated with [Claude Code](https://claude.com/claude-code)