### PR TITLE
feat(http): remote multi-tenant Streamable HTTP transport (BYO-key) + Docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+target
+.git
+.github
+docs
+*.md
+!README.md
+.claude
+
+# Local env files (may hold secrets) — never send them to the build context
+.env
+.env.*

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@
 /.planning/
 /GrokSearch-rs-rebuild-plan.md
 /docs/promotion-linuxdo.md
+/docs/remote-mcp-deploy-plan.md
 
 # gstack / QA tooling artifacts
 /.gstack/

--- a/Caddyfile
+++ b/Caddyfile
@@ -1,0 +1,29 @@
+# Caddy site for the docker-compose deploy. Automatic HTTPS via Let's Encrypt.
+# Gateway-style path routing: each backend service lives under its own path
+# prefix, so a single host can front many MCP (and other) services.
+#
+# Set MCP_HOSTNAME (in a .env file or the environment) to your own domain, or to
+# your VPS's dash-joined-IP sslip.io name, e.g. 203-0-113-5.sslip.io for
+# 203.0.113.5. It defaults to localhost (a safe internal cert) until you set it.
+{$MCP_HOSTNAME:localhost} {
+	encode zstd gzip
+
+	# grok-search-rs MCP — reachable at /groksearch_rs/mcp
+	# (handle_path strips the /groksearch_rs prefix before proxying to /mcp).
+	handle_path /groksearch_rs/* {
+		reverse_proxy grok-search-rs:8080
+	}
+
+	# Backward-compatible bare endpoint: /mcp still reaches grok-search-rs.
+	handle /mcp* {
+		reverse_proxy grok-search-rs:8080
+	}
+
+	# Add more services under their own prefixes, e.g.:
+	#   handle_path /another_service/* { reverse_proxy another_service:8080 }
+
+	# Unknown paths -> 404 (instead of Caddy's default empty 200).
+	handle {
+		respond "not found" 404
+	}
+}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -44,6 +44,54 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "axum"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
+dependencies = [
+ "axum-core",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
+ "serde_json",
+ "serde_path_to_error",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -273,6 +321,7 @@ version = "0.1.17"
 dependencies = [
  "anyhow",
  "async-trait",
+ "axum",
  "base64",
  "getrandom 0.3.4",
  "percent-encoding",
@@ -350,6 +399,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "hyper"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -362,6 +417,7 @@ dependencies = [
  "http",
  "http-body",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "smallvec",
@@ -590,10 +646,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "miniz_oxide"
@@ -951,6 +1019,17 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,14 @@ ring = "0.17"
 url = "2"
 percent-encoding = "2"
 quick-xml = { version = "0.37", default-features = false, features = ["encoding"] }
+axum = { version = "0.8", optional = true, default-features = false, features = ["tokio", "http1", "json"] }
+
+[features]
+# Native Streamable HTTP transport (remote, multi-tenant, bring-your-own-key).
+# OFF by default: the default build stays a pure stdio binary — no axum, no
+# multi-threaded runtime — so local stdio users are entirely unaffected. The
+# server build opts in with `--features http`.
+http = ["dep:axum", "tokio/net", "tokio/rt-multi-thread"]
 
 [dev-dependencies]
 tempfile = "3"
@@ -44,3 +52,11 @@ strip = true
 lto = "thin"
 codegen-units = 1
 panic = "abort"
+
+# Server / HTTP build: same size optimizations as `release`, but panic=unwind so
+# a single request handler panic cannot abort the whole multi-tenant process
+# (the panicking task's connection is dropped; the server keeps serving). Build
+# the deployable server binary with `--profile release-http --features http`.
+[profile.release-http]
+inherits = "release"
+panic = "unwind"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+# syntax=docker/dockerfile:1
+#
+# grok-search-rs — public multi-tenant Streamable HTTP MCP server.
+# The image holds NO credentials: each request carries the caller's own keys as
+# headers (X-Grok-Api-Key / X-Tavily-Api-Key / X-Firecrawl-Api-Key).
+
+# ---- build stage ----------------------------------------------------------
+FROM rust:1-bookworm AS builder
+WORKDIR /app
+COPY . .
+# release-http => panic=unwind so a handler panic can't abort the whole process.
+RUN cargo build --profile release-http --features http \
+    && cp target/release-http/grok-search-rs /grok-search-rs
+
+# ---- runtime stage --------------------------------------------------------
+FROM debian:bookworm-slim
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates \
+    && rm -rf /var/lib/apt/lists/* \
+    && useradd --system --no-create-home --shell /usr/sbin/nologin grokmcp
+COPY --from=builder /grok-search-rs /usr/local/bin/grok-search-rs
+# Bind all interfaces inside the container; a reverse proxy terminates TLS.
+ENV GROK_MCP_BIND=0.0.0.0:8080
+EXPOSE 8080
+USER grokmcp
+ENTRYPOINT ["grok-search-rs", "--http"]

--- a/Dockerfile.deploy
+++ b/Dockerfile.deploy
@@ -1,0 +1,14 @@
+# Runtime-only image: copies a pre-built static musl binary (no in-container
+# compile), so it builds instantly even on a 1 GB box. Build the binary first
+# on a capable machine:
+#   cargo zigbuild --profile release-http --features http --target x86_64-unknown-linux-musl
+# then place target/.../release-http/grok-search-rs next to this file and:
+#   docker build -f Dockerfile.deploy -t grok-search-rs:deploy .
+FROM alpine:3.20
+RUN apk add --no-cache ca-certificates \
+    && adduser -D -H -s /sbin/nologin grokmcp
+COPY grok-search-rs /usr/local/bin/grok-search-rs
+ENV GROK_MCP_BIND=0.0.0.0:8080
+EXPOSE 8080
+USER grokmcp
+ENTRYPOINT ["grok-search-rs", "--http"]

--- a/README.md
+++ b/README.md
@@ -4,17 +4,18 @@
 
 **A lightweight Rust MCP server for Grok / OpenAI‑compatible web search, plus Tavily fetch/map and Firecrawl fallback.**
 
-`grok-search-rs` is an **MCP stdio server** — your client (Claude Code, Codex, Cursor, VS Code, …) launches it; you do not run it directly. It exposes one set of tools (`web_search`, `get_sources`, `web_fetch`, `web_map`, `doctor`) and supports two upstream transports so you can plug into either xAI's official API or any OpenAI‑compatible relay.
+`grok-search-rs` is an **MCP server** — run it locally over **stdio** (your client launches it; you do not run it directly) or as a **remote Streamable HTTP** service for mobile / multi‑device access (see [self-hosting](#self-hosting-remote-http)). It exposes one set of tools (`web_search`, `get_sources`, `web_fetch`, `web_map`, `doctor`) and supports two upstream transports so you can plug into either xAI's official API or any OpenAI‑compatible relay.
 
 ---
 
 ## Features
 
 - 🔎 **Live web search** with cited sources, cached for follow‑up `get_sources` calls. Opt‑in `include_content` enriches the top sources with full extracted text in one call.
-- 📏 **Response budgeting** — `web_search` keeps responses inside agent context limits: only the top `max_inline_sources` carry inline text, a whole‑response char budget (`response_max_chars`, default 60k) trims tail sources with recovery notes, `response_format: "concise" | "detailed"` picks the payload size, and `get_sources` pages through cached sources with `offset`/`limit`. The session cache always keeps full content.
+- 📏 **Response budgeting** — `web_search` keeps responses inside agent context limits: only the top `max_inline_sources` carry inline text, a whole‑response char budget (`response_max_chars`, default 45k — sized to stay under the MCP client token ceiling after JSON serialization) trims tail sources with recovery notes, `response_format: "concise" | "detailed"` picks the payload size, and `get_sources` pages through cached sources with `offset`/`limit`. The session cache always keeps full content.
 - 🧩 **Structured `web_fetch`** — GitHub issues/PRs, StackExchange/MathOverflow, arXiv, and Wikipedia URLs are parsed by specialist extractors into clean Markdown (title, state/labels, accepted‑answer ordering, abstracts, vote‑sorted answers). Anything else falls back to the generic Tavily → Firecrawl chain. Output carries `source_type` and a `fallback_reason` when a specialist was skipped.
 - 🔀 **Two transports** — native xAI Responses (`/v1/responses`) **or** any OpenAI‑compatible chat‑completions gateway (`/v1/chat/completions`). Pick by env vars; no flag.
 - 🔐 **Optional Grok OAuth mode** — `login/status/logout` commands store a local xAI OAuth token for Responses auth, so the MCP server can run without `GROK_SEARCH_API_KEY`.
+- 🌐 **Optional remote mode** — build with `--features http` to serve the same tools over **Streamable HTTP** (multi‑tenant, bring‑your‑own‑key via request headers) for mobile / multi‑device access. See [self-hosting](#self-hosting-remote-http).
 - 📥 **Tavily fetch / map** for full‑text extraction and link discovery, with **Firecrawl** as automatic fallback. `TAVILY_API_KEY` accepts a comma‑separated key list — keys rotate round‑robin with automatic failover on rate/quota errors.
 - 🐦 **Optional X/Twitter search** via `x_search` (Responses transport only).
 - 🩺 **`doctor`** — connectivity probe + redacted config in one tool call.
@@ -33,6 +34,21 @@ The npm package ships a native Rust binary; the `grok-search-rs` command is what
 ---
 
 ## Quick Start
+
+**Option A — use the hosted instance (no install).** Point any MCP client that supports remote
+HTTP + custom headers at the public endpoint and pass your own keys as headers:
+
+```bash
+claude mcp add --transport http grok-search https://mcp.episkeyai.com/groksearch_rs/mcp \
+  --header "X-Grok-Api-Key: xai-..." \
+  --header "X-Tavily-Api-Key: tvly-..."
+```
+
+The default gateway is xAI official (`api.x.ai`) — use an xAI key. For another gateway (e.g.
+Modelverse) add `--header "X-Grok-Base-Url: https://api.modelverse.cn/v1"`. No keys are stored
+server-side; best-effort availability. Prefer your own server? See [self-hosting](#self-hosting-remote-http).
+
+**Option B — install locally (stdio).**
 
 1. After `npm install -g grok-search-rs`, add this MCP server entry to your client config:
 
@@ -158,7 +174,7 @@ Notes:
 | `GROK_SEARCH_TIMEOUT_SECONDS` | `60` | HTTP timeout for all upstreams. |
 | `GROK_SEARCH_FETCH_MAX_CHARS` | unset | Default char cap on `web_fetch`. |
 | `GROK_SEARCH_MAX_INLINE_SOURCES` | `5` | Max `web_search` sources carrying inline content; the rest are metadata‑only. |
-| `GROK_SEARCH_RESPONSE_MAX_CHARS` | `60000` | Whole‑response char budget for `web_search`; over‑budget output is truncated tail‑first with `truncated: true`. |
+| `GROK_SEARCH_RESPONSE_MAX_CHARS` | `45000` | Whole‑response char budget for `web_search`; over‑budget output is truncated tail‑first with `truncated: true`. Sized to keep the serialized result under the MCP client token ceiling (Claude Code default `MAX_MCP_OUTPUT_TOKENS=25000`). |
 
 ### Source extraction (`web_fetch` specialists / `web_search` enrichment)
 
@@ -204,6 +220,56 @@ Tired of duplicating `env` blocks across clients? Run `grok-search-rs --init` on
 | `web_fetch` | Page content as clean Markdown. Specialist extractors for GitHub / StackExchange / arXiv / Wikipedia; generic Tavily → Firecrawl fallback otherwise. Returns `source_type` + `fallback_reason`. |
 | `web_map` | Discover URLs on a domain via Tavily Map. |
 | `doctor` | Live connectivity probe + redacted config. Run first when something looks off. |
+
+---
+
+## Self-hosting (remote HTTP)
+
+Besides the default stdio mode, `grok-search-rs` can run as a **remote, multi‑tenant
+Streamable HTTP MCP server** so mobile / on‑the‑go / multi‑device clients can reach it over
+the network. It is **opt‑in behind the `http` Cargo feature** — the default build is
+unchanged (pure stdio, no HTTP dependencies linked in).
+
+**Bring‑your‑own‑key, zero shared credentials.** The server stores no API keys. Each
+request carries the caller's own keys as headers, so many users can share one endpoint and
+each pays with their own keys:
+
+- `X-Grok-Api-Key`, `X-Tavily-Api-Key`, `X-Firecrawl-Api-Key` (optional `X-GitHub-Token`)
+
+A missing required key returns `401` (fail‑closed); OAuth is rejected on this transport
+(stdio only). The operator fixes the Grok‑compatible gateway via `GROK_SEARCH_URL`
+(default `https://api.x.ai`), and callers may switch to another allowlisted gateway with an
+`X-Grok-Base-Url` header (see `GROK_SEARCH_ALLOWED_GROK_URLS`). The remote transport uses the
+Grok **Responses** API only; the OpenAI-compatible chat-completions transport is stdio-only.
+
+```bash
+cargo build --profile release-http --features http    # release-http => panic=unwind (handler panic won't kill the server)
+GROK_MCP_BIND=127.0.0.1:8080 target/release-http/grok-search-rs --http   # bind loopback; terminate TLS upstream
+```
+
+Put a TLS‑terminating reverse proxy (e.g. Caddy) in front. The repo ships a `Dockerfile`,
+`Dockerfile.deploy` (runtime‑only, for low‑RAM hosts), `docker-compose.yml`, and `Caddyfile`
+for a one‑command deploy with automatic HTTPS. Set `MCP_HOSTNAME` (your domain or a
+`<dashed-ip>.sslip.io` name) via the environment or a git‑ignored `.env` — **not** in the
+repo.
+
+Connect a client the same way as the hosted instance ([Quick Start](#quick-start)), pointing
+`url` at your own host (`https://<your-host>/groksearch_rs/mcp`).
+
+### Rotating a key
+
+Keys are never stored server‑side, so rotation is entirely client‑side:
+
+- **stdio** — update the key in your MCP client's `env` block (or the global `config.toml`)
+  and restart the client.
+- **remote HTTP** — update the header value in your client config. For Claude Code:
+  ```bash
+  claude mcp remove grok-search -s user
+  claude mcp add --transport http grok-search https://<your-host>/groksearch_rs/mcp \
+    --header "X-Grok-Api-Key: <new-key>" --header "X-Tavily-Api-Key: <new-key>"
+  ```
+
+Rotate immediately if a key was ever printed, logged, or shared.
 
 ---
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,45 @@
+# One-command deploy: grok-search-rs behind Caddy with automatic HTTPS.
+#
+#   MCP_HOSTNAME=your-domain.example.com docker compose up -d --build
+#
+# Set MCP_HOSTNAME to your own domain (A record -> your server IP) or your VPS's
+# dash-joined-IP sslip.io name (e.g. 203-0-113-5.sslip.io). Keep it out of the
+# repo — pass it via the environment or a local .env file (git-ignored).
+#
+# Endpoint: https://<MCP_HOSTNAME>/groksearch_rs/mcp — each user supplies their
+# OWN keys as request headers (X-Grok-Api-Key / X-Tavily-Api-Key / X-Firecrawl-Api-Key).
+services:
+  grok-search-rs:
+    build: .
+    image: grok-search-rs:latest
+    restart: unless-stopped
+    environment:
+      GROK_MCP_BIND: "0.0.0.0:8080"
+      # Operator NON-secret defaults only (e.g. a fixed Grok-compatible gateway):
+      #   GROK_SEARCH_URL: "https://api.x.ai/v1"
+      # NEVER put *_API_KEY here — credentials come from per-request headers, and
+      # the server strips any server-side keys from the per-request config.
+    expose:
+      - "8080"
+    mem_limit: 256m
+    security_opt:
+      - no-new-privileges:true
+
+  caddy:
+    image: caddy:2-alpine
+    restart: unless-stopped
+    depends_on:
+      - grok-search-rs
+    environment:
+      MCP_HOSTNAME: "${MCP_HOSTNAME:-localhost}"
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile:ro
+      - caddy_data:/data
+      - caddy_config:/config
+
+volumes:
+  caddy_data:
+  caddy_config:

--- a/src/config.rs
+++ b/src/config.rs
@@ -312,7 +312,7 @@ impl Config {
             enrich_concurrency: usize_value(&map, "GROK_SEARCH_ENRICH_CONCURRENCY", 3).clamp(1, 5),
             enrich_max_chars: usize_value(&map, "GROK_SEARCH_ENRICH_MAX_CHARS", 15000),
             max_inline_sources: usize_value(&map, "GROK_SEARCH_MAX_INLINE_SOURCES", 5),
-            response_max_chars: usize_value(&map, "GROK_SEARCH_RESPONSE_MAX_CHARS", 60_000),
+            response_max_chars: usize_value(&map, "GROK_SEARCH_RESPONSE_MAX_CHARS", 45_000),
         }
     }
 
@@ -500,7 +500,7 @@ pub const CONFIG_TEMPLATE: &str = r#"# grok-search-rs global configuration
 # enrich_concurrency    = 3          # concurrent resolve_content calls per web_search (1..5)
 # enrich_max_chars      = 15000      # per-source inline content char cap
 # max_inline_sources    = 5          # max sources carrying inline content per response
-# response_max_chars    = 60000      # whole-response char budget (answer + inline content)
+# response_max_chars    = 45000      # whole-response char budget (answer + inline content); kept below the MCP client token ceiling (default ~25k tokens) after JSON serialization
 "#;
 
 fn load_file_map(path: &Path) -> Option<HashMap<String, String>> {
@@ -624,11 +624,13 @@ fn decide_transport(map: &HashMap<String, String>, auth_mode: AuthMode) -> Trans
     Transport::Responses
 }
 
+/// Two-state presence marker for a secret. Never emits any fragment of the
+/// value — mirrors [`Config::github_token_status`] so `doctor`/diagnostics on a
+/// public endpoint cannot leak even a prefix/suffix of a caller's key.
 fn redact(value: Option<&str>) -> String {
     match value {
-        None => "unset".to_string(),
-        Some(v) if v.len() <= 8 => "***".to_string(),
-        Some(v) => format!("{}***{}", &v[..4], &v[v.len() - 4..]),
+        Some(v) if !v.trim().is_empty() => "set".to_string(),
+        _ => "unset".to_string(),
     }
 }
 

--- a/src/http.rs
+++ b/src/http.rs
@@ -1,0 +1,713 @@
+//! Native Streamable HTTP transport (Cargo feature `http`).
+//!
+//! Exposes the same MCP tools as the stdio transport over a single
+//! `POST /mcp` endpoint, but multi-tenant: the server process holds **no**
+//! credentials. Each request carries the caller's own API keys in headers
+//! (`X-Grok-Api-Key` / `X-Tavily-Api-Key` / `X-Firecrawl-Api-Key` /
+//! `X-GitHub-Token`); a fully-credentialed [`SearchService`] is built per
+//! request via [`SearchService::for_request`], reusing one shared HTTP client
+//! and one process-wide source cache (so `get_sources` continuation still
+//! works across requests). The whole module is gated behind the `http` feature
+//! so the default stdio build never links axum.
+//!
+//! TLS terminates upstream (Caddy); this server binds loopback only.
+
+use std::collections::{HashMap, HashSet};
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use axum::{
+    extract::State,
+    http::{HeaderMap, StatusCode},
+    response::{IntoResponse, Response},
+    routing::post,
+    Json, Router,
+};
+use serde_json::Value;
+use tokio::sync::{Mutex, Semaphore};
+
+use crate::cache::SourceCache;
+use crate::config::Config;
+use crate::error::GrokSearchError;
+use crate::mcp::{error_response, handle_message};
+use crate::service::SearchService;
+
+/// Max JSON request body. MCP tool calls are tiny; anything larger is abuse.
+const MAX_BODY_BYTES: usize = 64 * 1024;
+
+/// Max concurrent in-flight requests; excess gets 429 to protect the 1 GB box.
+const MAX_CONCURRENT_REQUESTS: usize = 32;
+
+/// Protocol revisions the Streamable HTTP transport implements. Excludes
+/// 2024-11-05 (the deprecated HTTP+SSE transport this endpoint does not serve)
+/// and 2025-03-26 (which still mandates JSON-RPC batching — removed only in
+/// 2025-06-18; since this endpoint rejects batches, it declares 2025-06-18+ only).
+const HTTP_PROTOCOL_VERSIONS: &[&str] = &["2025-11-25", "2025-06-18"];
+
+/// Operator-set env keys that must NEVER survive into a per-request config:
+/// credentials come only from request headers, never from the server process
+/// environment. Stripped from the operator base env once at startup so a stray
+/// server-side key can never leak into a tenant's request.
+const SECRET_ENV_KEYS: &[&str] = &[
+    "GROK_SEARCH_API_KEY",
+    "TAVILY_API_KEY",
+    "FIRECRAWL_API_KEY",
+    "GITHUB_TOKEN",
+    "OPENAI_COMPATIBLE_API_KEY",
+    "OPENAI_COMPATIBLE_API_URL",
+    "OPENAI_COMPATIBLE_MODEL",
+    "GROK_SEARCH_AUTH_MODE",
+    "GROK_SEARCH_AUTH_FILE",
+];
+
+/// Request header -> config env key overlay. Header names match on a
+/// case-insensitive basis (axum lowercases header names).
+const HEADER_TO_ENV: &[(&str, &str)] = &[
+    ("x-grok-api-key", "GROK_SEARCH_API_KEY"),
+    ("x-tavily-api-key", "TAVILY_API_KEY"),
+    ("x-firecrawl-api-key", "FIRECRAWL_API_KEY"),
+    ("x-github-token", "GITHUB_TOKEN"),
+];
+
+#[derive(Clone)]
+struct AppState {
+    /// Shared across every request: one connection pool, operator timeout.
+    http_client: reqwest::Client,
+    /// One process-wide cache so `get_sources` continuation survives requests.
+    cache: Arc<Mutex<SourceCache>>,
+    /// Operator non-secret defaults (timeout, budgets, …), secrets stripped.
+    base_env: Arc<HashMap<String, String>>,
+    /// Allowed `Origin` values; `None` means no allowlist configured (allow).
+    allowed_origins: Arc<Option<HashSet<String>>>,
+    /// Bounds concurrent in-flight requests (DoS protection on a small box).
+    limiter: Arc<Semaphore>,
+    /// Grok-compatible gateways a request may target via `X-Grok-Base-Url`
+    /// (stored normalized). Always contains the operator default; extra ones
+    /// come from GROK_SEARCH_ALLOWED_GROK_URLS. Keeps per-request gateway
+    /// selection from becoming an open SSRF proxy.
+    allowed_grok_urls: Arc<HashSet<String>>,
+}
+
+/// Run the HTTP transport, binding `bind` (loopback in production, behind
+/// Caddy). `base_env` is the operator process environment; its non-secret
+/// entries seed every request's config, secrets are stripped.
+pub async fn run_http(base_env: HashMap<String, String>, bind: SocketAddr) -> anyhow::Result<()> {
+    // Operator (non-secret) config drives the shared client + cache sizing.
+    let operator_cfg = Config::from_env_map(base_env.clone());
+    // Restricted client: rejects redirects to non-public IP-literal targets.
+    let http_client = crate::providers::http::build_restricted_client(operator_cfg.timeout);
+    let cache = Arc::new(Mutex::new(SourceCache::new(operator_cfg.cache_size)));
+    let allowed_origins = parse_allowed_origins(&base_env);
+    let allowed_grok_urls = parse_allowed_grok_urls(&base_env, &operator_cfg.grok_api_url);
+
+    let state = AppState {
+        http_client,
+        cache,
+        base_env: Arc::new(strip_secrets(base_env)),
+        allowed_origins: Arc::new(allowed_origins),
+        limiter: Arc::new(Semaphore::new(MAX_CONCURRENT_REQUESTS)),
+        allowed_grok_urls: Arc::new(allowed_grok_urls),
+    };
+
+    // Only POST is registered; axum answers other methods on /mcp with 405.
+    // Body size is capped inside the handler (after the concurrency permit is
+    // held), so no DefaultBodyLimit layer is needed.
+    let app = Router::new()
+        .route("/mcp", post(mcp_post))
+        .with_state(state);
+
+    let listener = tokio::net::TcpListener::bind(bind).await?;
+    eprintln!("grok-search-rs: Streamable HTTP transport listening on http://{bind}/mcp");
+    axum::serve(listener, app).await?;
+    Ok(())
+}
+
+async fn mcp_post(State(state): State<AppState>, request: axum::extract::Request) -> Response {
+    // 0. Concurrency cap FIRST — acquire the permit BEFORE buffering the body,
+    //    so slow or oversized request bodies can't tie up memory/connections
+    //    past the cap without ever hitting 429.
+    let _permit = match state.limiter.clone().try_acquire_owned() {
+        Ok(permit) => permit,
+        Err(_) => return (StatusCode::TOO_MANY_REQUESTS, "server at capacity").into_response(),
+    };
+
+    let (parts, body) = request.into_parts();
+    let headers = parts.headers;
+
+    // Read the body under a hard size cap, now that the permit is held.
+    let body = match axum::body::to_bytes(body, MAX_BODY_BYTES).await {
+        Ok(bytes) => bytes,
+        Err(_) => {
+            return (StatusCode::PAYLOAD_TOO_LARGE, "request body too large").into_response()
+        }
+    };
+
+    // 1. Origin validation (DNS-rebinding defense). Absent Origin (non-browser
+    //    clients) is allowed; a present Origin must be on the allowlist when one
+    //    is configured. Enforced server-side, not via CORS alone.
+    if let Some(origin) = header_str(&headers, "origin") {
+        if let Some(allowed) = state.allowed_origins.as_ref() {
+            if !allowed.contains(origin) {
+                return (StatusCode::FORBIDDEN, "origin not allowed").into_response();
+            }
+        }
+    }
+
+    // 2. Parse the JSON-RPC body ourselves so we control the error shape.
+    let mut request: Value = match serde_json::from_slice(&body) {
+        Ok(value) => value,
+        Err(err) => {
+            return json_rpc_error(
+                StatusCode::BAD_REQUEST,
+                Value::Null,
+                -32700,
+                format!("parse error: {err}"),
+            );
+        }
+    };
+
+    // 3. Batching was removed in protocol 2025-06-18+; reject arrays.
+    if request.is_array() {
+        return json_rpc_error(
+            StatusCode::BAD_REQUEST,
+            Value::Null,
+            -32600,
+            "batch requests are not supported".to_string(),
+        );
+    }
+
+    let id = request.get("id").cloned().unwrap_or(Value::Null);
+
+    // 3b. Streamable HTTP protocol-version handling. This endpoint implements
+    //     only Streamable HTTP (not the deprecated 2024-11-05 HTTP+SSE
+    //     transport): a non-initialize request with an unsupported
+    //     MCP-Protocol-Version header -> 400; an initialize that asks for a
+    //     non-Streamable-HTTP version is never echoed back (we declare our
+    //     latest instead), so clients can't negotiate a transport we don't serve.
+    if request.get("method").and_then(Value::as_str) == Some("initialize") {
+        let requested = request
+            .pointer("/params/protocolVersion")
+            .and_then(Value::as_str);
+        if requested.is_some_and(|version| !HTTP_PROTOCOL_VERSIONS.contains(&version)) {
+            if let Some(params) = request.get_mut("params").and_then(Value::as_object_mut) {
+                params.insert(
+                    "protocolVersion".to_string(),
+                    Value::from(crate::mcp::LATEST_PROTOCOL_VERSION),
+                );
+            }
+        }
+    } else if let Some(version) = header_str(&headers, "mcp-protocol-version") {
+        if !HTTP_PROTOCOL_VERSIONS.contains(&version) {
+            return json_rpc_error(
+                StatusCode::BAD_REQUEST,
+                id,
+                -32600,
+                format!("unsupported MCP-Protocol-Version: {version}"),
+            );
+        }
+    }
+
+    // 4. Derive a per-request config from operator defaults + header keys, then
+    //    build a request-scoped, fully-credentialed service. Missing required
+    //    key -> 401 (fail-closed); OAuth -> 400. Never falls back to a server key.
+    // Multi-gateway: a client may pick a Grok gateway via X-Grok-Base-Url, but
+    // only from the operator allowlist; otherwise the operator default is used.
+    // This gives remote callers the same "any gateway + matching key" freedom as
+    // the stdio path, without becoming an open proxy.
+    let gateway = match resolve_gateway(&headers, &state.allowed_grok_urls) {
+        Ok(gateway) => gateway,
+        Err(message) => return json_rpc_error(StatusCode::FORBIDDEN, id, -32602, message),
+    };
+    let config = request_config(&state.base_env, &headers, gateway.as_deref());
+    let service =
+        match SearchService::for_request(state.http_client.clone(), state.cache.clone(), config) {
+            Ok(service) => service,
+            Err(err) => {
+                let status = match err {
+                    GrokSearchError::MissingConfig(_) => StatusCode::UNAUTHORIZED,
+                    _ => StatusCode::BAD_REQUEST,
+                };
+                return json_rpc_error(status, id, err.code() as i64, err.to_string());
+            }
+        };
+
+    // 5. Clamp abusable numeric args (DoS) — HTTP path only; stdio is untouched.
+    clamp_request_args(&mut request);
+
+    // 6. SSRF guard: for URL-fetching tools, block non-public / bad-scheme
+    //    targets before any server-side request is made. HTTP path only, so
+    //    local stdio users keep full fetch capability (e.g. localhost).
+    if let Some(url) = fetch_tool_url(&request) {
+        if let Err((status, message)) = validate_public_url(url).await {
+            return json_rpc_error(status, id, -32602, message);
+        }
+    }
+
+    // 7. Dispatch through the shared, transport-agnostic handler. Respond as an
+    //    SSE stream when the client accepts text/event-stream (Streamable HTTP
+    //    streaming mode), else a single application/json body. `None` = a
+    //    notification/response with no reply -> 202 with an empty body.
+    match handle_message(&service, request).await {
+        Some(response) if wants_sse(&headers) => sse_response(&response),
+        Some(response) => (StatusCode::OK, Json(response)).into_response(),
+        None => StatusCode::ACCEPTED.into_response(),
+    }
+}
+
+/// Whether the client accepts an SSE stream (Streamable HTTP streaming mode).
+/// Streamable HTTP clients send `Accept: application/json, text/event-stream`.
+fn wants_sse(headers: &HeaderMap) -> bool {
+    header_str(headers, "accept")
+        .map(|accept| accept.contains("text/event-stream"))
+        .unwrap_or(false)
+}
+
+/// Frame a single JSON-RPC response as a one-event SSE stream that then closes,
+/// per the Streamable HTTP transport: one `message` event carrying the JSON-RPC
+/// response, after which the stream ends (these tools are request/response).
+fn sse_response(response: &Value) -> Response {
+    use axum::http::header::{CACHE_CONTROL, CONTENT_TYPE};
+    let data = serde_json::to_string(response).unwrap_or_else(|_| "{}".to_string());
+    let body = format!("event: message\ndata: {data}\n\n");
+    let mut resp = Response::new(axum::body::Body::from(body));
+    resp.headers_mut().insert(
+        CONTENT_TYPE,
+        axum::http::HeaderValue::from_static("text/event-stream"),
+    );
+    resp.headers_mut()
+        .insert(CACHE_CONTROL, axum::http::HeaderValue::from_static("no-cache"));
+    resp
+}
+
+/// If `request` is a tools/call for a URL-fetching tool (`web_fetch`/`web_map`),
+/// return its `url` argument for SSRF validation.
+fn fetch_tool_url(request: &Value) -> Option<&str> {
+    if request.get("method").and_then(Value::as_str) != Some("tools/call") {
+        return None;
+    }
+    let params = request.get("params")?;
+    match params.get("name").and_then(Value::as_str)? {
+        "web_fetch" | "web_map" => params.get("arguments")?.get("url")?.as_str(),
+        _ => None,
+    }
+}
+
+/// Reject a URL that could drive a server-side request at a non-public target
+/// (SSRF): bad scheme, or a host that is / resolves to a private, loopback,
+/// link-local (incl. cloud metadata), or CGNAT address. Returns
+/// `(status, message)` on rejection.
+async fn validate_public_url(raw: &str) -> Result<(), (StatusCode, String)> {
+    let parsed = url::Url::parse(raw)
+        .map_err(|err| (StatusCode::BAD_REQUEST, format!("invalid url: {err}")))?;
+    match parsed.scheme() {
+        "http" | "https" => {}
+        other => {
+            return Err((
+                StatusCode::BAD_REQUEST,
+                format!("unsupported url scheme: {other}"),
+            ))
+        }
+    }
+    let host = parsed
+        .host_str()
+        .ok_or((StatusCode::BAD_REQUEST, "url has no host".to_string()))?;
+
+    // IP literal (strip IPv6 brackets): check directly, no DNS lookup.
+    let literal = host.trim_start_matches('[').trim_end_matches(']');
+    if let Ok(ip) = literal.parse::<std::net::IpAddr>() {
+        return if crate::providers::http::is_public_ip(&ip) {
+            Ok(())
+        } else {
+            Err((
+                StatusCode::FORBIDDEN,
+                "url targets a non-public address".to_string(),
+            ))
+        };
+    }
+
+    // Hostname: resolve and require every resolved address to be public.
+    let port = parsed.port_or_known_default().unwrap_or(443);
+    let host_owned = host.to_string();
+    let resolved = tokio::task::spawn_blocking(move || {
+        use std::net::ToSocketAddrs;
+        (host_owned.as_str(), port)
+            .to_socket_addrs()
+            .map(|iter| iter.map(|addr| addr.ip()).collect::<Vec<_>>())
+    })
+    .await
+    .map_err(|err| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("resolver task failed: {err}"),
+        )
+    })?
+    .map_err(|err| (StatusCode::BAD_REQUEST, format!("cannot resolve host: {err}")))?;
+
+    if resolved.is_empty() {
+        return Err((StatusCode::BAD_REQUEST, "host did not resolve".to_string()));
+    }
+    for ip in resolved {
+        if !crate::providers::http::is_public_ip(&ip) {
+            return Err((
+                StatusCode::FORBIDDEN,
+                "url resolves to a non-public address".to_string(),
+            ));
+        }
+    }
+    Ok(())
+}
+
+/// Clamp abusable numeric tool arguments to sane upper bounds so a single
+/// public request cannot ask for unbounded work.
+fn clamp_request_args(request: &mut Value) {
+    if request.get("method").and_then(Value::as_str) != Some("tools/call") {
+        return;
+    }
+    let Some(params) = request.get_mut("params") else {
+        return;
+    };
+    let name = params
+        .get("name")
+        .and_then(Value::as_str)
+        .map(str::to_string);
+    let Some(args) = params.get_mut("arguments").and_then(Value::as_object_mut) else {
+        return;
+    };
+    match name.as_deref() {
+        Some("web_search") => {
+            clamp_u64(args, "extra_sources", 50);
+            clamp_u64(args, "recency_days", 3650);
+        }
+        // Enforce the fetch cap even when max_chars is absent or non-integer, so
+        // a public caller can't bypass it by omitting the argument (the operator
+        // default fetch cap is unbounded).
+        Some("web_fetch") => cap_u64(args, "max_chars", 5_000_000),
+        Some("web_map") => clamp_u64(args, "max_results", 100),
+        _ => {}
+    }
+}
+
+fn clamp_u64(args: &mut serde_json::Map<String, Value>, key: &str, max: u64) {
+    if let Some(value) = args.get(key).and_then(Value::as_u64) {
+        if value > max {
+            args.insert(key.to_string(), Value::from(max));
+        }
+    }
+}
+
+/// Like [`clamp_u64`], but also enforces `max` when the argument is absent or
+/// non-integer — so a caller cannot bypass the cap by omitting it.
+fn cap_u64(args: &mut serde_json::Map<String, Value>, key: &str, max: u64) {
+    match args.get(key).and_then(Value::as_u64) {
+        Some(value) if value <= max => {}
+        _ => {
+            args.insert(key.to_string(), Value::from(max));
+        }
+    }
+}
+
+/// Build a per-request [`Config`] from the operator base env (secrets already
+/// stripped) overlaid with the caller's header-supplied keys.
+fn request_config(
+    base_env: &HashMap<String, String>,
+    headers: &HeaderMap,
+    gateway: Option<&str>,
+) -> Config {
+    let mut map = base_env.clone();
+    for (header_name, env_key) in HEADER_TO_ENV {
+        if let Some(value) = header_str(headers, header_name) {
+            let trimmed = value.trim();
+            if !trimmed.is_empty() {
+                map.insert((*env_key).to_string(), trimmed.to_string());
+            }
+        }
+    }
+    if let Some(url) = gateway {
+        map.insert("GROK_SEARCH_URL".to_string(), url.to_string());
+    }
+    Config::from_env_map(map)
+}
+
+/// Resolve the Grok gateway for a request. A client may request one via
+/// `X-Grok-Base-Url`; it is honored only if its normalized form is on the
+/// operator allowlist, otherwise the request is rejected. Absent header ->
+/// `None` (the operator default gateway is used).
+fn resolve_gateway(
+    headers: &HeaderMap,
+    allowed: &HashSet<String>,
+) -> Result<Option<String>, String> {
+    let requested = header_str(headers, "x-grok-base-url")
+        .map(str::trim)
+        .filter(|value| !value.is_empty());
+    let Some(raw) = requested else {
+        return Ok(None);
+    };
+    if allowed.contains(&crate::config::normalize_v1_base(raw)) {
+        Ok(Some(raw.to_string()))
+    } else {
+        Err(format!("grok gateway not allowed: {raw}"))
+    }
+}
+
+/// Build the set of allowed (normalized) Grok gateways: the operator default
+/// plus any comma-separated GROK_SEARCH_ALLOWED_GROK_URLS entries.
+fn parse_allowed_grok_urls(env: &HashMap<String, String>, default_url: &str) -> HashSet<String> {
+    let mut set = HashSet::new();
+    set.insert(default_url.to_string());
+    if let Some(raw) = env.get("GROK_SEARCH_ALLOWED_GROK_URLS") {
+        for entry in raw.split(',').map(str::trim).filter(|value| !value.is_empty()) {
+            set.insert(crate::config::normalize_v1_base(entry));
+        }
+    }
+    set
+}
+
+fn header_str<'a>(headers: &'a HeaderMap, name: &str) -> Option<&'a str> {
+    headers.get(name).and_then(|value| value.to_str().ok())
+}
+
+fn json_rpc_error(status: StatusCode, id: Value, code: i64, message: String) -> Response {
+    (status, Json(error_response(id, code, message))).into_response()
+}
+
+fn strip_secrets(mut env: HashMap<String, String>) -> HashMap<String, String> {
+    for key in SECRET_ENV_KEYS {
+        env.remove(*key);
+    }
+    env
+}
+
+/// Parse `GROK_MCP_ALLOWED_ORIGINS` (comma-separated) into an allowlist.
+/// Unset/empty -> `None` (no browser-origin restriction; keys are per-request).
+fn parse_allowed_origins(env: &HashMap<String, String>) -> Option<HashSet<String>> {
+    let raw = env.get("GROK_MCP_ALLOWED_ORIGINS")?;
+    let set: HashSet<String> = raw
+        .split(',')
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+        .collect();
+    if set.is_empty() {
+        None
+    } else {
+        Some(set)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn base() -> HashMap<String, String> {
+        HashMap::new()
+    }
+
+    fn headers(pairs: &[(&str, &str)]) -> HeaderMap {
+        let mut map = HeaderMap::new();
+        for (name, value) in pairs {
+            map.insert(
+                axum::http::HeaderName::from_bytes(name.as_bytes()).unwrap(),
+                value.parse().unwrap(),
+            );
+        }
+        map
+    }
+
+    #[test]
+    fn request_config_overlays_header_keys() {
+        let cfg = request_config(
+            &base(),
+            &headers(&[
+                ("X-Grok-Api-Key", "xai-caller"),
+                ("X-Tavily-Api-Key", "tvly-caller"),
+            ]),
+            None,
+        );
+        assert_eq!(cfg.grok_api_key.as_deref(), Some("xai-caller"));
+        assert_eq!(cfg.tavily_api_key.as_deref(), Some("tvly-caller"));
+    }
+
+    #[test]
+    fn request_config_applies_gateway_override() {
+        let cfg = request_config(
+            &base(),
+            &headers(&[("X-Grok-Api-Key", "xai-caller")]),
+            Some("https://api.x.ai"),
+        );
+        assert_eq!(cfg.grok_api_url, "https://api.x.ai/v1");
+    }
+
+    #[test]
+    fn resolve_gateway_enforces_allowlist() {
+        let mut allowed = HashSet::new();
+        allowed.insert("https://api.x.ai/v1".to_string());
+        allowed.insert("https://api.modelverse.cn/v1".to_string());
+        // No header -> operator default (None).
+        assert_eq!(resolve_gateway(&headers(&[]), &allowed).unwrap(), None);
+        // Allowlisted gateway (normalization-insensitive) -> honored verbatim.
+        let got = resolve_gateway(
+            &headers(&[("X-Grok-Base-Url", "https://api.modelverse.cn")]),
+            &allowed,
+        )
+        .unwrap();
+        assert_eq!(got.as_deref(), Some("https://api.modelverse.cn"));
+        // Not allowlisted -> rejected.
+        assert!(resolve_gateway(
+            &headers(&[("X-Grok-Base-Url", "https://evil.example")]),
+            &allowed
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn request_config_never_inherits_server_secret() {
+        // Even if the operator base env carries a key, it is stripped so it can
+        // never leak into a tenant request.
+        let mut server_env = HashMap::new();
+        server_env.insert("GROK_SEARCH_API_KEY".to_string(), "xai-SERVER".to_string());
+        let sanitized = strip_secrets(server_env);
+        let cfg = request_config(&sanitized, &headers(&[]), None);
+        assert_eq!(
+            cfg.grok_api_key, None,
+            "server key must not survive into a keyless request"
+        );
+    }
+
+    #[test]
+    fn strip_secrets_removes_every_secret_key() {
+        let mut env = HashMap::new();
+        for key in SECRET_ENV_KEYS {
+            env.insert((*key).to_string(), "secret".to_string());
+        }
+        env.insert("GROK_SEARCH_TIMEOUT_SECONDS".to_string(), "30".to_string());
+        let stripped = strip_secrets(env);
+        for key in SECRET_ENV_KEYS {
+            assert!(!stripped.contains_key(*key), "{key} not stripped");
+        }
+        // Non-secret operator knobs survive.
+        assert_eq!(
+            stripped.get("GROK_SEARCH_TIMEOUT_SECONDS").map(String::as_str),
+            Some("30")
+        );
+    }
+
+    #[test]
+    fn parse_allowed_origins_handles_unset_and_list() {
+        assert!(parse_allowed_origins(&base()).is_none());
+        let mut env = HashMap::new();
+        env.insert(
+            "GROK_MCP_ALLOWED_ORIGINS".to_string(),
+            "https://a.example, https://b.example".to_string(),
+        );
+        let set = parse_allowed_origins(&env).expect("allowlist");
+        assert!(set.contains("https://a.example"));
+        assert!(set.contains("https://b.example"));
+    }
+
+    #[tokio::test]
+    async fn validate_public_url_blocks_ssrf_targets() {
+        for bad in [
+            "http://169.254.169.254/latest/meta-data/", // cloud metadata
+            "http://127.0.0.1/",                         // loopback
+            "http://10.0.0.5/",                          // private
+            "http://192.168.1.1/",                       // private
+            "http://100.64.0.1/",                        // CGNAT
+            "https://[::1]/",                            // IPv6 loopback
+            "file:///etc/passwd",                        // bad scheme
+            "gopher://example.com/",                     // bad scheme
+        ] {
+            assert!(
+                validate_public_url(bad).await.is_err(),
+                "expected {bad} to be rejected"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn validate_public_url_allows_public_ip_literal() {
+        // Public IP literals pass with no DNS lookup.
+        assert!(validate_public_url("https://1.1.1.1/").await.is_ok());
+        assert!(validate_public_url("http://8.8.8.8/").await.is_ok());
+    }
+
+    #[test]
+    fn clamp_request_args_caps_numeric_inputs() {
+        let mut request = serde_json::json!({
+            "jsonrpc": "2.0", "id": 1, "method": "tools/call",
+            "params": {
+                "name": "web_search",
+                "arguments": { "query": "q", "extra_sources": 9999, "recency_days": 999999 }
+            }
+        });
+        clamp_request_args(&mut request);
+        assert_eq!(request["params"]["arguments"]["extra_sources"], 50);
+        assert_eq!(request["params"]["arguments"]["recency_days"], 3650);
+    }
+
+    #[test]
+    fn clamp_request_args_enforces_web_fetch_cap() {
+        // Absent max_chars -> cap injected (cannot bypass by omitting it).
+        let mut absent = serde_json::json!({
+            "method": "tools/call",
+            "params": { "name": "web_fetch", "arguments": { "url": "https://example.com" } }
+        });
+        clamp_request_args(&mut absent);
+        assert_eq!(absent["params"]["arguments"]["max_chars"], 5_000_000);
+        // Oversized -> clamped down.
+        let mut big = serde_json::json!({
+            "method": "tools/call",
+            "params": { "name": "web_fetch", "arguments": { "url": "x", "max_chars": 999_999_999_u64 } }
+        });
+        clamp_request_args(&mut big);
+        assert_eq!(big["params"]["arguments"]["max_chars"], 5_000_000);
+        // Smaller value -> kept.
+        let mut small = serde_json::json!({
+            "method": "tools/call",
+            "params": { "name": "web_fetch", "arguments": { "url": "x", "max_chars": 1000 } }
+        });
+        clamp_request_args(&mut small);
+        assert_eq!(small["params"]["arguments"]["max_chars"], 1000);
+    }
+
+    #[test]
+    fn fetch_tool_url_targets_fetch_tools_only() {
+        let fetch = serde_json::json!({
+            "method": "tools/call",
+            "params": { "name": "web_fetch", "arguments": { "url": "https://example.com" } }
+        });
+        assert_eq!(fetch_tool_url(&fetch), Some("https://example.com"));
+        let search = serde_json::json!({
+            "method": "tools/call",
+            "params": { "name": "web_search", "arguments": { "query": "x" } }
+        });
+        assert_eq!(fetch_tool_url(&search), None);
+    }
+
+    #[test]
+    fn wants_sse_reads_accept_header() {
+        assert!(wants_sse(&headers(&[(
+            "Accept",
+            "application/json, text/event-stream"
+        )])));
+        assert!(!wants_sse(&headers(&[("Accept", "application/json")])));
+        assert!(!wants_sse(&headers(&[])));
+    }
+
+    #[tokio::test]
+    async fn sse_response_frames_a_single_message_event() {
+        let resp = sse_response(&serde_json::json!({"jsonrpc":"2.0","id":1,"result":{}}));
+        assert_eq!(
+            resp.headers()
+                .get(axum::http::header::CONTENT_TYPE)
+                .unwrap(),
+            "text/event-stream"
+        );
+        let bytes = axum::body::to_bytes(resp.into_body(), 64 * 1024)
+            .await
+            .unwrap();
+        let text = String::from_utf8(bytes.to_vec()).unwrap();
+        assert!(text.starts_with("event: message\ndata: "));
+        assert!(text.ends_with("\n\n"));
+        assert!(text.contains("\"jsonrpc\":\"2.0\""));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,8 @@ pub mod cache;
 pub mod config;
 pub mod credentials;
 pub mod error;
+#[cfg(feature = "http")]
+pub mod http;
 pub mod logging;
 pub mod mcp;
 pub mod model;

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,8 +2,29 @@ use std::io::{IsTerminal, Write};
 
 use grok_search_rs::config::{self, AuthMode, Config, InitOutcome};
 
-#[tokio::main(flavor = "current_thread")]
-async fn main() -> anyhow::Result<()> {
+fn main() -> anyhow::Result<()> {
+    build_runtime()?.block_on(async_main())
+}
+
+/// Multi-threaded runtime for the concurrent HTTP server build.
+#[cfg(feature = "http")]
+fn build_runtime() -> std::io::Result<tokio::runtime::Runtime> {
+    tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(2)
+        .enable_all()
+        .build()
+}
+
+/// Single-threaded runtime for the default stdio build — mirrors the previous
+/// `#[tokio::main(flavor = "current_thread")]` so the stdio path is unchanged.
+#[cfg(not(feature = "http"))]
+fn build_runtime() -> std::io::Result<tokio::runtime::Runtime> {
+    tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+}
+
+async fn async_main() -> anyhow::Result<()> {
     // CLI shim: handle --version, --init before MCP server mode.
     let args: Vec<String> = std::env::args().skip(1).collect();
 
@@ -32,6 +53,25 @@ async fn main() -> anyhow::Result<()> {
     if args.first().map(String::as_str) == Some("logout") {
         let cfg = Config::load();
         return run_logout(&cfg);
+    }
+
+    // Native Streamable HTTP transport (feature `http`): opt in with `--http` /
+    // `serve`, or GROK_MCP_BIND=host:port. Credentials come only from
+    // per-request headers, so this path intentionally ignores server-side keys.
+    // stdio stays the default when neither is set — local users are unaffected.
+    #[cfg(feature = "http")]
+    {
+        let wants_http = args.iter().any(|a| a == "--http" || a == "serve");
+        let bind_env = std::env::var("GROK_MCP_BIND").ok();
+        if wants_http || bind_env.is_some() {
+            let addr = bind_env.unwrap_or_else(|| "127.0.0.1:8080".to_string());
+            let bind: std::net::SocketAddr = addr
+                .parse()
+                .map_err(|err| anyhow::anyhow!("invalid GROK_MCP_BIND '{addr}': {err}"))?;
+            let base_env: std::collections::HashMap<String, String> =
+                std::env::vars().collect();
+            return grok_search_rs::http::run_http(base_env, bind).await;
+        }
     }
 
     let cfg = Config::load();

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -32,7 +32,31 @@ pub async fn run_stdio(service: SearchService) -> anyhow::Result<()> {
     Ok(())
 }
 
-async fn handle_message(service: &SearchService, request: Value) -> Option<Value> {
+/// Protocol revisions this server speaks, newest first. `initialize` echoes the
+/// client's requested version when it is one of these — so existing stdio
+/// clients that still request "2024-11-05" keep getting "2024-11-05" — and
+/// otherwise declares [`LATEST_PROTOCOL_VERSION`].
+pub(crate) const SUPPORTED_PROTOCOL_VERSIONS: &[&str] =
+    &["2025-11-25", "2025-06-18", "2025-03-26", "2024-11-05"];
+
+/// Latest revision we support; declared when the client requests nothing or an
+/// unsupported version.
+pub(crate) const LATEST_PROTOCOL_VERSION: &str = "2025-11-25";
+
+/// Pick the protocol revision to declare in the `initialize` result: the
+/// client's requested revision when supported, else our latest.
+pub(crate) fn negotiate_protocol_version(requested: Option<&str>) -> &'static str {
+    match requested {
+        Some(req) => SUPPORTED_PROTOCOL_VERSIONS
+            .iter()
+            .find(|version| **version == req)
+            .copied()
+            .unwrap_or(LATEST_PROTOCOL_VERSION),
+        None => LATEST_PROTOCOL_VERSION,
+    }
+}
+
+pub(crate) async fn handle_message(service: &SearchService, request: Value) -> Option<Value> {
     request.get("id")?;
     let id = request.get("id").cloned().unwrap_or(Value::Null);
     Some(
@@ -53,19 +77,28 @@ async fn handle_request(service: &SearchService, request: Value) -> Result<Value
         .ok_or_else(|| GrokSearchError::InvalidParams("missing method".to_string()))?;
 
     match method {
-        "initialize" => Ok(success_response(
-            id,
-            json!({
-                "protocolVersion": "2024-11-05",
-                "serverInfo": {
-                    "name": "grok-search-rs",
-                    "version": env!("CARGO_PKG_VERSION")
-                },
-                "capabilities": {
-                    "tools": {}
-                }
-            }),
-        )),
+        "initialize" => {
+            // Negotiate: echo the client's requested revision when we speak it
+            // (keeps existing stdio clients that still ask for "2024-11-05"
+            // working), otherwise declare our latest supported revision.
+            let requested = request
+                .get("params")
+                .and_then(|params| params.get("protocolVersion"))
+                .and_then(Value::as_str);
+            Ok(success_response(
+                id,
+                json!({
+                    "protocolVersion": negotiate_protocol_version(requested),
+                    "serverInfo": {
+                        "name": "grok-search-rs",
+                        "version": env!("CARGO_PKG_VERSION")
+                    },
+                    "capabilities": {
+                        "tools": {}
+                    }
+                }),
+            ))
+        }
         "ping" => Ok(success_response(id, json!({}))),
         "tools/list" => Ok(success_response(id, tools_list())),
         "tools/call" => {
@@ -320,7 +353,7 @@ fn success_response(id: Value, result: Value) -> Value {
     })
 }
 
-fn error_response(id: Value, code: i64, message: String) -> Value {
+pub(crate) fn error_response(id: Value, code: i64, message: String) -> Value {
     json!({
         "jsonrpc": "2.0",
         "id": id,
@@ -349,6 +382,59 @@ mod tests {
         .await;
 
         assert_eq!(response, None);
+    }
+
+    #[test]
+    fn negotiate_protocol_version_prefers_supported_client_version() {
+        // Backward compatibility: an old client asking for 2024-11-05 is echoed.
+        assert_eq!(negotiate_protocol_version(Some("2024-11-05")), "2024-11-05");
+        assert_eq!(negotiate_protocol_version(Some("2025-06-18")), "2025-06-18");
+        assert_eq!(negotiate_protocol_version(Some("2025-11-25")), "2025-11-25");
+        // Unknown / absent -> our latest.
+        assert_eq!(
+            negotiate_protocol_version(Some("1999-01-01")),
+            LATEST_PROTOCOL_VERSION
+        );
+        assert_eq!(negotiate_protocol_version(None), LATEST_PROTOCOL_VERSION);
+    }
+
+    #[tokio::test]
+    async fn initialize_echoes_legacy_client_version() {
+        let service = SearchService::fake_with_sources();
+        let response = handle_request(
+            &service,
+            json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "initialize",
+                "params": { "protocolVersion": "2024-11-05", "capabilities": {} }
+            }),
+        )
+        .await
+        .expect("initialize response");
+        // An existing stdio client must still see its own requested revision.
+        assert_eq!(response["result"]["protocolVersion"], "2024-11-05");
+        assert_eq!(response["result"]["serverInfo"]["name"], "grok-search-rs");
+    }
+
+    #[tokio::test]
+    async fn initialize_declares_latest_for_unknown_version() {
+        let service = SearchService::fake_with_sources();
+        let response = handle_request(
+            &service,
+            json!({
+                "jsonrpc": "2.0",
+                "id": 2,
+                "method": "initialize",
+                "params": { "protocolVersion": "3000-01-01", "capabilities": {} }
+            }),
+        )
+        .await
+        .expect("initialize response");
+        assert_eq!(
+            response["result"]["protocolVersion"],
+            LATEST_PROTOCOL_VERSION
+        );
     }
 
     #[tokio::test]

--- a/src/providers/http.rs
+++ b/src/providers/http.rs
@@ -20,6 +20,85 @@ pub fn build_client(timeout: Duration) -> Client {
         .unwrap_or_else(|_| Client::new())
 }
 
+/// True if `ip` is a globally-routable public address. Rejects loopback,
+/// private, link-local (incl. cloud metadata 169.254.169.254), CGNAT,
+/// unspecified, multicast, broadcast, and documentation ranges — for both IPv4
+/// and IPv6 (including IPv4-mapped IPv6). Used by the public HTTP transport's
+/// SSRF guard; gated to that build so it is never dead code in the stdio build.
+#[cfg(feature = "http")]
+pub(crate) fn is_public_ip(ip: &std::net::IpAddr) -> bool {
+    use std::net::IpAddr;
+    match ip {
+        IpAddr::V4(v4) => {
+            let o = v4.octets();
+            !(v4.is_loopback()
+                || v4.is_private()
+                || v4.is_link_local()
+                || v4.is_unspecified()
+                || v4.is_broadcast()
+                || v4.is_multicast()
+                || v4.is_documentation()
+                // CGNAT 100.64.0.0/10
+                || (o[0] == 100 && (o[1] & 0xc0) == 64))
+        }
+        IpAddr::V6(v6) => {
+            if let Some(v4) = v6.to_ipv4_mapped() {
+                return is_public_ip(&IpAddr::V4(v4));
+            }
+            let seg0 = v6.segments()[0];
+            !(v6.is_loopback()
+                || v6.is_unspecified()
+                || v6.is_multicast()
+                // unique local fc00::/7
+                || (seg0 & 0xfe00) == 0xfc00
+                // link-local fe80::/10
+                || (seg0 & 0xffc0) == 0xfe80)
+        }
+    }
+}
+
+/// Like [`build_client`] but rejects redirects to private/loopback IP-literal
+/// targets (defense-in-depth against redirect-based SSRF) and caps redirect
+/// depth. Used only by the public HTTP transport.
+#[cfg(feature = "http")]
+pub fn build_restricted_client(timeout: Duration) -> Client {
+    use reqwest::redirect::Policy;
+    Client::builder()
+        .timeout(timeout)
+        .gzip(true)
+        .pool_idle_timeout(Some(Duration::from_secs(90)))
+        .tcp_keepalive(Some(Duration::from_secs(60)))
+        .tcp_nodelay(true)
+        .redirect(Policy::custom(|attempt| {
+            use std::net::ToSocketAddrs;
+            if attempt.previous().len() > 5 {
+                return attempt.error("too many redirects");
+            }
+            let Some(host) = attempt.url().host_str() else {
+                return attempt.follow();
+            };
+            // Reject redirects that target — or resolve to — a non-public
+            // address. Covers IP literals AND hostnames, closing redirect-based
+            // SSRF / DNS-rebinding (a public URL that 30x's to an internal name).
+            let ips: Vec<std::net::IpAddr> = match host.parse::<std::net::IpAddr>() {
+                Ok(ip) => vec![ip],
+                Err(_) => {
+                    let port = attempt.url().port_or_known_default().unwrap_or(443);
+                    match (host, port).to_socket_addrs() {
+                        Ok(addrs) => addrs.map(|addr| addr.ip()).collect(),
+                        Err(_) => return attempt.error("redirect host did not resolve"),
+                    }
+                }
+            };
+            if ips.iter().any(|ip| !is_public_ip(ip)) {
+                return attempt.error("redirect to a non-public address is blocked");
+            }
+            attempt.follow()
+        }))
+        .build()
+        .unwrap_or_else(|_| Client::new())
+}
+
 /// Failure from [`post_json_with_status`]. `status` is the upstream HTTP
 /// status when the request reached the server and came back non-2xx; `None`
 /// for transport, timeout, body-read, and parse failures. Lets callers make

--- a/src/providers/tavily.rs
+++ b/src/providers/tavily.rs
@@ -34,9 +34,15 @@ impl KeyRing {
         if keys.is_empty() {
             keys.push(raw.to_string());
         }
+        // Start at a random offset. On the HTTP transport the provider (and this
+        // ring) is rebuilt per request, so a fixed start of 0 would make every
+        // request begin on the first key and concentrate load there. A random
+        // start spreads load across keys statelessly; stdio keeps its persistent
+        // round-robin (the random start is just a one-time offset).
+        let start = random_offset(keys.len());
         Self {
             keys,
-            cursor: AtomicUsize::new(0),
+            cursor: AtomicUsize::new(start),
         }
     }
 
@@ -52,6 +58,19 @@ impl KeyRing {
 
     fn key(&self, index: usize) -> &str {
         &self.keys[index % self.keys.len()]
+    }
+}
+
+/// A best-effort random starting offset in `0..len` (falls back to 0 if the RNG
+/// is unavailable). Only meaningful for multi-key rings.
+fn random_offset(len: usize) -> usize {
+    if len <= 1 {
+        return 0;
+    }
+    let mut buf = [0u8; 8];
+    match getrandom::fill(&mut buf) {
+        Ok(()) => (u64::from_ne_bytes(buf) % len as u64) as usize,
+        Err(_) => 0,
     }
 }
 
@@ -280,10 +299,20 @@ mod key_ring_tests {
 
     #[test]
     fn start_rotates_round_robin_across_requests() {
+        // The starting key is randomized per ring, but consecutive starts still
+        // advance by one and wrap — round-robin is preserved.
         let ring = KeyRing::parse("a,b,c");
+        let first = ring.start();
+        assert_eq!(ring.start(), (first + 1) % 3);
+        assert_eq!(ring.start(), (first + 2) % 3);
+        assert_eq!(ring.start(), (first + 3) % 3);
+    }
+
+    #[test]
+    fn single_key_ring_always_starts_at_zero() {
+        // A single-key ring has a deterministic (0) start — no randomization.
+        let ring = KeyRing::parse("solo");
         assert_eq!(ring.start(), 0);
-        assert_eq!(ring.start(), 1);
-        assert_eq!(ring.start(), 2);
         assert_eq!(ring.start(), 0);
     }
 
@@ -299,9 +328,11 @@ mod key_ring_tests {
         let provider =
             TavilyProvider::with_client(Client::new(), "https://api.tavily.com", "tvly-a,tvly-b");
         let clone = provider.clone();
-        assert_eq!(provider.keys.start(), 0);
-        assert_eq!(clone.keys.start(), 1);
-        assert_eq!(provider.keys.start(), 0);
+        // The cursor is shared (Arc): the clone continues the sequence rather
+        // than restarting, regardless of the randomized starting offset.
+        let a = provider.keys.start();
+        assert_eq!(clone.keys.start(), (a + 1) % 2);
+        assert_eq!(provider.keys.start(), (a + 2) % 2);
     }
 
     #[test]

--- a/src/service.rs
+++ b/src/service.rs
@@ -111,108 +111,217 @@ pub struct SearchService {
     source_router: Arc<crate::sources::SourceRouter>,
 }
 
+/// The credential-derived half of a [`SearchService`]: everything that must be
+/// rebuilt when the caller's keys change. [`build_providers`] constructs these
+/// from a [`Config`]; [`SearchService::new`] uses it with a process-wide config
+/// (the stdio path), and [`SearchService::with_config`] uses it per request
+/// while sharing the long-lived HTTP client and source cache.
+struct ProviderSet {
+    ai: Arc<dyn AiProvider>,
+    default_model: String,
+    sources: Option<Arc<dyn SourceProvider>>,
+    fallback_sources: Option<Arc<dyn SourceProvider>>,
+    source_router: Arc<crate::sources::SourceRouter>,
+}
+
+/// Build the credential-bearing providers for a given `config`, reusing the
+/// caller-supplied shared `http` client. Extracted verbatim from the original
+/// `SearchService::new` body so both the process-wide (stdio) and per-request
+/// (HTTP) construction paths share one implementation.
+fn build_providers(config: &Config, http: &reqwest::Client) -> Result<ProviderSet> {
+    use crate::config::Transport;
+
+    let ai: Arc<dyn AiProvider> = match config.transport {
+        Transport::Responses => {
+            let credential: Arc<dyn crate::credentials::CredentialProvider> =
+                match config.grok_auth_mode {
+                    AuthMode::ApiKey => Arc::new(StaticApiKeyCredential::new(
+                        config
+                            .grok_api_key
+                            .clone()
+                            .ok_or(GrokSearchError::MissingConfig("GROK_SEARCH_API_KEY"))?,
+                    )),
+                    AuthMode::OAuth => {
+                        let auth_path = config
+                            .grok_auth_file
+                            .clone()
+                            .or_else(crate::config::auth_path)
+                            .ok_or_else(|| {
+                                GrokSearchError::OAuth(
+                                    "oauth_auth_path_unavailable: set GROK_SEARCH_AUTH_FILE"
+                                        .to_string(),
+                                )
+                            })?;
+                        Arc::new(OAuthCredential::new(http.clone(), auth_path))
+                    }
+                };
+            Arc::new(GrokResponsesProvider::with_credential_client(
+                http.clone(),
+                config.grok_api_url.clone(),
+                credential,
+                config.web_search_enabled,
+                config.x_search_enabled,
+            ))
+        }
+        Transport::ChatCompletions => {
+            let url = config
+                .openai_compatible_api_url
+                .clone()
+                .ok_or(GrokSearchError::MissingConfig("OPENAI_COMPATIBLE_API_URL"))?;
+            let key = config
+                .openai_compatible_api_key
+                .clone()
+                .ok_or(GrokSearchError::MissingConfig("OPENAI_COMPATIBLE_API_KEY"))?;
+            let model = config
+                .openai_compatible_model
+                .clone()
+                .unwrap_or_else(|| config.grok_model.clone());
+            if config.x_search_enabled {
+                eprintln!(
+                    "grok-search-rs: x_search_enabled is ignored when using OPENAI_COMPATIBLE_* transport"
+                );
+            }
+            Arc::new(
+                crate::providers::openai_compatible::OpenAICompatProvider::with_client(
+                    http.clone(),
+                    url,
+                    key,
+                    model,
+                    config.web_search_enabled,
+                ),
+            )
+        }
+    };
+
+    let sources = if config.tavily_enabled {
+        config.tavily_api_key.clone().map(|key| {
+            Arc::new(TavilyProvider::with_client(
+                http.clone(),
+                config.tavily_api_url.clone(),
+                key,
+            )) as Arc<dyn SourceProvider>
+        })
+    } else {
+        None
+    };
+
+    let fallback_sources = if config.firecrawl_enabled {
+        config.firecrawl_api_key.clone().map(|key| {
+            Arc::new(FirecrawlProvider::with_client(
+                http.clone(),
+                config.firecrawl_api_url.clone(),
+                key,
+            )) as Arc<dyn SourceProvider>
+        })
+    } else {
+        None
+    };
+
+    let source_router = Arc::new(crate::sources::SourceRouter::from_config(config));
+
+    Ok(ProviderSet {
+        ai,
+        default_model: resolve_default_model(config),
+        sources,
+        fallback_sources,
+        source_router,
+    })
+}
+
+/// Non-reversible per-tenant namespace tag derived from the caller's primary
+/// key. Cache entries are stored under `tag:session_id` so one tenant can never
+/// read another tenant's cached `get_sources` pages on the shared HTTP process.
+/// For stdio (a single process key) the tag is constant, so behavior is
+/// unchanged. Uses a SHA-256 prefix — never any fragment of the raw key.
+fn tenant_tag(config: &Config) -> String {
+    let material = config
+        .grok_api_key
+        .as_deref()
+        .or(config.openai_compatible_api_key.as_deref())
+        .unwrap_or("");
+    if material.is_empty() {
+        return "anon".to_string();
+    }
+    let digest = ring::digest::digest(&ring::digest::SHA256, material.as_bytes());
+    digest.as_ref()[..8]
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect()
+}
+
 impl SearchService {
     pub fn new(config: Config) -> Result<Self> {
-        use crate::config::Transport;
         let http = crate::providers::http::build_client(config.timeout);
+        let providers = build_providers(&config, &http)?;
+        let cache = Arc::new(Mutex::new(SourceCache::new(config.cache_size)));
+        Ok(Self::from_parts(config, http, cache, providers))
+    }
 
-        let ai: Arc<dyn AiProvider> = match config.transport {
-            Transport::Responses => {
-                let credential: Arc<dyn crate::credentials::CredentialProvider> =
-                    match config.grok_auth_mode {
-                        AuthMode::ApiKey => Arc::new(StaticApiKeyCredential::new(
-                            config
-                                .grok_api_key
-                                .clone()
-                                .ok_or(GrokSearchError::MissingConfig("GROK_SEARCH_API_KEY"))?,
-                        )),
-                        AuthMode::OAuth => {
-                            let auth_path = config
-                                .grok_auth_file
-                                .clone()
-                                .or_else(crate::config::auth_path)
-                                .ok_or_else(|| {
-                                    GrokSearchError::OAuth(
-                                        "oauth_auth_path_unavailable: set GROK_SEARCH_AUTH_FILE"
-                                            .to_string(),
-                                    )
-                                })?;
-                            Arc::new(OAuthCredential::new(http.clone(), auth_path))
-                        }
-                    };
-                Arc::new(GrokResponsesProvider::with_credential_client(
-                    http.clone(),
-                    config.grok_api_url.clone(),
-                    credential,
-                    config.web_search_enabled,
-                    config.x_search_enabled,
-                ))
-            }
-            Transport::ChatCompletions => {
-                let url = config
-                    .openai_compatible_api_url
-                    .clone()
-                    .ok_or(GrokSearchError::MissingConfig("OPENAI_COMPATIBLE_API_URL"))?;
-                let key = config
-                    .openai_compatible_api_key
-                    .clone()
-                    .ok_or(GrokSearchError::MissingConfig("OPENAI_COMPATIBLE_API_KEY"))?;
-                let model = config
-                    .openai_compatible_model
-                    .clone()
-                    .unwrap_or_else(|| config.grok_model.clone());
-                if config.x_search_enabled {
-                    eprintln!(
-                        "grok-search-rs: x_search_enabled is ignored when using OPENAI_COMPATIBLE_* transport"
-                    );
-                }
-                Arc::new(
-                    crate::providers::openai_compatible::OpenAICompatProvider::with_client(
-                        http.clone(),
-                        url,
-                        key,
-                        model,
-                        config.web_search_enabled,
-                    ),
-                )
-            }
-        };
+    /// Build a request-scoped service that reuses this service's shared HTTP
+    /// client and source cache, but derives every credential-bearing provider
+    /// from `config`. The HTTP transport calls this per request so each caller
+    /// searches with their own keys while the process keeps a single source
+    /// cache — so `get_sources` continuation still works across requests.
+    ///
+    /// OAuth is rejected here: it resolves a single on-disk identity and is
+    /// incompatible with per-request, multi-tenant credentials. HTTP callers
+    /// must pass an API key. The local stdio path keeps OAuth via [`new`].
+    ///
+    /// [`new`]: SearchService::new
+    pub fn with_config(&self, config: Config) -> Result<Self> {
+        Self::for_request(self.http_client.clone(), self.cache.clone(), config)
+    }
 
-        let sources = if config.tavily_enabled {
-            config.tavily_api_key.clone().map(|key| {
-                Arc::new(TavilyProvider::with_client(
-                    http.clone(),
-                    config.tavily_api_url.clone(),
-                    key,
-                )) as Arc<dyn SourceProvider>
-            })
-        } else {
-            None
-        };
+    /// Build a request-scoped service from shared state — a reused HTTP client
+    /// and the process-wide source cache — plus a per-request `config`. This is
+    /// the entrypoint the HTTP transport uses: the server process holds no
+    /// credentials of its own, so it keeps only the shared client + cache and
+    /// constructs a fully-credentialed service per request from the caller's
+    /// header keys. OAuth is rejected here (single on-disk identity is
+    /// incompatible with per-request multi-tenancy); a missing required key
+    /// fails at construction (fail-closed) rather than reusing any server key.
+    pub fn for_request(
+        http_client: reqwest::Client,
+        cache: Arc<Mutex<SourceCache>>,
+        config: Config,
+    ) -> Result<Self> {
+        if config.grok_auth_mode == AuthMode::OAuth {
+            return Err(GrokSearchError::OAuth(
+                "oauth is not supported on the HTTP transport; pass a per-request API key"
+                    .to_string(),
+            ));
+        }
+        let providers = build_providers(&config, &http_client)?;
+        Ok(Self::from_parts(config, http_client, cache, providers))
+    }
 
-        let fallback_sources = if config.firecrawl_enabled {
-            config.firecrawl_api_key.clone().map(|key| {
-                Arc::new(FirecrawlProvider::with_client(
-                    http.clone(),
-                    config.firecrawl_api_url.clone(),
-                    key,
-                )) as Arc<dyn SourceProvider>
-            })
-        } else {
-            None
-        };
-
-        let source_router = Arc::new(crate::sources::SourceRouter::from_config(&config));
-        Ok(Self {
-            cache: Arc::new(Mutex::new(SourceCache::new(config.cache_size))),
-            default_model: resolve_default_model(&config),
+    /// Assemble a `SearchService` from an already-built provider set plus the
+    /// shared `http` client and `cache`. Single assembly point for both `new`
+    /// (fresh client + cache) and `with_config` (shared client + cache).
+    fn from_parts(
+        config: Config,
+        http: reqwest::Client,
+        cache: Arc<Mutex<SourceCache>>,
+        providers: ProviderSet,
+    ) -> Self {
+        Self {
+            cache,
+            default_model: providers.default_model,
             config,
-            ai,
-            sources,
-            fallback_sources,
-            http_client: http.clone(),
-            source_router,
-        })
+            ai: providers.ai,
+            sources: providers.sources,
+            fallback_sources: providers.fallback_sources,
+            http_client: http,
+            source_router: providers.source_router,
+        }
+    }
+
+    /// Namespace a session id with the caller's tenant tag so cached
+    /// `get_sources` pages are isolated per tenant. The plain `session_id`
+    /// returned to the caller is unchanged; only the internal cache key is
+    /// prefixed.
+    fn tenant_cache_key(&self, session_id: &str) -> String {
+        format!("{}:{}", tenant_tag(&self.config), session_id)
     }
 
     pub fn fake_with_sources() -> Self {
@@ -419,10 +528,8 @@ impl SearchService {
 
         let merged_arc = Arc::new(merged);
         let sources_count = merged_arc.len();
-        self.cache
-            .lock()
-            .await
-            .set(session_id.clone(), merged_arc.clone());
+        let cache_key = self.tenant_cache_key(&session_id);
+        self.cache.lock().await.set(cache_key, merged_arc.clone());
 
         // The cache keeps the full enriched content; only the returned copy is
         // trimmed to the response budget so drill-down loses nothing.
@@ -521,10 +628,8 @@ impl SearchService {
 
         let fallback_arc = Arc::new(fallback);
         let sources_count = fallback_arc.len();
-        self.cache
-            .lock()
-            .await
-            .set(session_id.clone(), fallback_arc.clone());
+        let cache_key = self.tenant_cache_key(&session_id);
+        self.cache.lock().await.set(cache_key, fallback_arc.clone());
 
         let content = if response.content.trim().is_empty() {
             format!(
@@ -571,7 +676,7 @@ impl SearchService {
             .cache
             .lock()
             .await
-            .get(session_id)
+            .get(&self.tenant_cache_key(session_id))
             .ok_or_else(|| GrokSearchError::NotFound(format!("session_id={session_id}")))?;
         let total_sources = cached.len();
         let start = offset.min(total_sources);
@@ -1849,5 +1954,90 @@ mod enrich_tests {
                 "get_sources must reuse the cached enriched content"
             );
         }
+    }
+}
+
+#[cfg(test)]
+mod request_scope_tests {
+    use super::*;
+
+    /// A long-lived template service, as the HTTP transport would hold one.
+    fn template() -> SearchService {
+        SearchService::new(Config::from_env_map([(
+            "GROK_SEARCH_API_KEY",
+            "xai-template",
+        )]))
+        .expect("template service builds")
+    }
+
+    #[test]
+    fn with_config_rejects_oauth() {
+        let svc = template();
+        let cfg = Config::from_env_map([("GROK_SEARCH_AUTH_MODE", "oauth")]);
+        assert!(
+            svc.with_config(cfg).is_err(),
+            "OAuth must be rejected on the per-request (HTTP) path"
+        );
+    }
+
+    #[test]
+    fn with_config_fails_closed_without_grok_key() {
+        let svc = template();
+        // No grok key and no OpenAI-compatible gateway -> Responses transport ->
+        // construction fails rather than silently reusing the template's key.
+        let cfg = Config::from_env_map(Vec::<(String, String)>::new());
+        assert!(
+            svc.with_config(cfg).is_err(),
+            "missing required key must fail closed, never fall back to the server key"
+        );
+    }
+
+    #[test]
+    fn with_config_accepts_per_request_key() {
+        let svc = template();
+        let cfg = Config::from_env_map([
+            ("GROK_SEARCH_API_KEY", "xai-caller"),
+            ("TAVILY_API_KEY", "tvly-caller"),
+        ]);
+        assert!(
+            svc.with_config(cfg).is_ok(),
+            "a caller-supplied key must build a request-scoped service"
+        );
+    }
+
+    #[tokio::test]
+    async fn cache_shared_within_tenant_isolated_across_tenants() {
+        let svc = template(); // key "xai-template"
+        let session = "abcdef012345";
+
+        // Same-key request-scoped service shares cached sessions, so
+        // get_sources continuation survives across requests.
+        let same = svc
+            .with_config(Config::from_env_map([(
+                "GROK_SEARCH_API_KEY",
+                "xai-template",
+            )]))
+            .expect("same-tenant scoped service");
+        // Seed under the tenant-namespaced key, as web_search would.
+        same.cache
+            .lock()
+            .await
+            .set(same.tenant_cache_key(session), Arc::new(Vec::<Source>::new()));
+        assert!(
+            same.get_sources(session, 0, None).await.is_ok(),
+            "same tenant must read its own cached session"
+        );
+
+        // A different caller key must NOT read that session.
+        let other = svc
+            .with_config(Config::from_env_map([(
+                "GROK_SEARCH_API_KEY",
+                "xai-other",
+            )]))
+            .expect("other-tenant scoped service");
+        assert!(
+            other.get_sources(session, 0, None).await.is_err(),
+            "a different tenant must not read another tenant's cached session"
+        );
     }
 }

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -125,9 +125,12 @@ fn config_redacts_grok_tavily_and_firecrawl_keys() {
     ]);
 
     let info = cfg.redacted_diagnostics();
-    assert!(info.contains("grok"));
-    assert!(info.contains("tvly"));
-    assert!(info.contains("fc-a"));
+    // Secrets are reported only as a two-state set/unset marker — never any
+    // fragment of the value (no prefix or suffix), so diagnostics are safe to
+    // surface on a public endpoint.
+    assert!(info.contains("grok_api_key=set"));
+    assert!(info.contains("tavily_api_key=set"));
+    assert!(info.contains("firecrawl_api_key=set"));
     assert!(!info.contains("1234567890"));
     assert!(!info.contains("abcdefghi"));
 }
@@ -439,7 +442,7 @@ fn config_path_none_when_no_env_set() {
 fn response_budget_defaults_and_env_overrides() {
     let defaults = Config::from_env_map([] as [(&str, &str); 0]);
     assert_eq!(defaults.max_inline_sources, 5);
-    assert_eq!(defaults.response_max_chars, 60_000);
+    assert_eq!(defaults.response_max_chars, 45_000);
 
     let overridden = Config::from_env_map([
         ("GROK_SEARCH_MAX_INLINE_SOURCES", "2"),


### PR DESCRIPTION
## What

Adds an **opt-in remote Streamable HTTP transport** so `grok-search-rs` can run as a public, multi-tenant remote MCP server — for mobile / on-the-go / multi-device access — while the default **stdio build stays byte-for-byte unchanged**. Gated behind the `http` Cargo feature (off by default): the default build links no axum and keeps the single-threaded runtime.

## Transport (`src/http.rs`, feature = `http`)

- `POST /mcp`; responds JSON or a one-event SSE stream per the client `Accept` header (Streamable HTTP content negotiation). `GET`/`DELETE` → 405, batch arrays → `-32600`, notifications → 202.
- **Bring-your-own-key**: per-request `SearchService::for_request` built from `X-Grok-Api-Key` / `X-Tavily-Api-Key` / `X-Firecrawl-Api-Key` / `X-GitHub-Token` headers. The server stores no credentials, strips server-side secret env, fails closed (401) on a missing required key, and rejects OAuth (stdio only).
- `initialize` protocol-version negotiation: echoes supported client versions (incl. legacy `2024-11-05`), else declares `2025-11-25`.

## Security (HTTP path only; stdio keeps full local capability)

SSRF guard on `web_fetch`/`web_map` (scheme allowlist + IP-literal/DNS-resolved public-address check), redirect-restricted client, per-tenant cache namespacing, `doctor` redaction downgraded to set/unset, numeric-arg clamping, 64 KB request-body limit, and a concurrency cap that sheds excess with 429.

## Deploy

`Dockerfile` + `Dockerfile.deploy` (runtime-only for low-RAM hosts, non-root, `release-http` profile = panic=unwind), `docker-compose.yml` + `Caddyfile` (Caddy automatic HTTPS, gateway-style path routing `/groksearch_rs/mcp`), and `docs/remote-mcp-deploy-plan.md`. Host/infra values are placeholders — set `MCP_HOSTNAME` at deploy time; nothing host-specific is committed.

## Backward compatibility

- Default `cargo build` links no axum; `current_thread` runtime preserved.
- Handler semantics unchanged (only visibility widened + version negotiation).
- Security clamps are HTTP-path only; local stdio keeps full capability (e.g. `localhost` fetch).
- OAuth still works on stdio.

## Verification

- Default build: 97 lib tests green, no axum in the dependency tree.
- `--features http`: 107 lib tests + full integration suite green, `clippy` clean.
- End-to-end: initialize / version-negotiation / 401 / 405 / `-32600` / SSRF-403 / SSE all verified via curl and a live Docker deployment behind Caddy (valid Let's Encrypt cert).

Also syncs the in-flight `response_max_chars` default (60k → 45k) across config, README, and tests.
