### PR TITLE
feat(docker): multi-platform deploy image (amd64/arm64)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,7 @@
 target
+# Pre-built deploy binaries; only Dockerfile.deploy needs them (it has its
+# own Dockerfile.deploy.dockerignore that keeps dist/ in)
+dist
 .git
 .github
 docs

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /target/
+/dist/
 /tmp/
 /logs/
 /.ace-tool/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to GrokSearch-rs are documented here.
 
 ## Unreleased
 
+### Added
+
+- **`Dockerfile.deploy` 多平台镜像(amd64/arm64)。** 运行时镜像按 BuildKit 的
+  `TARGETPLATFORM` 从 `dist/<os>/<arch>/` 选取预编译 musl 二进制;新增
+  `scripts/build-deploy-dist.sh` 用 cargo-zigbuild 一键交叉编译并装配 `dist/`
+  布局,`docker buildx build --platform linux/amd64,linux/arm64` 即可产出多架构
+  镜像,单平台 `docker build` 仍跟随宿主架构(构建上下文由
+  `Dockerfile.deploy.dockerignore` 收敛为仅 `dist/`)。
+
 ## 0.1.20 - 2026-07-21
 
 ### Added

--- a/Dockerfile.deploy
+++ b/Dockerfile.deploy
@@ -1,13 +1,18 @@
 # Runtime-only image: copies a pre-built static musl binary (no in-container
-# compile), so it builds instantly even on a 1 GB box. Build the binary first
-# on a capable machine:
-#   cargo zigbuild --profile release-http --features http --target x86_64-unknown-linux-musl
-# then place target/.../release-http/grok-search-rs next to this file and:
+# compile), so it builds instantly even on a 1 GB box. Cross-compile the
+# binaries first on a capable machine (any host OS/arch):
+#   scripts/build-deploy-dist.sh   # -> dist/linux/{amd64,arm64}/grok-search-rs
+# Build for the host platform:
 #   docker build -f Dockerfile.deploy -t grok-search-rs:deploy .
+# Or emit a multi-platform manifest (push to a registry, or containerd store):
+#   docker buildx build -f Dockerfile.deploy \
+#     --platform linux/amd64,linux/arm64 -t <registry>/grok-search-rs:deploy --push .
 FROM alpine:3.20
 RUN apk add --no-cache ca-certificates \
     && adduser -D -H -s /sbin/nologin grokmcp
-COPY grok-search-rs /usr/local/bin/grok-search-rs
+# BuildKit sets TARGETPLATFORM per output platform (linux/amd64, linux/arm64, ...).
+ARG TARGETPLATFORM
+COPY dist/${TARGETPLATFORM}/grok-search-rs /usr/local/bin/grok-search-rs
 ENV GROK_MCP_BIND=0.0.0.0:8080
 EXPOSE 8080
 USER grokmcp

--- a/Dockerfile.deploy.dockerignore
+++ b/Dockerfile.deploy.dockerignore
@@ -1,0 +1,5 @@
+# Per-Dockerfile ignore file (BuildKit picks it over .dockerignore when
+# building with -f Dockerfile.deploy): the deploy image only COPYs the
+# pre-built binaries, so keep the build context to dist/ alone.
+*
+!dist

