### PR TITLE
feat(http): honor any public Grok gateway via X-Grok-Base-Url

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ claude mcp add --transport http grok-search https://mcp.episkeyai.com/groksearch
   --header "X-Tavily-Api-Key: tvly-..."
 ```
 
-The default gateway is xAI official (`api.x.ai`) — use an xAI key. For another gateway (e.g.
-Modelverse) add `--header "X-Grok-Base-Url: https://api.modelverse.cn/v1"`. No keys are stored
+The default gateway is xAI official (`api.x.ai`) — use an xAI key. For any other Grok‑compatible
+gateway, add `--header "X-Grok-Base-Url: https://your-gateway.example/v1"` with a matching key. No keys are stored
 server-side; best-effort availability. Prefer your own server? See [self-hosting](#self-hosting-remote-http).
 
 **Option B — install locally (stdio).**
@@ -120,7 +120,7 @@ Pick **one** transport group. Both Tavily and Firecrawl keys are shared across t
 | `GROK_SEARCH_WEB_SEARCH` | `true` | Offer `web_search` tool to Grok. |
 | `GROK_SEARCH_X_SEARCH` | `false` | Offer `x_search` tool (X/Twitter) to Grok. |
 
-Verified upstreams: **xAI** (`https://api.x.ai`, both tools), **Modelverse** (`https://api.modelverse.cn`, `x_search` depends on relay).
+Verified upstream: **xAI** (`https://api.x.ai`, both tools). Other Grok‑compatible gateways work with a matching key; `x_search` availability depends on the gateway.
 
 OAuth mode is a single-binary flow:
 
@@ -237,10 +237,10 @@ each pays with their own keys:
 - `X-Grok-Api-Key`, `X-Tavily-Api-Key`, `X-Firecrawl-Api-Key` (optional `X-GitHub-Token`)
 
 A missing required key returns `401` (fail‑closed); OAuth is rejected on this transport
-(stdio only). The operator fixes the Grok‑compatible gateway via `GROK_SEARCH_URL`
-(default `https://api.x.ai`), and callers may switch to another allowlisted gateway with an
-`X-Grok-Base-Url` header (see `GROK_SEARCH_ALLOWED_GROK_URLS`). The remote transport uses the
-Grok **Responses** API only; the OpenAI-compatible chat-completions transport is stdio-only.
+(stdio only). The operator sets the default Grok‑compatible gateway via `GROK_SEARCH_URL`
+(default `https://api.x.ai`), and callers may point at any other Grok‑compatible gateway with an
+`X-Grok-Base-Url` header (any public gateway is honored; internal/private addresses are rejected).
+The remote transport uses the Grok **Responses** API only; the OpenAI-compatible chat-completions transport is stdio-only.
 
 ```bash
 cargo build --profile release-http --features http    # release-http => panic=unwind (handler panic won't kill the server)

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -26,12 +26,12 @@ Example:
 
 ```bash
 GROK_SEARCH_API_KEY=...
-GROK_SEARCH_URL=https://api.modelverse.cn
+GROK_SEARCH_URL=https://api.x.ai
 GROK_SEARCH_MODEL=grok-4-1-fast-reasoning
 GROK_SEARCH_X_SEARCH=false
 ```
 
-The example above calls `https://api.modelverse.cn/v1/responses`.
+The example above calls `https://api.x.ai/v1/responses`.
 
 ### OAuth mode
 

--- a/src/http.rs
+++ b/src/http.rs
@@ -81,6 +81,9 @@ struct AppState {
     allowed_origins: Arc<Option<HashSet<String>>>,
     /// Bounds concurrent in-flight requests (DoS protection on a small box).
     limiter: Arc<Semaphore>,
+    /// Operator request timeout, reused to build a per-request DNS-pinned client
+    /// for a caller-supplied gateway (`X-Grok-Base-Url`).
+    timeout: std::time::Duration,
 }
 
 /// Run the HTTP transport, binding `bind` (loopback in production, behind
@@ -100,6 +103,7 @@ pub async fn run_http(base_env: HashMap<String, String>, bind: SocketAddr) -> an
         base_env: Arc::new(strip_secrets(base_env)),
         allowed_origins: Arc::new(allowed_origins),
         limiter: Arc::new(Semaphore::new(MAX_CONCURRENT_REQUESTS)),
+        timeout: operator_cfg.timeout,
     };
 
     // Only POST is registered; axum answers other methods on /mcp with 405.
