### PR TITLE
feat(http): per-request Grok model via X-Grok-Model header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to GrokSearch-rs are documented here.
 
 ## Unreleased
 
+### Added
+
+- **`X-Grok-Model` 请求头(远程 HTTP)。** 调用方可按请求指定 Grok 模型名,与
+  `X-Grok-Base-Url` 配套(模型 id 因网关而异);缺省沿用运营方默认模型。
+
 ## 0.1.19 - 2026-07-21
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -45,7 +45,8 @@ claude mcp add --transport http grok-search https://mcp.episkeyai.com/groksearch
 ```
 
 The default gateway is xAI official (`api.x.ai`) — use an xAI key. For any other Grok‑compatible
-gateway, add `--header "X-Grok-Base-Url: https://your-gateway.example/v1"` with a matching key. No keys are stored
+gateway, add `--header "X-Grok-Base-Url: https://your-gateway.example/v1"` with a matching key, and
+optionally `--header "X-Grok-Model: <model>"` (model ids are gateway‑specific). No keys are stored
 server-side; best-effort availability. Prefer your own server? See [self-hosting](#self-hosting-remote-http).
 
 **Option B — install locally (stdio).**
@@ -235,6 +236,7 @@ request carries the caller's own keys as headers, so many users can share one en
 each pays with their own keys:
 
 - `X-Grok-Api-Key`, `X-Tavily-Api-Key`, `X-Firecrawl-Api-Key` (optional `X-GitHub-Token`)
+- Optional non‑secret overrides: `X-Grok-Base-Url` (gateway), `X-Grok-Model` (model name, since model ids are gateway‑specific)
 
 A missing required key returns `401` (fail‑closed); OAuth is rejected on this transport
 (stdio only). The operator sets the default Grok‑compatible gateway via `GROK_SEARCH_URL`

--- a/src/http.rs
+++ b/src/http.rs
@@ -72,6 +72,10 @@ const HEADER_TO_ENV: &[(&str, &str)] = &[
     ("x-tavily-api-key", "TAVILY_API_KEY"),
     ("x-firecrawl-api-key", "FIRECRAWL_API_KEY"),
     ("x-github-token", "GITHUB_TOKEN"),
+    // Non-secret: lets a caller pick the Grok model per request (pairs with
+    // X-Grok-Base-Url, since model names are gateway-specific). Absent header
+    // -> the operator default model.
+    ("x-grok-model", "GROK_SEARCH_MODEL"),
 ];
 
 #[derive(Clone)]
@@ -632,11 +636,16 @@ mod tests {
             &headers(&[
                 ("X-Grok-Api-Key", "xai-caller"),
                 ("X-Tavily-Api-Key", "tvly-caller"),
+                ("X-Grok-Model", "grok-caller-model"),
             ]),
             None,
         );
         assert_eq!(cfg.grok_api_key.as_deref(), Some("xai-caller"));
         assert_eq!(cfg.tavily_api_key.as_deref(), Some("tvly-caller"));
+        assert_eq!(cfg.grok_model, "grok-caller-model");
+        // Absent model header -> operator default survives.
+        let default_cfg = request_config(&base(), &headers(&[]), None);
+        assert_eq!(default_cfg.grok_model, "grok-4-1-fast-reasoning");
     }
 
     #[test]


### PR DESCRIPTION
## What

Add an `X-Grok-Model` request header to the remote HTTP transport: a caller can pick the Grok model per request, pairing with `X-Grok-Base-Url` — model ids are gateway-specific, so choosing a gateway implies choosing a model. Absent header → the operator default model (unchanged behavior).

Implementation is a single non-secret `HEADER_TO_ENV` mapping (`x-grok-model` → `GROK_SEARCH_MODEL`); it flows through the existing `request_config` overlay, so trimming/empty-header semantics match the other headers. Docs (README header list + hosted-instance blurb) and CHANGELOG (`Unreleased`) updated.

## Process note

This is a re-submission of `a4e096d` (previously pushed directly to `main`, reverted in `cf60b20`) so the change goes through review like every other code change.

## Verification

- `cargo test --features http` — http module 14/14 green, incl. the extended `request_config_overlays_header_keys` (header applies; absent header keeps operator default); clippy clean.
- Live on the deployed instance: `doctor` with `X-Grok-Model: grok-4.5` reports `model=grok-4.5, reachable=true`; without the header it reports the operator default.
