### PR TITLE
fix(mcp): stop exposing model/platform in web_search schema (#15)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to GrokSearch-rs are documented here.
 
 ## Unreleased
 
+### Changed
+
+- **MCP `web_search` 不再暴露 `model` / `platform` 入参(#15)。** 此前工具 schema
+  把这两个字段作为无约束的自由字符串开放给调用方 LLM,客户端模型会自行填写——
+  例如把 `model` 填成并不存在的 `grok-4`——从而覆盖运营方在 `GROK_SEARCH_MODEL`
+  配置的默认模型,并把无效模型名透传给上游。现在 schema 不再声明这两个参数、
+  服务端也忽略任何传入值:Grok 模型只由运营方配置(`GROK_SEARCH_MODEL`)或按
+  请求的 `X-Grok-Model` 头决定,不再受调用方 AI 影响;focus platform 同理不再
+  由 AI 指定。
+
 ## 0.1.20 - 2026-07-21
 
 ### Added

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -140,14 +140,15 @@ async fn call_tool(service: &SearchService, name: &str, args: Value) -> Result<V
             })?;
             let input = WebSearchInput {
                 query: query.to_string(),
-                platform: args
-                    .get("platform")
-                    .and_then(Value::as_str)
-                    .map(str::to_string),
-                model: args
-                    .get("model")
-                    .and_then(Value::as_str)
-                    .map(str::to_string),
+                // model/platform are intentionally NOT read from tool input: the
+                // calling client's LLM must not choose the Grok model or focus
+                // platform (issue #15) — it hallucinates names like `grok-4` that
+                // override the operator's configured model. The model is fixed by
+                // config (GROK_SEARCH_MODEL) or the per-request X-Grok-Model
+                // header; leaving these None routes through the default in
+                // build_search_request.
+                platform: None,
+                model: None,
                 extra_sources: args
                     .get("extra_sources")
                     .and_then(Value::as_u64)
@@ -236,8 +237,6 @@ fn tools_list() -> Value {
                     "required": ["query"],
                     "properties": {
                         "query": { "type": "string" },
-                        "platform": { "type": "string" },
-                        "model": { "type": "string" },
                         "extra_sources": {
                             "type": "integer",
                             "minimum": 0,
@@ -545,6 +544,38 @@ mod tests {
         assert!(
             get_sources.contains("new search"),
             "get_sources: {get_sources}"
+        );
+    }
+
+    #[test]
+    fn web_search_schema_hides_model_and_platform() {
+        // issue #15: the calling client's LLM must not be offered `model` or
+        // `platform` — it fills them with hallucinated values (e.g. `grok-4`)
+        // that override the operator's configured model. The schema must not
+        // advertise them, so the client never learns they exist.
+        let listed = tools_list();
+        let tools = listed["tools"].as_array().expect("tools array");
+        let web_search = tools
+            .iter()
+            .find(|t| t["name"] == "web_search")
+            .expect("web_search tool present");
+        let props = web_search["inputSchema"]["properties"]
+            .as_object()
+            .expect("web_search inputSchema.properties object");
+
+        assert!(
+            !props.contains_key("model"),
+            "web_search must not expose `model`: {props:?}"
+        );
+        assert!(
+            !props.contains_key("platform"),
+            "web_search must not expose `platform`: {props:?}"
+        );
+        // Guard against an over-broad deletion: the real parameters stay.
+        assert!(props.contains_key("query"), "query must remain: {props:?}");
+        assert!(
+            props.contains_key("response_format"),
+            "response_format must remain: {props:?}"
         );
     }
 }


### PR DESCRIPTION
## 背景 / Issue

[#15](https://github.com/Episkey-G/GrokSearch-rs/issues/15):调用方(如 `5.6-sol`)调用 MCP `web_search` 时,其 LLM 会自行给 `model` 栏填入并不存在的 `grok-4`,而不是运营方配置的模型;`platform` 同理——运营方已定好,不该由 AI 填写。

## 根因

`web_search` 的 `inputSchema` 把 `model` / `platform` 作为**无约束的裸字符串**开放给调用方 LLM(无 `description`、无 `enum`、无默认值提示),而服务端在 `build_search_request` 里 `input.model` **无条件覆盖** `default_model` 且**零校验**——AI 一旦幻觉出 `grok-4`,就直接把无效模型名透传上游、盖掉运营方 `GROK_SEARCH_MODEL`。

> 注:当前版本 `platform` 其实**没有**任何环境变量默认(`Config` 无该字段),它纯粹是 per-call 参数;issue 里"已在变量设置过"属误解。但结论一致:不该让 AI 自由填。

## 改动(方案:从 schema 移除)

- `tools_list()`:删除 `web_search` schema 里的 `model` / `platform` 两个属性 → 调用方 LLM 不再"看到"它们。
- `call_tool()`:`web_search` 分支硬编码 `platform: None, model: None` → 即使旧客户端仍在 body 里塞值也被忽略。
- 保留 `WebSearchInput.model/platform` 字段与 `build_search_request` 覆盖逻辑不变(供 HTTP 头路径复用)。

## 不影响 `X-Grok-Model`(#18)

HTTP 层的 `X-Grok-Model` 头经 `HEADER_TO_ENV` 映射为 `GROK_SEARCH_MODEL` 环境变量 → per-request `Config` → `default_model`,与 `WebSearchInput.model` **正交**。改动后三条路径归属清晰:

| 来源 | 改动后行为 |
| - | - |
| AI 在 tool body 填 `model` | **忽略**(本次修复) |
| 调用方显式 `X-Grok-Model` 头 | **生效**(保留 #18) |
| 都没填 | 运营方默认 `GROK_SEARCH_MODEL` |

## 验证

- `cargo test --lib`:**104 passed, 0 failed**(含新增回归测试 `web_search_schema_hides_model_and_platform`)。
- `cargo clippy --lib --tests`:clean。
- 改动文件 `rustfmt` clean。

Fixes #15