--- a/README.md
+++ b/README.md
@@ -250,7 +250,8 @@ GROK_MCP_BIND=127.0.0.1:8080 target/release-http/grok-search-rs --http   # bind 
 ```
 
 Put a TLS‑terminating reverse proxy (e.g. Caddy) in front. The repo ships a `Dockerfile`,
-`Dockerfile.deploy` (runtime‑only, for low‑RAM hosts), `docker-compose.yml`, and `Caddyfile`
+`Dockerfile.deploy` (runtime‑only, multi‑arch `amd64`/`arm64` — cross‑compile the binaries
+first with `scripts/build-deploy-dist.sh`; ideal for low‑RAM hosts), `docker-compose.yml`, and `Caddyfile`
 for a one‑command deploy with automatic HTTPS. Set `MCP_HOSTNAME` (your domain or a
 `<dashed-ip>.sslip.io` name) via the environment or a git‑ignored `.env` — **not** in the
 repo.

--- a/scripts/build-deploy-dist.sh
+++ b/scripts/build-deploy-dist.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Cross-compile the static musl binaries Dockerfile.deploy expects and lay
+# them out as dist/<docker-platform>/grok-search-rs:
+#   dist/linux/amd64/grok-search-rs
+#   dist/linux/arm64/grok-search-rs
+#
+# Usage:
+#   scripts/build-deploy-dist.sh               # every supported platform
+#   scripts/build-deploy-dist.sh linux/arm64   # a subset
+#
+# Requires cargo-zigbuild (cargo install cargo-zigbuild, or brew install cargo-zigbuild).
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT"
+
+if ! command -v cargo-zigbuild >/dev/null 2>&1; then
+  echo "cargo-zigbuild not found; install with: cargo install cargo-zigbuild (or brew install cargo-zigbuild)" >&2
+  exit 69
+fi
+
+rust_target() {
+  case "$1" in
+    linux/amd64) echo "x86_64-unknown-linux-musl" ;;
+    linux/arm64) echo "aarch64-unknown-linux-musl" ;;
+    *) echo "unsupported platform '$1' (supported: linux/amd64 linux/arm64)" >&2; return 64 ;;
+  esac
+}
+
+PLATFORMS=("$@")
+if [[ ${#PLATFORMS[@]} -eq 0 ]]; then
+  PLATFORMS=(linux/amd64 linux/arm64)
+fi
+
+for platform in "${PLATFORMS[@]}"; do
+  target="$(rust_target "$platform")"
+  echo "==> $platform ($target)"
+  rustup target add "$target"
+  cargo zigbuild --profile release-http --features http --target "$target" --locked
+  mkdir -p "dist/$platform"
+  cp "target/$target/release-http/grok-search-rs" "dist/$platform/grok-search-rs"
+done
+
+echo "==> dist/ ready:"
+ls -l dist/*/*/grok-search-rs

--- a/scripts/build-deploy-dist.sh
+++ b/scripts/build-deploy-dist.sh
@@ -39,7 +39,9 @@ for platform in "${PLATFORMS[@]}"; do
   rustup target add "$target"
   cargo zigbuild --profile release-http --features http --target "$target" --locked
   mkdir -p "dist/$platform"
-  cp "target/$target/release-http/grok-search-rs" "dist/$platform/grok-search-rs"
+  # install(1), not cp: pin mode 0755 regardless of umask — docker COPY keeps
+  # the staged mode and the image runs as non-root, so 0700 here bricks it.
+  install -m 0755 "target/$target/release-http/grok-search-rs" "dist/$platform/grok-search-rs"
 done
 
 echo "==> dist/ ready:"


### PR DESCRIPTION
## 背景

`Dockerfile.deploy` 此前只服务 x86_64:注释硬编码 `x86_64-unknown-linux-musl`,镜像假设构建上下文里有单个(x86)预编译二进制,无法产出 ARM 镜像。

## 改动

- **`Dockerfile.deploy` 按 `TARGETPLATFORM` 选取二进制**:`COPY dist/${TARGETPLATFORM}/grok-search-rs`(BuildKit 自动注入,如 `linux/amd64`、`linux/arm64`)。单平台 `docker build` 跟随宿主架构;`docker buildx build --platform linux/amd64,linux/arm64` 产出多架构 manifest。基础镜像 `alpine:3.20` 本身即多架构。
- **新增 `scripts/build-deploy-dist.sh`**:cargo-zigbuild 一键交叉编译两个 musl 目标(`x86_64-`/`aarch64-unknown-linux-musl`,`--profile release-http --features http --locked`)并装配 `dist/linux/{amd64,arm64}/` 布局;支持只传子集(如 `scripts/build-deploy-dist.sh linux/arm64`)。
- **新增 `Dockerfile.deploy.dockerignore`**(BuildKit per-Dockerfile ignore):deploy 构建上下文收敛为仅 `dist/`。
- **`.dockerignore` 排除 `dist`**:避免预编译二进制混进主 `Dockerfile` 的构建上下文并击穿其缓存;**`.gitignore` 排除 `/dist/`**。
- README 部署段落与 CHANGELOG(Unreleased)同步。

## 部署流程变化(la-vps)

二进制在服务器上的落点由「`Dockerfile.deploy` 同级的 `./grok-search-rs`」改为 **`./dist/linux/amd64/grok-search-rs`**,scp 目标路径需相应调整;其余(`docker build -f Dockerfile.deploy`、compose)不变。要求服务器 Docker 走 BuildKit(Docker ≥ 23 默认;la-vps 为新装 Docker CE,满足)。

## 验证

- `scripts/build-deploy-dist.sh` 实跑通过,产出两个平台的静态 musl 二进制。
- `docker build --platform linux/arm64` 与 `--platform linux/amd64` 各自构建成功(per-Dockerfile ignore 生效——否则 `.dockerignore` 已排除 `dist`,COPY 必失败)。
- 两个镜像分别 `docker run --rm <img> --version` 冒烟通过(arm64 原生、amd64 经 Rosetta)。
- `docker buildx build --platform linux/amd64,linux/arm64` 双平台装配通过(临时 docker-container builder;构建日志确认两平台各自 COPY 对应 `dist/` 二进制)。
