### PR TITLE
test(tavily): make key-rotation assertions order-independent

### DIFF
--- a/tests/tavily_rotation.rs
+++ b/tests/tavily_rotation.rs
@@ -106,8 +106,12 @@ async fn key_scoped_failure_rotates_to_next_key_and_succeeds() {
         .expect("second key should succeed after 429 on first");
 
     assert_eq!(sources.len(), 1);
+    // The random start offset picks either key first, so assert order-independently:
+    // the 429 must rotate to the *other* key, leaving each key used exactly once.
+    let mut seen = auth_log.lock().expect("auth log lock").clone();
+    seen.sort();
     assert_eq!(
-        *auth_log.lock().expect("auth log lock"),
+        seen,
         vec!["Bearer key-a".to_string(), "Bearer key-b".to_string()],
         "expected the 429 to trigger a retry with the next key"
     );
@@ -157,8 +161,12 @@ async fn successive_requests_round_robin_across_keys() {
             .expect("mock returns 200");
     }
 
+    // Random start offset means either key can go first; assert order-independently
+    // that both keys were each used exactly once (round-robin covered the full ring).
+    let mut seen = auth_log.lock().expect("auth log lock").clone();
+    seen.sort();
     assert_eq!(
-        *auth_log.lock().expect("auth log lock"),
+        seen,
         vec!["Bearer key-a".to_string(), "Bearer key-b".to_string()],
         "two successful requests should consume credits from different keys"
     );


### PR DESCRIPTION
## 问题

`tests/tavily_rotation.rs` 的 `successive_requests_round_robin_across_keys` 与 `key_scoped_failure_rotates_to_next_key_and_succeeds` 约 50% 概率失败(flaky)。

根因:`KeyRing::parse`(`src/providers/tavily.rs`)用 `random_offset(keys.len())` 作为 round-robin cursor 的随机起点——HTTP 传输每请求重建 provider,随机起点用于无状态地分散负载。但这两个测试硬断言首请求用 `key-a`、期望固定顺序 `["Bearer key-a", "Bearer key-b"]`,只有随机起点为偶数(key-a 先发)时才通过。

## 改动

仅改测试断言,**生产随机起点逻辑不动**:将固定顺序断言改为 sort 后集合相等——两次请求记录的 `Authorization` 头排序后必须等于 `["Bearer key-a", "Bearer key-b"]`,即两个 key 各恰好用一次。

- 顺序无关,消除 ~50% flaky;
- 比单纯 `len() == 2` 更强,精准表达 `successive_...` 的「round-robin 覆盖全环」与 `key_scoped_failure_...` 的「429 后轮到另一个 key」真实意图。

## 验证

- `cargo test --features http --test tavily_rotation` **连跑 10 次全绿**,每次 `5 passed; 0 failed`(用例数正确,非空跑)。
- `providers::tavily::key_ring_tests` 单元测试连跑 5 次,每次 `8 passed; 0 failed`——未触及、未受影响。
