### PR TITLE
fix(service): surface real error when primary source fetch fails without fallback

### DIFF
--- a/src/service.rs
+++ b/src/service.rs
@@ -1066,26 +1066,27 @@ fn apply_fetch_limit(
 /// Generic (non-specialist) content fetch via the configured source providers:
 /// primary (Tavily) first, then fallback (Firecrawl). Shared by `web_fetch` and
 /// inline enrichment so both agree on how an ordinary URL is retrieved once no
-/// specialist extractor matches. Returns `MissingConfig` when neither provider
-/// is configured.
+/// specialist extractor matches. Returns `MissingConfig` only when neither
+/// provider is configured; a configured primary that fails or yields empty
+/// content with no fallback surfaces its real error instead, so users are not
+/// sent to debug config that is actually set.
 async fn generic_source_fetch(
     primary: &Option<Arc<dyn SourceProvider>>,
     fallback: &Option<Arc<dyn SourceProvider>>,
     url: &str,
 ) -> Result<String> {
-    if let Some(provider) = primary {
-        if let Ok(content) = provider.fetch(url).await {
-            if !content.trim().is_empty() {
-                return Ok(content);
-            }
-        }
+    let primary_err = match primary {
+        Some(provider) => match provider.fetch(url).await {
+            Ok(content) if !content.trim().is_empty() => return Ok(content),
+            Ok(_) => GrokSearchError::Provider(format!("Tavily returned empty content for {url}")),
+            Err(err) => err,
+        },
+        None => GrokSearchError::MissingConfig("TAVILY_API_KEY or FIRECRAWL_API_KEY"),
+    };
+    match fallback {
+        Some(provider) => provider.fetch(url).await,
+        None => Err(primary_err),
     }
-    if let Some(provider) = fallback {
-        return provider.fetch(url).await;
-    }
-    Err(GrokSearchError::MissingConfig(
-        "TAVILY_API_KEY or FIRECRAWL_API_KEY",
-    ))
 }
 
 /// Concurrently back-fill `Source.content` for the first `max_sources` sources
@@ -1685,6 +1686,27 @@ mod enrich_tests {
         }
     }
 
+    /// Generic `fetch` succeeds but yields whitespace-only content — exercises
+    /// the "primary configured but empty" error path of `generic_source_fetch`.
+    struct EmptyFetchProvider;
+    #[async_trait]
+    impl SourceProvider for EmptyFetchProvider {
+        async fn search_sources(
+            &self,
+            _query: &str,
+            _max_results: usize,
+            _filters: &SearchFilters,
+        ) -> Result<Vec<Source>> {
+            Ok(Vec::new())
+        }
+        async fn fetch(&self, _url: &str) -> Result<String> {
+            Ok("  \n".to_string())
+        }
+        async fn map(&self, _url: &str, _max_results: usize) -> Result<Vec<Source>> {
+            Ok(Vec::new())
+        }
+    }
+
     /// Build a SearchService with fake AI + a caller-supplied supplemental
     /// provider, router, and config. Mirrors the doctor_* struct-literal tests.
     fn service_with_sources(
@@ -1892,6 +1914,65 @@ mod enrich_tests {
         assert!(
             !content.starts_with("_Failed to retrieve:"),
             "must not store a failure note when generic fetch succeeds: {content:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn generic_fetch_missing_config_only_when_no_provider_configured() {
+        let err = generic_source_fetch(&None, &None, "https://example.com")
+            .await
+            .expect_err("no providers must error");
+        assert!(
+            matches!(
+                err,
+                GrokSearchError::MissingConfig("TAVILY_API_KEY or FIRECRAWL_API_KEY")
+            ),
+            "expected MissingConfig, got: {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn generic_fetch_primary_error_surfaces_without_fallback() {
+        // Regression: a configured primary whose fetch failed used to fall
+        // through to MissingConfig("TAVILY_API_KEY or FIRECRAWL_API_KEY") even
+        // though TAVILY_API_KEY was set, sending users to debug config instead
+        // of the actual provider failure.
+        let primary: Option<Arc<dyn SourceProvider>> = Some(Arc::new(SearchOkFetchErrProvider));
+        let err = generic_source_fetch(&primary, &None, "https://example.com")
+            .await
+            .expect_err("primary failure must error");
+        match err {
+            GrokSearchError::Provider(msg) => assert_eq!(msg, "generic fetch unavailable"),
+            other => panic!("primary error must pass through unchanged, got: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn generic_fetch_primary_empty_content_reports_empty_without_fallback() {
+        let url = "https://npmjs.com/package/grok-search-rs";
+        let primary: Option<Arc<dyn SourceProvider>> = Some(Arc::new(EmptyFetchProvider));
+        let err = generic_source_fetch(&primary, &None, url)
+            .await
+            .expect_err("empty content must error");
+        match err {
+            GrokSearchError::Provider(msg) => assert!(
+                msg.contains("empty content") && msg.contains(url),
+                "message must name the empty result and url, got: {msg}"
+            ),
+            other => panic!("expected Provider empty-content error, got: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn generic_fetch_primary_failure_still_rescued_by_fallback() {
+        let primary: Option<Arc<dyn SourceProvider>> = Some(Arc::new(SearchOkFetchErrProvider));
+        let fallback: Option<Arc<dyn SourceProvider>> = Some(Arc::new(FakeSourceProvider));
+        let content = generic_source_fetch(&primary, &fallback, "https://example.com")
+            .await
+            .expect("fallback must rescue primary failure");
+        assert!(
+            content.starts_with("Fetched content from"),
+            "fallback content expected, got: {content:?}"
         );
     }
 

--- a/tests/tavily_rotation.rs
+++ b/tests/tavily_rotation.rs
@@ -106,9 +106,21 @@ async fn key_scoped_failure_rotates_to_next_key_and_succeeds() {
         .expect("second key should succeed after 429 on first");
 
     assert_eq!(sources.len(), 1);
+    // The starting key is randomized per ring; the invariant is that the 429
+    // triggers exactly one retry with the OTHER key, whichever came first.
+    let log = auth_log.lock().expect("auth log lock").clone();
     assert_eq!(
-        *auth_log.lock().expect("auth log lock"),
-        vec!["Bearer key-a".to_string(), "Bearer key-b".to_string()],
+        log.len(),
+        2,
+        "expected the 429 to trigger exactly one retry"
+    );
+    assert!(
+        log.iter()
+            .all(|auth| auth == "Bearer key-a" || auth == "Bearer key-b"),
+        "unexpected auth headers: {log:?}"
+    );
+    assert_ne!(
+        log[0], log[1],
         "expected the 429 to trigger a retry with the next key"
     );
 }
@@ -157,9 +169,17 @@ async fn successive_requests_round_robin_across_keys() {
             .expect("mock returns 200");
     }
 
-    assert_eq!(
-        *auth_log.lock().expect("auth log lock"),
-        vec!["Bearer key-a".to_string(), "Bearer key-b".to_string()],
+    // The starting key is randomized per ring; round-robin means the second
+    // request must consume the OTHER key, whichever the ring started on.
+    let log = auth_log.lock().expect("auth log lock").clone();
+    assert_eq!(log.len(), 2);
+    assert!(
+        log.iter()
+            .all(|auth| auth == "Bearer key-a" || auth == "Bearer key-b"),
+        "unexpected auth headers: {log:?}"
+    );
+    assert_ne!(
+        log[0], log[1],
         "two successful requests should consume credits from different keys"
     );
 }


### PR DESCRIPTION
## Problem

`generic_source_fetch` (src/service.rs) fell through to `MissingConfig("TAVILY_API_KEY or FIRECRAWL_API_KEY")` whenever the **configured** primary (Tavily) errored or returned empty content and no fallback (Firecrawl) was configured — e.g. `https://npmjs.com/package/grok-search-rs`, where npm anti-bot breaks Tavily extract. `doctor` shows the key as set, so the error sent users to debug config that was never the problem.

## Fix

- `MissingConfig` is returned **only when neither provider is configured**.
- Configured primary errors → the provider error **passes through unchanged**.
- Primary succeeds but yields empty/whitespace content → dedicated `Provider("Tavily returned empty content for <url>")`.
- Unchanged semantics: primary Ok + non-empty → content; primary failure with fallback configured → fallback takes over.

Caller impact: `web_fetch` now propagates the real cause to the MCP layer; inline enrichment (`Ok(Err(_))`) discards the error content and keeps its specialist-reason note — behavior unchanged, covered by existing enrich tests.

## Tests

Four new unit tests in `enrich_tests` (new `EmptyFetchProvider` mock; reuses `SearchOkFetchErrProvider`): both-None → MissingConfig; primary Err + no fallback → error passthrough; primary empty + no fallback → empty-content error naming the URL; primary Err + fallback → fallback rescue.

## Separate commit: de-flake tavily_rotation tests

Two integration tests asserted the absolute key order `[key-a, key-b]`, but `KeyRing` deliberately randomizes its starting offset (stateless load spreading on the per-request HTTP transport) — each failed ~50% of runs on a clean tree. Assertions are now offset-agnostic (two attempts, both known keys, second differs from first), matching the in-module `KeyRing` unit-test style. No production code touched.

## Verification

- `cargo test`: 228 passed / 0 failed; `cargo test --features http`: 242 passed / 0 failed
- `cargo clippy --all-targets -- -D warnings`: clean on both feature sets
- `cargo fmt --check`: changed code clean (remaining diffs are pre-existing on main)
- `tavily_rotation` run 6× consecutively: all green