@@ -203,28 +207,44 @@ async fn mcp_post(State(state): State<AppState>, request: axum::extract::Request
     // 4. Derive a per-request config from operator defaults + header keys, then
     //    build a request-scoped, fully-credentialed service. Missing required
     //    key -> 401 (fail-closed); OAuth -> 400. Never falls back to a server key.
-    // Multi-gateway: a client may point at any Grok-compatible gateway via
-    // X-Grok-Base-Url (BYO gateway + matching key, same freedom as the stdio
-    // path). The gateway host is SSRF-validated below, so a caller can target
-    // any *public* gateway but never the operator's internal/metadata network.
     let gateway = resolve_gateway(&headers);
-    if let Some(url) = gateway.as_deref() {
-        if let Err((status, message)) = validate_public_url(url).await {
-            return json_rpc_error(status, id, -32602, message);
-        }
-    }
     let config = request_config(&state.base_env, &headers, gateway.as_deref());
-    let service =
-        match SearchService::for_request(state.http_client.clone(), state.cache.clone(), config) {
-            Ok(service) => service,
-            Err(err) => {
-                let status = match err {
-                    GrokSearchError::MissingConfig(_) => StatusCode::UNAUTHORIZED,
-                    _ => StatusCode::BAD_REQUEST,
-                };
-                return json_rpc_error(status, id, err.code() as i64, err.to_string());
-            }
+
+    // Build with the shared client FIRST so a missing/invalid key fails fast
+    // (401) BEFORE any gateway DNS: an unauthenticated request must never reach
+    // the resolver, else a bogus/slow `X-Grok-Base-Url` host would hold a
+    // concurrency permit until resolution (unauthenticated resolver DoS).
+    let service = match SearchService::for_request(
+        state.http_client.clone(),
+        state.cache.clone(),
+        config.clone(),
+    ) {
+        Ok(service) => service,
+        Err(err) => return for_request_error(id.clone(), err),
+    };
+
+    // Multi-gateway: a client may point at any Grok-compatible gateway via
+    // X-Grok-Base-Url (BYO gateway + matching key, same freedom as stdio). Its
+    // host is SSRF-validated AND the outbound connection is PINNED to the
+    // validated public IPs, so reqwest cannot re-resolve the hostname to an
+    // internal / metadata address between the check and the request
+    // (DNS-rebinding SSRF).
+    let service = if let Some(url) = gateway.as_deref() {
+        let addrs = match validate_public_url(url).await {
+            Ok(addrs) => addrs,
+            Err((status, message)) => return json_rpc_error(status, id.clone(), -32602, message),
         };
+        let client = match pinned_gateway_client(url, &addrs, state.timeout) {
+            Ok(client) => client,
+            Err((status, message)) => return json_rpc_error(status, id.clone(), -32602, message),
+        };
+        match SearchService::for_request(client, state.cache.clone(), config) {
+            Ok(service) => service,
+            Err(err) => return for_request_error(id.clone(), err),
+        }
+    } else {
+        service
+    };
 
     // 5. Clamp abusable numeric args (DoS) — HTTP path only; stdio is untouched.
     clamp_request_args(&mut request);
@@ -289,9 +309,10 @@ fn fetch_tool_url(request: &Value) -> Option<&str> {
 
 /// Reject a URL that could drive a server-side request at a non-public target
 /// (SSRF): bad scheme, or a host that is / resolves to a private, loopback,
-/// link-local (incl. cloud metadata), or CGNAT address. Returns
-/// `(status, message)` on rejection.
-async fn validate_public_url(raw: &str) -> Result<(), (StatusCode, String)> {
+/// link-local (incl. cloud metadata), or CGNAT address. On success returns the
+/// validated public IP(s) the host resolves to, so the caller can pin the
+/// actual connection to them (closing DNS-rebinding between check and use).
+async fn validate_public_url(raw: &str) -> Result<Vec<std::net::IpAddr>, (StatusCode, String)> {
     let parsed = url::Url::parse(raw)
         .map_err(|err| (StatusCode::BAD_REQUEST, format!("invalid url: {err}")))?;
     match parsed.scheme() {
@@ -311,7 +332,7 @@ async fn validate_public_url(raw: &str) -> Result<(), (StatusCode, String)> {
     let literal = host.trim_start_matches('[').trim_end_matches(']');
     if let Ok(ip) = literal.parse::<std::net::IpAddr>() {
         return if crate::providers::http::is_public_ip(&ip) {
-            Ok(())
+            Ok(vec![ip])
         } else {
             Err((
                 StatusCode::FORBIDDEN,
@@ -320,16 +341,26 @@ async fn validate_public_url(raw: &str) -> Result<(), (StatusCode, String)> {
         };
     }
 
-    // Hostname: resolve and require every resolved address to be public.
+    // Hostname: resolve (under a hard deadline so a slow resolver can't hold a
+    // concurrency permit) and require every resolved address to be public.
     let port = parsed.port_or_known_default().unwrap_or(443);
     let host_owned = host.to_string();
-    let resolved = tokio::task::spawn_blocking(move || {
-        use std::net::ToSocketAddrs;
-        (host_owned.as_str(), port)
-            .to_socket_addrs()
-            .map(|iter| iter.map(|addr| addr.ip()).collect::<Vec<_>>())
-    })
+    let resolved = tokio::time::timeout(
+        std::time::Duration::from_secs(5),
+        tokio::task::spawn_blocking(move || {
+            use std::net::ToSocketAddrs;
+            (host_owned.as_str(), port)
+                .to_socket_addrs()
+                .map(|iter| iter.map(|addr| addr.ip()).collect::<Vec<_>>())
+        }),
+    )
     .await
+    .map_err(|_| {
+        (
+            StatusCode::GATEWAY_TIMEOUT,
+            "host resolution timed out".to_string(),
+        )
+    })?
     .map_err(|err| {
         (
             StatusCode::INTERNAL_SERVER_ERROR,
@@ -341,15 +372,51 @@ async fn validate_public_url(raw: &str) -> Result<(), (StatusCode, String)> {
     if resolved.is_empty() {
         return Err((StatusCode::BAD_REQUEST, "host did not resolve".to_string()));
     }
-    for ip in resolved {
-        if !crate::providers::http::is_public_ip(&ip) {
+    for ip in &resolved {
+        if !crate::providers::http::is_public_ip(ip) {
             return Err((
                 StatusCode::FORBIDDEN,
                 "url resolves to a non-public address".to_string(),
             ));
         }
     }
-    Ok(())
+    Ok(resolved)
+}
+
+/// Build a restricted client whose DNS for the gateway `host` is pinned to
+/// `addrs` — the IPs [`validate_public_url`] just verified are public, at the
+/// gateway port. Connecting only to a pre-validated address closes the
+/// DNS-rebinding window between the SSRF check and the actual request.
+fn pinned_gateway_client(
+    url: &str,
+    addrs: &[std::net::IpAddr],
+    timeout: std::time::Duration,
+) -> Result<reqwest::Client, (StatusCode, String)> {
+    let parsed = url::Url::parse(url)
+        .map_err(|err| (StatusCode::BAD_REQUEST, format!("invalid url: {err}")))?;
+    let host = parsed
+        .host_str()
+        .ok_or((StatusCode::BAD_REQUEST, "url has no host".to_string()))?;
+    let port = parsed.port_or_known_default().unwrap_or(443);
+    let socket_addrs: Vec<std::net::SocketAddr> = addrs
+        .iter()
+        .map(|ip| std::net::SocketAddr::new(*ip, port))
+        .collect();
+    Ok(crate::providers::http::build_restricted_client_pinned(
+        timeout,
+        host,
+        &socket_addrs,
+    ))
+}
+
+/// Map a `SearchService::for_request` construction error to a JSON-RPC HTTP
+/// response: a missing key -> 401 (fail-closed), OAuth / other -> 400.
+fn for_request_error(id: Value, err: GrokSearchError) -> Response {
+    let status = match err {
+        GrokSearchError::MissingConfig(_) => StatusCode::UNAUTHORIZED,
+        _ => StatusCode::BAD_REQUEST,
+    };
+    json_rpc_error(status, id, err.code() as i64, err.to_string())
 }
 
 /// Clamp abusable numeric tool arguments to sane upper bounds so a single
@@ -592,8 +659,11 @@ mod tests {
 
     #[tokio::test]
     async fn validate_public_url_allows_public_ip_literal() {
-        // Public IP literals pass with no DNS lookup.
-        assert!(validate_public_url("https://1.1.1.1/").await.is_ok());
+        // Public IP literals pass with no DNS lookup, returning the pinned IP.
+        assert_eq!(
+            validate_public_url("https://1.1.1.1/").await.unwrap(),
+            vec!["1.1.1.1".parse::<std::net::IpAddr>().unwrap()]
+        );
         assert!(validate_public_url("http://8.8.8.8/").await.is_ok());
     }
 

--- a/src/http.rs
+++ b/src/http.rs
@@ -81,11 +81,6 @@ struct AppState {
     allowed_origins: Arc<Option<HashSet<String>>>,
     /// Bounds concurrent in-flight requests (DoS protection on a small box).
     limiter: Arc<Semaphore>,
-    /// Grok-compatible gateways a request may target via `X-Grok-Base-Url`
-    /// (stored normalized). Always contains the operator default; extra ones
-    /// come from GROK_SEARCH_ALLOWED_GROK_URLS. Keeps per-request gateway
-    /// selection from becoming an open SSRF proxy.
-    allowed_grok_urls: Arc<HashSet<String>>,
 }
 
 /// Run the HTTP transport, binding `bind` (loopback in production, behind
@@ -98,7 +93,6 @@ pub async fn run_http(base_env: HashMap<String, String>, bind: SocketAddr) -> an
     let http_client = crate::providers::http::build_restricted_client(operator_cfg.timeout);
     let cache = Arc::new(Mutex::new(SourceCache::new(operator_cfg.cache_size)));
     let allowed_origins = parse_allowed_origins(&base_env);
-    let allowed_grok_urls = parse_allowed_grok_urls(&base_env, &operator_cfg.grok_api_url);
 
     let state = AppState {
         http_client,
@@ -106,7 +100,6 @@ pub async fn run_http(base_env: HashMap<String, String>, bind: SocketAddr) -> an
         base_env: Arc::new(strip_secrets(base_env)),
         allowed_origins: Arc::new(allowed_origins),
         limiter: Arc::new(Semaphore::new(MAX_CONCURRENT_REQUESTS)),
-        allowed_grok_urls: Arc::new(allowed_grok_urls),
     };
 
     // Only POST is registered; axum answers other methods on /mcp with 405.
@@ -210,14 +203,16 @@ async fn mcp_post(State(state): State<AppState>, request: axum::extract::Request
     // 4. Derive a per-request config from operator defaults + header keys, then
     //    build a request-scoped, fully-credentialed service. Missing required
     //    key -> 401 (fail-closed); OAuth -> 400. Never falls back to a server key.
-    // Multi-gateway: a client may pick a Grok gateway via X-Grok-Base-Url, but
-    // only from the operator allowlist; otherwise the operator default is used.
-    // This gives remote callers the same "any gateway + matching key" freedom as
-    // the stdio path, without becoming an open proxy.
-    let gateway = match resolve_gateway(&headers, &state.allowed_grok_urls) {
-        Ok(gateway) => gateway,
-        Err(message) => return json_rpc_error(StatusCode::FORBIDDEN, id, -32602, message),
-    };
+    // Multi-gateway: a client may point at any Grok-compatible gateway via
+    // X-Grok-Base-Url (BYO gateway + matching key, same freedom as the stdio
+    // path). The gateway host is SSRF-validated below, so a caller can target
+    // any *public* gateway but never the operator's internal/metadata network.
+    let gateway = resolve_gateway(&headers);
+    if let Some(url) = gateway.as_deref() {
+        if let Err((status, message)) = validate_public_url(url).await {
+            return json_rpc_error(status, id, -32602, message);
+        }
+    }
     let config = request_config(&state.base_env, &headers, gateway.as_deref());
     let service =
         match SearchService::for_request(state.http_client.clone(), state.cache.clone(), config) {
@@ -428,38 +423,15 @@ fn request_config(
     Config::from_env_map(map)
 }
 
-/// Resolve the Grok gateway for a request. A client may request one via
-/// `X-Grok-Base-Url`; it is honored only if its normalized form is on the
-/// operator allowlist, otherwise the request is rejected. Absent header ->
-/// `None` (the operator default gateway is used).
-fn resolve_gateway(
-    headers: &HeaderMap,
-    allowed: &HashSet<String>,
-) -> Result<Option<String>, String> {
-    let requested = header_str(headers, "x-grok-base-url")
+/// The Grok gateway a request targets via `X-Grok-Base-Url`, honored verbatim
+/// (BYO gateway). Absent/empty header -> `None` (the operator default gateway
+/// is used). The returned URL's host is SSRF-validated by the caller before
+/// use, so any *public* gateway is allowed but internal addresses are not.
+fn resolve_gateway(headers: &HeaderMap) -> Option<String> {
+    header_str(headers, "x-grok-base-url")
         .map(str::trim)
-        .filter(|value| !value.is_empty());
-    let Some(raw) = requested else {
-        return Ok(None);
-    };
-    if allowed.contains(&crate::config::normalize_v1_base(raw)) {
-        Ok(Some(raw.to_string()))
-    } else {
-        Err(format!("grok gateway not allowed: {raw}"))
-    }
-}
-
-/// Build the set of allowed (normalized) Grok gateways: the operator default
-/// plus any comma-separated GROK_SEARCH_ALLOWED_GROK_URLS entries.
-fn parse_allowed_grok_urls(env: &HashMap<String, String>, default_url: &str) -> HashSet<String> {
-    let mut set = HashSet::new();
-    set.insert(default_url.to_string());
-    if let Some(raw) = env.get("GROK_SEARCH_ALLOWED_GROK_URLS") {
-        for entry in raw.split(',').map(str::trim).filter(|value| !value.is_empty()) {
-            set.insert(crate::config::normalize_v1_base(entry));
-        }
-    }
-    set
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
 }
 
 fn header_str<'a>(headers: &'a HeaderMap, name: &str) -> Option<&'a str> {
@@ -538,25 +510,20 @@ mod tests {
     }
 
     #[test]
-    fn resolve_gateway_enforces_allowlist() {
-        let mut allowed = HashSet::new();
-        allowed.insert("https://api.x.ai/v1".to_string());
-        allowed.insert("https://api.modelverse.cn/v1".to_string());
+    fn resolve_gateway_reads_header_verbatim() {
         // No header -> operator default (None).
-        assert_eq!(resolve_gateway(&headers(&[]), &allowed).unwrap(), None);
-        // Allowlisted gateway (normalization-insensitive) -> honored verbatim.
-        let got = resolve_gateway(
-            &headers(&[("X-Grok-Base-Url", "https://api.modelverse.cn")]),
-            &allowed,
-        )
-        .unwrap();
-        assert_eq!(got.as_deref(), Some("https://api.modelverse.cn"));
-        // Not allowlisted -> rejected.
-        assert!(resolve_gateway(
-            &headers(&[("X-Grok-Base-Url", "https://evil.example")]),
-            &allowed
-        )
-        .is_err());
+        assert_eq!(resolve_gateway(&headers(&[])), None);
+        // Any gateway is honored verbatim (allowlist removed); the host is
+        // SSRF-validated separately in the request path.
+        assert_eq!(
+            resolve_gateway(&headers(&[("X-Grok-Base-Url", "https://api.x.ai")])).as_deref(),
+            Some("https://api.x.ai"),
+        );
+        // Empty / whitespace-only header -> None.
+        assert_eq!(
+            resolve_gateway(&headers(&[("X-Grok-Base-Url", "   ")])),
+            None
+        );
     }
 
     #[test]

--- a/src/http.rs
+++ b/src/http.rs
@@ -38,9 +38,10 @@ const MAX_BODY_BYTES: usize = 64 * 1024;
 /// Max concurrent in-flight requests; excess gets 429 to protect the 1 GB box.
 const MAX_CONCURRENT_REQUESTS: usize = 32;
 
-/// Max concurrent caller-gateway DNS resolutions; excess gets 503. Bounds how
-/// many (potentially hung) blocking getaddrinfo calls can run at once.
-const MAX_GATEWAY_DNS_LOOKUPS: usize = 8;
+/// Max concurrent host resolutions (caller-gateway + fetch-tool SSRF
+/// validation); excess gets 503. Bounds how many (potentially hung) blocking
+/// getaddrinfo calls can run at once.
+const MAX_DNS_LOOKUPS: usize = 8;
 
 /// Protocol revisions the Streamable HTTP transport implements. Excludes
 /// 2024-11-05 (the deprecated HTTP+SSE transport this endpoint does not serve)
@@ -85,9 +86,10 @@ struct AppState {
     allowed_origins: Arc<Option<HashSet<String>>>,
     /// Bounds concurrent in-flight requests (DoS protection on a small box).
     limiter: Arc<Semaphore>,
-    /// Caps concurrent caller-gateway host resolutions so hung blocking
-    /// getaddrinfo calls (which outlive their timeout) can't pile up threads.
-    gateway_dns_limiter: Arc<Semaphore>,
+    /// Caps concurrent host resolutions (gateway + fetch-tool validation) so
+    /// hung blocking getaddrinfo calls (which outlive their timeout) can't
+    /// pile up threads.
+    dns_limiter: Arc<Semaphore>,
     /// Operator request timeout, reused to build a per-request DNS-pinned client
     /// for a caller-supplied gateway (`X-Grok-Base-Url`).
     timeout: std::time::Duration,
@@ -110,7 +112,7 @@ pub async fn run_http(base_env: HashMap<String, String>, bind: SocketAddr) -> an
         base_env: Arc::new(strip_secrets(base_env)),
         allowed_origins: Arc::new(allowed_origins),
         limiter: Arc::new(Semaphore::new(MAX_CONCURRENT_REQUESTS)),
-        gateway_dns_limiter: Arc::new(Semaphore::new(MAX_GATEWAY_DNS_LOOKUPS)),
+        dns_limiter: Arc::new(Semaphore::new(MAX_DNS_LOOKUPS)),
         timeout: operator_cfg.timeout,
     };
 
@@ -252,7 +254,7 @@ async fn mcp_post(State(state): State<AppState>, request: axum::extract::Request
         // Cap concurrent gateway-host resolutions: a blocking getaddrinfo can
         // outlive its 5s timeout, so bound how many run at once (the permit is
         // held until the lookup returns) — a hung host can't pile up threads.
-        let dns_permit = match state.gateway_dns_limiter.clone().try_acquire_owned() {
+        let dns_permit = match state.dns_limiter.clone().try_acquire_owned() {
             Ok(permit) => permit,
             Err(_) => {
                 return json_rpc_error(
@@ -271,7 +273,15 @@ async fn mcp_post(State(state): State<AppState>, request: axum::extract::Request
             Ok(client) => client,
             Err((status, message)) => return json_rpc_error(status, id.clone(), -32602, message),
         };
-        match SearchService::for_request(client, state.cache.clone(), config) {
+        // The pinned, no-redirect client applies to the GROK provider only;
+        // Tavily/Firecrawl/source fetching keep the shared restricted client
+        // (which follows redirects, re-validating every hop).
+        match SearchService::for_request_with_grok_client(
+            state.http_client.clone(),
+            client,
+            state.cache.clone(),
+            config,
+        ) {
             Ok(service) => service,
             Err(err) => return for_request_error(id.clone(), err),
         }
@@ -284,9 +294,23 @@ async fn mcp_post(State(state): State<AppState>, request: axum::extract::Request
 
     // 6. SSRF guard: for URL-fetching tools, block non-public / bad-scheme
     //    targets before any server-side request is made. HTTP path only, so
-    //    local stdio users keep full fetch capability (e.g. localhost).
+    //    local stdio users keep full fetch capability (e.g. localhost). The
+    //    hostname lookup takes a DNS permit too: a timed-out getaddrinfo keeps
+    //    its blocking thread alive, so the same semaphore that bounds gateway
+    //    lookups must bound fetch-validation lookups.
     if let Some(url) = fetch_tool_url(&request) {
-        if let Err((status, message)) = validate_public_url(url, None).await {
+        let dns_permit = match state.dns_limiter.clone().try_acquire_owned() {
+            Ok(permit) => permit,
+            Err(_) => {
+                return json_rpc_error(
+                    StatusCode::SERVICE_UNAVAILABLE,
+                    id,
+                    -32603,
+                    "resolver busy".to_string(),
+                )
+            }
+        };
+        if let Err((status, message)) = validate_public_url(url, Some(dns_permit)).await {
             return json_rpc_error(status, id, -32602, message);
         }
     }

--- a/src/http.rs
+++ b/src/http.rs
@@ -38,6 +38,10 @@ const MAX_BODY_BYTES: usize = 64 * 1024;
 /// Max concurrent in-flight requests; excess gets 429 to protect the 1 GB box.
 const MAX_CONCURRENT_REQUESTS: usize = 32;
 
+/// Max concurrent caller-gateway DNS resolutions; excess gets 503. Bounds how
+/// many (potentially hung) blocking getaddrinfo calls can run at once.
+const MAX_GATEWAY_DNS_LOOKUPS: usize = 8;
+
 /// Protocol revisions the Streamable HTTP transport implements. Excludes
 /// 2024-11-05 (the deprecated HTTP+SSE transport this endpoint does not serve)
 /// and 2025-03-26 (which still mandates JSON-RPC batching — removed only in
@@ -81,6 +85,9 @@ struct AppState {
     allowed_origins: Arc<Option<HashSet<String>>>,
     /// Bounds concurrent in-flight requests (DoS protection on a small box).
     limiter: Arc<Semaphore>,
+    /// Caps concurrent caller-gateway host resolutions so hung blocking
+    /// getaddrinfo calls (which outlive their timeout) can't pile up threads.
+    gateway_dns_limiter: Arc<Semaphore>,
     /// Operator request timeout, reused to build a per-request DNS-pinned client
     /// for a caller-supplied gateway (`X-Grok-Base-Url`).
     timeout: std::time::Duration,
@@ -103,6 +110,7 @@ pub async fn run_http(base_env: HashMap<String, String>, bind: SocketAddr) -> an
         base_env: Arc::new(strip_secrets(base_env)),
         allowed_origins: Arc::new(allowed_origins),
         limiter: Arc::new(Semaphore::new(MAX_CONCURRENT_REQUESTS)),
+        gateway_dns_limiter: Arc::new(Semaphore::new(MAX_GATEWAY_DNS_LOOKUPS)),
         timeout: operator_cfg.timeout,
     };
 
@@ -230,7 +238,32 @@ async fn mcp_post(State(state): State<AppState>, request: axum::extract::Request
     // internal / metadata address between the check and the request
     // (DNS-rebinding SSRF).
     let service = if let Some(url) = gateway.as_deref() {
-        let addrs = match validate_public_url(url).await {
+        // Caller gateways must be HTTPS: the request carries the caller's bearer
+        // key, so a plaintext http:// gateway (typo/downgrade) would leak it on
+        // the wire. (URL-fetch tools still allow http; this is the gateway only.)
+        if !gateway_is_https(url) {
+            return json_rpc_error(
+                StatusCode::BAD_REQUEST,
+                id.clone(),
+                -32602,
+                "X-Grok-Base-Url must use https".to_string(),
+            );
+        }
+        // Cap concurrent gateway-host resolutions: a blocking getaddrinfo can
+        // outlive its 5s timeout, so bound how many run at once (the permit is
+        // held until the lookup returns) — a hung host can't pile up threads.
+        let dns_permit = match state.gateway_dns_limiter.clone().try_acquire_owned() {
+            Ok(permit) => permit,
+            Err(_) => {
+                return json_rpc_error(
+                    StatusCode::SERVICE_UNAVAILABLE,
+                    id.clone(),
+                    -32603,
+                    "gateway resolver busy".to_string(),
+                )
+            }
+        };
+        let addrs = match validate_public_url(url, Some(dns_permit)).await {
             Ok(addrs) => addrs,
             Err((status, message)) => return json_rpc_error(status, id.clone(), -32602, message),
         };
@@ -253,7 +286,7 @@ async fn mcp_post(State(state): State<AppState>, request: axum::extract::Request
     //    targets before any server-side request is made. HTTP path only, so
     //    local stdio users keep full fetch capability (e.g. localhost).
     if let Some(url) = fetch_tool_url(&request) {
-        if let Err((status, message)) = validate_public_url(url).await {
+        if let Err((status, message)) = validate_public_url(url, None).await {
             return json_rpc_error(status, id, -32602, message);
         }
     }
@@ -312,7 +345,10 @@ fn fetch_tool_url(request: &Value) -> Option<&str> {
 /// link-local (incl. cloud metadata), or CGNAT address. On success returns the
 /// validated public IP(s) the host resolves to, so the caller can pin the
 /// actual connection to them (closing DNS-rebinding between check and use).
-async fn validate_public_url(raw: &str) -> Result<Vec<std::net::IpAddr>, (StatusCode, String)> {
+async fn validate_public_url(
+    raw: &str,
+    dns_permit: Option<tokio::sync::OwnedSemaphorePermit>,
+) -> Result<Vec<std::net::IpAddr>, (StatusCode, String)> {
     let parsed = url::Url::parse(raw)
         .map_err(|err| (StatusCode::BAD_REQUEST, format!("invalid url: {err}")))?;
     match parsed.scheme() {
@@ -348,6 +384,10 @@ async fn validate_public_url(raw: &str) -> Result<Vec<std::net::IpAddr>, (Status
     let resolved = tokio::time::timeout(
         std::time::Duration::from_secs(5),
         tokio::task::spawn_blocking(move || {
+            // Hold the resolver permit until getaddrinfo actually returns: the
+            // 5s timeout abandons this task but cannot cancel it, so the permit
+            // (not the timeout) is what bounds concurrent hung lookups.
+            let _dns_permit = dns_permit;
             use std::net::ToSocketAddrs;
             (host_owned.as_str(), port)
                 .to_socket_addrs()
@@ -533,6 +573,15 @@ fn parse_allowed_origins(env: &HashMap<String, String>) -> Option<HashSet<String
     }
 }
 
+/// A caller-supplied gateway must be HTTPS: the request carries the caller's
+/// bearer key, so a plaintext `http://` gateway would leak it on the wire.
+/// (URL-fetch tools still allow `http`; this restriction is gateway-only.)
+fn gateway_is_https(url: &str) -> bool {
+    url::Url::parse(url)
+        .map(|parsed| parsed.scheme() == "https")
+        .unwrap_or(false)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -651,7 +700,7 @@ mod tests {
             "gopher://example.com/",                     // bad scheme
         ] {
             assert!(
-                validate_public_url(bad).await.is_err(),
+                validate_public_url(bad, None).await.is_err(),
                 "expected {bad} to be rejected"
             );
         }
@@ -661,10 +710,18 @@ mod tests {
     async fn validate_public_url_allows_public_ip_literal() {
         // Public IP literals pass with no DNS lookup, returning the pinned IP.
         assert_eq!(
-            validate_public_url("https://1.1.1.1/").await.unwrap(),
+            validate_public_url("https://1.1.1.1/", None).await.unwrap(),
             vec!["1.1.1.1".parse::<std::net::IpAddr>().unwrap()]
         );
-        assert!(validate_public_url("http://8.8.8.8/").await.is_ok());
+        assert!(validate_public_url("http://8.8.8.8/", None).await.is_ok());
+    }
+
+    #[test]
+    fn gateway_is_https_rejects_plaintext() {
+        assert!(gateway_is_https("https://api.x.ai/v1"));
+        assert!(!gateway_is_https("http://api.x.ai/v1"));
+        assert!(!gateway_is_https("ftp://api.x.ai"));
+        assert!(!gateway_is_https("not a url"));
     }
 
     #[test]

--- a/src/providers/http.rs
+++ b/src/providers/http.rs
@@ -57,11 +57,11 @@ pub(crate) fn is_public_ip(ip: &std::net::IpAddr) -> bool {
     }
 }
 
-/// Like [`build_client`] but rejects redirects to private/loopback IP-literal
-/// targets (defense-in-depth against redirect-based SSRF) and caps redirect
-/// depth. Used only by the public HTTP transport.
+/// Shared builder for the restricted (SSRF-aware) HTTP-transport client: the
+/// tuning knobs plus a redirect policy that rejects redirects to non-public
+/// targets. Callers finish with `.build()`, optionally after pinning DNS.
 #[cfg(feature = "http")]
-pub fn build_restricted_client(timeout: Duration) -> Client {
+fn restricted_client_builder(timeout: Duration) -> reqwest::ClientBuilder {
     use reqwest::redirect::Policy;
     Client::builder()
         .timeout(timeout)
@@ -95,6 +95,30 @@ pub fn build_restricted_client(timeout: Duration) -> Client {
             }
             attempt.follow()
         }))
+}
+
+/// Like [`build_client`] but rejects redirects to private/loopback IP-literal
+/// targets (defense-in-depth against redirect-based SSRF) and caps redirect
+/// depth. Used only by the public HTTP transport.
+#[cfg(feature = "http")]
+pub fn build_restricted_client(timeout: Duration) -> Client {
+    restricted_client_builder(timeout)
+        .build()
+        .unwrap_or_else(|_| Client::new())
+}
+
+/// Like [`build_restricted_client`] but pins DNS for `host` to `addrs` (already
+/// validated as public) so the connection cannot re-resolve the hostname to an
+/// internal address between the SSRF check and the request (DNS-rebinding).
+/// Used for caller-supplied Grok gateways (`X-Grok-Base-Url`) on the HTTP path.
+#[cfg(feature = "http")]
+pub fn build_restricted_client_pinned(
+    timeout: Duration,
+    host: &str,
+    addrs: &[std::net::SocketAddr],
+) -> Client {
+    restricted_client_builder(timeout)
+        .resolve_to_addrs(host, addrs)
         .build()
         .unwrap_or_else(|_| Client::new())
 }

--- a/src/providers/http.rs
+++ b/src/providers/http.rs
@@ -117,8 +117,14 @@ pub fn build_restricted_client_pinned(
     host: &str,
     addrs: &[std::net::SocketAddr],
 ) -> Client {
+    use reqwest::redirect::Policy;
     restricted_client_builder(timeout)
         .resolve_to_addrs(host, addrs)
+        // The pin only covers the ORIGINAL host; a 3xx to another host would be
+        // re-resolved unpinned (redirect-level DNS-rebinding SSRF). A Grok
+        // gateway's /v1/responses endpoint never legitimately redirects, so
+        // refuse to follow redirects at all on the pinned client.
+        .redirect(Policy::none())
         .build()
         .unwrap_or_else(|_| Client::new())
 }

--- a/src/service.rs
+++ b/src/service.rs
@@ -129,6 +129,20 @@ struct ProviderSet {
 /// `SearchService::new` body so both the process-wide (stdio) and per-request
 /// (HTTP) construction paths share one implementation.
 fn build_providers(config: &Config, http: &reqwest::Client) -> Result<ProviderSet> {
+    build_providers_with_grok(config, http, http)
+}
+
+/// Like [`build_providers`], but the Grok **Responses** provider uses
+/// `grok_http` while every other provider (Tavily / Firecrawl / source
+/// fetching) keeps `http`. The HTTP transport passes a DNS-pinned,
+/// no-redirect client as `grok_http` for a caller-supplied gateway
+/// (`X-Grok-Base-Url`) — that restriction must apply to the gateway request
+/// only, not to unrelated fetch/search traffic.
+fn build_providers_with_grok(
+    config: &Config,
+    http: &reqwest::Client,
+    grok_http: &reqwest::Client,
+) -> Result<ProviderSet> {
     use crate::config::Transport;
 
     let ai: Arc<dyn AiProvider> = match config.transport {
@@ -156,7 +170,7 @@ fn build_providers(config: &Config, http: &reqwest::Client) -> Result<ProviderSe
                     }
                 };
             Arc::new(GrokResponsesProvider::with_credential_client(
-                http.clone(),
+                grok_http.clone(),
                 config.grok_api_url.clone(),
                 credential,
                 config.web_search_enabled,
@@ -232,16 +246,20 @@ fn build_providers(config: &Config, http: &reqwest::Client) -> Result<ProviderSe
 /// key. Cache entries are stored under `tag:session_id` so one tenant can never
 /// read another tenant's cached `get_sources` pages on the shared HTTP process.
 /// For stdio (a single process key) the tag is constant, so behavior is
-/// unchanged. Uses a SHA-256 prefix — never any fragment of the raw key.
+/// unchanged. The gateway URL is part of the hash material: with arbitrary
+/// public gateways two tenants on different gateways may present the same
+/// opaque key string, and they must not share a cache namespace. Uses a
+/// SHA-256 prefix — never any fragment of the raw key.
 fn tenant_tag(config: &Config) -> String {
-    let material = config
+    let key = config
         .grok_api_key
         .as_deref()
         .or(config.openai_compatible_api_key.as_deref())
         .unwrap_or("");
-    if material.is_empty() {
+    if key.is_empty() {
         return "anon".to_string();
     }
+    let material = format!("{}\n{}", config.grok_api_url, key);
     let digest = ring::digest::digest(&ring::digest::SHA256, material.as_bytes());
     digest.as_ref()[..8]
         .iter()
@@ -285,13 +303,29 @@ impl SearchService {
         cache: Arc<Mutex<SourceCache>>,
         config: Config,
     ) -> Result<Self> {
+        Self::for_request_with_grok_client(http_client.clone(), http_client, cache, config)
+    }
+
+    /// Like [`for_request`], but the Grok provider uses `grok_client` while all
+    /// other providers keep `http_client`. The HTTP transport passes a
+    /// DNS-pinned, no-redirect client here for a caller-supplied gateway, so
+    /// the pin/no-redirect restriction stays scoped to the gateway request and
+    /// never degrades unrelated fetch/search redirect handling.
+    ///
+    /// [`for_request`]: SearchService::for_request
+    pub fn for_request_with_grok_client(
+        http_client: reqwest::Client,
+        grok_client: reqwest::Client,
+        cache: Arc<Mutex<SourceCache>>,
+        config: Config,
+    ) -> Result<Self> {
         if config.grok_auth_mode == AuthMode::OAuth {
             return Err(GrokSearchError::OAuth(
                 "oauth is not supported on the HTTP transport; pass a per-request API key"
                     .to_string(),
             ));
         }
-        let providers = build_providers(&config, &http_client)?;
+        let providers = build_providers_with_grok(&config, &http_client, &grok_client)?;
         Ok(Self::from_parts(config, http_client, cache, providers))
     }
 
@@ -2039,5 +2073,31 @@ mod request_scope_tests {
             other.get_sources(session, 0, None).await.is_err(),
             "a different tenant must not read another tenant's cached session"
         );
+    }
+
+    #[test]
+    fn tenant_tag_namespaces_by_gateway() {
+        // Same opaque key on two different gateways must NOT share a cache
+        // namespace: with arbitrary public gateways, independent gateways can
+        // issue/accept identical key strings for different callers.
+        let on_xai = Config::from_env_map([
+            ("GROK_SEARCH_API_KEY", "same-key"),
+            ("GROK_SEARCH_URL", "https://api.x.ai"),
+        ]);
+        let on_other = Config::from_env_map([
+            ("GROK_SEARCH_API_KEY", "same-key"),
+            ("GROK_SEARCH_URL", "https://gateway.example"),
+        ]);
+        assert_ne!(
+            tenant_tag(&on_xai),
+            tenant_tag(&on_other),
+            "gateway must be part of the tenant namespace"
+        );
+        // Same key + same gateway stays stable (continuation still works).
+        let again = Config::from_env_map([
+            ("GROK_SEARCH_API_KEY", "same-key"),
+            ("GROK_SEARCH_URL", "https://api.x.ai"),
+        ]);
+        assert_eq!(tenant_tag(&on_xai), tenant_tag(&again));
     }
 }


### PR DESCRIPTION
## What

Remove the `GROK_SEARCH_ALLOWED_GROK_URLS` gateway allowlist from the remote HTTP transport. A caller's `X-Grok-Base-Url` is now honored verbatim, so remote (BYO-key) callers can point at **any** Grok-compatible gateway with a matching key — the same freedom the stdio path already has.

## Security — SSRF guard retained

Dropping the allowlist does **not** open an SSRF hole. The caller-supplied gateway host is now validated via the existing `validate_public_url` (public IPs only), so the server still rejects internal / loopback / link-local / cloud-metadata (`169.254.169.254`) targets. Only the curation *whitelist* is gone; the private-address guard stays. Requests on the operator default gateway skip the check entirely (no added latency).

## Changes

- `src/http.rs`: drop the `allowed_grok_urls` state, `parse_allowed_grok_urls`, and the allowlist check in `resolve_gateway`; SSRF-validate the caller gateway in the request path.
- `README.md`, `docs/CONFIGURATION.md`: remove the Modelverse gateway example and reword the multi-gateway section for the new behavior (any public gateway honored; internal addresses rejected).

## Tests

`cargo test --features http` — lib unit tests **111/111 green**, including the rewritten `resolve_gateway_reads_header_verbatim` and the existing `validate_public_url_*` SSRF tests.

> Note: `tests/tavily_rotation.rs` has two **pre-existing** flaky tests, unrelated to this PR — caused by a randomized round-robin start key in `src/providers/tavily.rs`. Tracked separately.
