### PR TITLE
fix(service): backfill source title/published_date at enrichment time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to GrokSearch-rs are documented here.
 
 ## Unreleased
 
+### Fixed
+
+- **`grok_responses` 来源的 `title`/`published_date` 不再几乎恒为 null(#21)。**
+  多数 Grok 引文以裸 URL 或内联 `[[n]](url)` 形式到达,结构上不携带元数据;
+  少数结构化 annotation 甚至把引文序号("1"、"2")当作 title。现在解析层拒收
+  纯数字/单字符的垃圾 title,enrichment 阶段在抓取正文的同时回填缺失元数据:
+  title 优先取源提供商的结构化字段(Tavily extract 的 `title`、Firecrawl 的
+  `metadata.title`),否则回退到正文首个 Markdown 标题;published_date 仅在
+  提供商返回时回填(Firecrawl `publishedTime` / `article:published_time`)。
+  只回填 None 字段,上游真实元数据永不覆盖;抓取失败与未 enrich 的尾部来源
+  保持诚实的 null。`SourceProvider::fetch` 相应改为返回结构化 `FetchedPage`
+  (content + title + published_date),`web_fetch` 行为不变。
+
 ### Added
 
 - **`Dockerfile.deploy` 多平台镜像(amd64/arm64)。** 运行时镜像按 BuildKit 的

--- a/src/adapters/grok_responses_response.rs
+++ b/src/adapters/grok_responses_response.rs
@@ -90,7 +90,14 @@ fn collect_one_source(item: &Value, sources: &mut Vec<Source>) {
     };
 
     let mut source = Source::new(url, "grok_responses");
-    if let Some(title) = item.get("title").and_then(Value::as_str) {
+    // Junk guard (issue #21): live api.x.ai annotations carry the citation
+    // index as the title ("1", "2"). Dropping them here keeps the field None
+    // so enrichment-time backfill is allowed to fill in a real title later.
+    if let Some(title) = item
+        .get("title")
+        .and_then(Value::as_str)
+        .filter(|title| !crate::model::source::is_junk_title(title))
+    {
         source = source.with_title(title);
     }
     if let Some(description) = item

--- a/src/model/source.rs
+++ b/src/model/source.rs
@@ -44,6 +44,36 @@ impl Source {
     }
 }
 
+/// A fetched page from a generic source provider: markdown content plus any
+/// structured metadata the provider returned alongside it. Metadata fields are
+/// best-effort — `None` whenever the provider response lacks them (Tavily
+/// extract carries a title but no date; Firecrawl scrape carries both).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FetchedPage {
+    pub content: String,
+    pub title: Option<String>,
+    pub published_date: Option<String>,
+}
+
+impl FetchedPage {
+    /// A page with content only — for providers/paths with no metadata.
+    pub fn text(content: impl Into<String>) -> Self {
+        Self {
+            content: content.into(),
+            title: None,
+            published_date: None,
+        }
+    }
+}
+
+/// Upstream annotation payloads have been observed carrying the citation index
+/// as the title (`"1"`, `"2"` — issue #21); single characters and purely
+/// numeric strings are those artifacts, never real page titles.
+pub fn is_junk_title(title: &str) -> bool {
+    let trimmed = title.trim();
+    trimmed.chars().count() <= 1 || trimmed.chars().all(|c| c.is_ascii_digit())
+}
+
 pub fn merge_sources(primary: Vec<Source>, secondary: Vec<Source>) -> Vec<Source> {
     let mut seen = HashSet::new();
     let mut merged = Vec::new();

--- a/src/providers/firecrawl.rs
+++ b/src/providers/firecrawl.rs
@@ -1,5 +1,5 @@
 use crate::error::{GrokSearchError, Result};
-use crate::model::source::Source;
+use crate::model::source::{FetchedPage, Source};
 use crate::providers::http::{build_client, post_json};
 use reqwest::Client;
 use serde_json::{json, Value};
@@ -38,28 +38,59 @@ impl FirecrawlProvider {
         Ok(normalize_firecrawl_results(&raw))
     }
 
-    pub async fn scrape(&self, url: &str) -> Result<String> {
+    pub async fn scrape(&self, url: &str) -> Result<FetchedPage> {
         let raw = self
             .post("scrape", &json!({ "url": url, "formats": ["markdown"] }))
             .await?;
-        let content = raw
-            .get("data")
-            .and_then(|data| data.get("markdown").or_else(|| data.get("content")))
-            .or_else(|| raw.get("markdown"))
-            .or_else(|| raw.get("content"))
-            .and_then(Value::as_str)
-            .map(str::to_string)
-            .filter(|text| !text.trim().is_empty());
-
-        content.ok_or_else(|| {
-            GrokSearchError::Provider("Firecrawl scrape returned empty content".to_string())
-        })
+        parse_firecrawl_scrape(&raw)
     }
 
     async fn post(&self, path: &str, body: &Value) -> Result<Value> {
         let endpoint = format!("{}/{}", self.api_url, path.trim_start_matches('/'));
         post_json(&self.client, &endpoint, &self.api_key, body, "Firecrawl").await
     }
+}
+
+/// Parse a Firecrawl scrape response into content + metadata. Scrape responses
+/// carry a rich `metadata` object (`title`, `publishedTime`,
+/// `article:published_time`, OG tags, …) next to the markdown; both the
+/// wrapped (`data.markdown`) and flat (`markdown`) response shapes are
+/// accepted, mirroring the content lookup.
+pub fn parse_firecrawl_scrape(raw: &Value) -> Result<FetchedPage> {
+    let content = raw
+        .get("data")
+        .and_then(|data| data.get("markdown").or_else(|| data.get("content")))
+        .or_else(|| raw.get("markdown"))
+        .or_else(|| raw.get("content"))
+        .and_then(Value::as_str)
+        .map(str::to_string)
+        .filter(|text| !text.trim().is_empty());
+
+    let Some(content) = content else {
+        return Err(GrokSearchError::Provider(
+            "Firecrawl scrape returned empty content".to_string(),
+        ));
+    };
+    let metadata = raw
+        .get("data")
+        .and_then(|data| data.get("metadata"))
+        .or_else(|| raw.get("metadata"));
+    let non_empty = |value: Option<&Value>| {
+        value
+            .and_then(Value::as_str)
+            .map(str::to_string)
+            .filter(|text| !text.trim().is_empty())
+    };
+    let title = non_empty(metadata.and_then(|m| m.get("title")));
+    let published_date = non_empty(metadata.and_then(|m| {
+        m.get("publishedTime")
+            .or_else(|| m.get("article:published_time"))
+    }));
+    Ok(FetchedPage {
+        content,
+        title,
+        published_date,
+    })
 }
 
 pub fn normalize_firecrawl_results(raw: &Value) -> Vec<Source> {

--- a/src/providers/tavily.rs
+++ b/src/providers/tavily.rs
@@ -1,6 +1,6 @@
 use crate::error::Result;
 use crate::model::search::SearchFilters;
-use crate::model::source::Source;
+use crate::model::source::{FetchedPage, Source};
 use crate::providers::http::{build_client, post_json_with_status};
 use reqwest::Client;
 use serde_json::{json, Value};
@@ -129,22 +129,11 @@ impl TavilyProvider {
         Ok(normalize_tavily_results(&raw))
     }
 
-    pub async fn extract(&self, url: &str) -> Result<String> {
+    pub async fn extract(&self, url: &str) -> Result<FetchedPage> {
         let raw = self
             .post("extract", &json!({ "urls": [url], "format": "markdown" }))
             .await?;
-        let extracted = raw
-            .get("results")
-            .and_then(Value::as_array)
-            .and_then(|items| items.first())
-            .and_then(|item| item.get("raw_content").or_else(|| item.get("content")))
-            .and_then(Value::as_str)
-            .map(str::to_string)
-            .filter(|text| !text.trim().is_empty());
-
-        extracted.ok_or_else(|| {
-            GrokSearchError::Provider("Tavily extract returned empty content".to_string())
-        })
+        parse_tavily_extract(&raw)
     }
 
     pub async fn map(&self, url: &str, max_results: usize) -> Result<Vec<Source>> {
@@ -237,6 +226,38 @@ pub fn tavily_map_request_body(url: &str, max_results: usize) -> Value {
 pub fn limit_tavily_results(mut sources: Vec<Source>, max_results: usize) -> Vec<Source> {
     sources.truncate(max_results);
     sources
+}
+
+/// Parse a Tavily extract response into content + metadata. The extract
+/// endpoint returns `title` alongside `raw_content` (verified live; the docs'
+/// sample response omits it) but no published-date field, so `published_date`
+/// is always `None` here.
+pub fn parse_tavily_extract(raw: &Value) -> Result<FetchedPage> {
+    let result = raw
+        .get("results")
+        .and_then(Value::as_array)
+        .and_then(|items| items.first());
+    let content = result
+        .and_then(|item| item.get("raw_content").or_else(|| item.get("content")))
+        .and_then(Value::as_str)
+        .map(str::to_string)
+        .filter(|text| !text.trim().is_empty());
+
+    let Some(content) = content else {
+        return Err(GrokSearchError::Provider(
+            "Tavily extract returned empty content".to_string(),
+        ));
+    };
+    let title = result
+        .and_then(|item| item.get("title"))
+        .and_then(Value::as_str)
+        .map(str::to_string)
+        .filter(|text| !text.trim().is_empty());
+    Ok(FetchedPage {
+        content,
+        title,
+        published_date: None,
+    })
 }
 
 pub fn normalize_tavily_results(raw: &Value) -> Vec<Source> {

--- a/src/service.rs
+++ b/src/service.rs
@@ -11,7 +11,7 @@ use crate::error::{GrokSearchError, Result};
 use crate::model::search::{
     ContentBlock, SearchFilters, SearchMessage, SearchRequest, SearchResponse, SearchTool,
 };
-use crate::model::source::{merge_sources, Source};
+use crate::model::source::{is_junk_title, merge_sources, FetchedPage, Source};
 use crate::model::tool::{GetSourcesOutput, WebFetchOutput, WebSearchInput, WebSearchOutput};
 use crate::providers::firecrawl::FirecrawlProvider;
 use crate::providers::grok::GrokResponsesProvider;
@@ -30,7 +30,7 @@ pub trait SourceProvider: Send + Sync {
         max_results: usize,
         filters: &SearchFilters,
     ) -> Result<Vec<Source>>;
-    async fn fetch(&self, url: &str) -> Result<String>;
+    async fn fetch(&self, url: &str) -> Result<FetchedPage>;
     async fn map(&self, url: &str, max_results: usize) -> Result<Vec<Source>>;
 }
 
@@ -59,7 +59,7 @@ impl SourceProvider for TavilyProvider {
         self.search(query, max_results, filters).await
     }
 
-    async fn fetch(&self, url: &str) -> Result<String> {
+    async fn fetch(&self, url: &str) -> Result<FetchedPage> {
         self.extract(url).await
     }
 
@@ -80,7 +80,7 @@ impl SourceProvider for FirecrawlProvider {
         FirecrawlProvider::search(self, query, max_results).await
     }
 
-    async fn fetch(&self, url: &str) -> Result<String> {
+    async fn fetch(&self, url: &str) -> Result<FetchedPage> {
         FirecrawlProvider::scrape(self, url).await
     }
 
@@ -781,7 +781,9 @@ impl SearchService {
     }
 
     async fn web_fetch_raw(&self, url: &str) -> Result<String> {
-        generic_source_fetch(&self.sources, &self.fallback_sources, url).await
+        generic_source_fetch(&self.sources, &self.fallback_sources, url)
+            .await
+            .map(|page| page.content)
     }
 
     pub async fn web_map(&self, url: &str, max_results: usize) -> Result<Vec<Source>> {
@@ -1074,10 +1076,10 @@ async fn generic_source_fetch(
     primary: &Option<Arc<dyn SourceProvider>>,
     fallback: &Option<Arc<dyn SourceProvider>>,
     url: &str,
-) -> Result<String> {
+) -> Result<FetchedPage> {
     let primary_err = match primary {
         Some(provider) => match provider.fetch(url).await {
-            Ok(content) if !content.trim().is_empty() => return Ok(content),
+            Ok(page) if !page.content.trim().is_empty() => return Ok(page),
             Ok(_) => GrokSearchError::Provider(format!("Tavily returned empty content for {url}")),
             Err(err) => err,
         },
@@ -1089,6 +1091,77 @@ async fn generic_source_fetch(
     }
 }
 
+/// One enrichment outcome: the content to store plus any metadata backfill
+/// harvested from the fetched page. Failure notes never carry metadata.
+struct EnrichedFetch {
+    content: Option<String>,
+    title: Option<String>,
+    published_date: Option<String>,
+}
+
+impl EnrichedFetch {
+    /// A deterministic failure note stored as content — never a title source.
+    fn note(note: String) -> Self {
+        Self {
+            content: Some(note),
+            title: None,
+            published_date: None,
+        }
+    }
+
+    /// Specialist markdown: heading fallback only (specialist extractors
+    /// return no structured metadata). Heading extraction runs before
+    /// truncation so a tight `max_chars` cannot cut the title line in half.
+    fn from_markdown(md: String, max_chars: usize) -> Self {
+        let title = first_markdown_heading(&md);
+        Self {
+            content: Some(md.chars().take(max_chars).collect()),
+            title,
+            published_date: None,
+        }
+    }
+
+    /// Generic provider page: provider metadata first, heading as fallback.
+    fn from_page(page: FetchedPage, max_chars: usize) -> Self {
+        let title = page
+            .title
+            .filter(|title| !is_junk_title(title))
+            .or_else(|| first_markdown_heading(&page.content));
+        Self {
+            content: Some(page.content.chars().take(max_chars).collect()),
+            title,
+            published_date: page.published_date,
+        }
+    }
+}
+
+/// Headings longer than this are prose that happens to start with `#`, not a
+/// plausible page title.
+const MAX_HEADING_TITLE_CHARS: usize = 200;
+
+/// First ATX heading (`# ` … `###### `) in the fetched markdown, as a
+/// title-of-last-resort for sources whose provider returned none. Only the
+/// first heading is considered — if it is junk or oversized, guessing a later
+/// section heading would mislabel the page, so the title stays `None`.
+fn first_markdown_heading(markdown: &str) -> Option<String> {
+    let heading = markdown.lines().find_map(|line| {
+        let trimmed = line.trim_start();
+        let hashes = trimmed.chars().take_while(|&c| c == '#').count();
+        if hashes == 0 || hashes > 6 {
+            return None;
+        }
+        // ATX requires whitespace after the marker run; "#hashtag" is prose.
+        let rest = &trimmed[hashes..];
+        if !rest.starts_with(char::is_whitespace) {
+            return None;
+        }
+        let text = rest.trim();
+        (!text.is_empty()).then(|| text.to_string())
+    })?;
+    (heading.chars().count() <= MAX_HEADING_TITLE_CHARS && !is_junk_title(&heading))
+        .then_some(heading)
+}
+
 /// Concurrently back-fill `Source.content` for the first `max_sources` sources
 /// via the Phase 1 `resolve_content` pipeline; later sources stay
 /// metadata-only (content = None) so a Grok response with dozens of citations
@@ -1098,7 +1171,8 @@ async fn generic_source_fetch(
 /// ends with `content = Some(..)` — real markdown (truncated to `max_chars`)
 /// on success, or a deterministic `_Failed to retrieve: ..._` note on any
 /// failure/timeout/invalid-url (D-05 within the inline window: never None,
-/// never empty). Source order is preserved.
+/// never empty). Source order is preserved. While content is in hand, missing
+/// `title`/`published_date` are back-filled from the fetched page (issue #21).
 #[allow(clippy::too_many_arguments)]
 async fn enrich_sources(
     sources: Vec<Source>,
@@ -1113,7 +1187,7 @@ async fn enrich_sources(
     fallback: Option<Arc<dyn SourceProvider>>,
 ) -> Vec<Source> {
     let sem = Arc::new(tokio::sync::Semaphore::new(concurrency));
-    let mut set: tokio::task::JoinSet<(usize, Option<String>)> = tokio::task::JoinSet::new();
+    let mut set: tokio::task::JoinSet<(usize, EnrichedFetch)> = tokio::task::JoinSet::new();
 
     for (idx, source) in sources.iter().enumerate().take(max_sources) {
         let permit = Arc::clone(&sem);
@@ -1128,17 +1202,14 @@ async fn enrich_sources(
             // acquire is micro-second scale for concurrency<=5; deadline
             // enforcement applies to the resolve_content call itself.
             let _permit = permit.acquire_owned().await.ok();
-            let content = match url::Url::parse(&url_str) {
-                Err(_) => Some(format!(
+            let fetched = match url::Url::parse(&url_str) {
+                Err(_) => EnrichedFetch::note(format!(
                     "_Failed to retrieve: invalid_url_\n\nSource: {url_str}"
                 )),
                 Ok(parsed) => {
                     let future = crate::sources::resolve_content(&client, &parsed, &router, &caps);
                     match tokio::time::timeout_at(deadline, future).await {
-                        Ok(Ok((md, _kind))) => {
-                            let truncated: String = md.chars().take(max_chars).collect();
-                            Some(truncated)
-                        }
+                        Ok(Ok((md, _kind))) => EnrichedFetch::from_markdown(md, max_chars),
                         // Specialist produced no content — either no specialist
                         // matched (generic URL) OR a matched specialist's API
                         // failed/rate-limited/rendered empty. Either way, mirror
@@ -1150,29 +1221,26 @@ async fn enrich_sources(
                         Ok(Err(reason)) => {
                             let generic = generic_source_fetch(&primary, &fallback, &url_str);
                             match tokio::time::timeout_at(deadline, generic).await {
-                                Ok(Ok(md)) => {
-                                    let truncated: String = md.chars().take(max_chars).collect();
-                                    Some(truncated)
-                                }
-                                Ok(Err(_)) => Some(format!(
+                                Ok(Ok(page)) => EnrichedFetch::from_page(page, max_chars),
+                                Ok(Err(_)) => EnrichedFetch::note(format!(
                                     "_Failed to retrieve: {reason}_\n\nSource: {url_str}"
                                 )),
-                                Err(_elapsed) => Some(format!(
+                                Err(_elapsed) => EnrichedFetch::note(format!(
                                     "_Failed to retrieve: timeout_\n\nSource: {url_str}"
                                 )),
                             }
                         }
-                        Err(_elapsed) => Some(format!(
+                        Err(_elapsed) => EnrichedFetch::note(format!(
                             "_Failed to retrieve: timeout_\n\nSource: {url_str}"
                         )),
                     }
                 }
             };
-            (idx, content)
+            (idx, fetched)
         });
     }
 
-    let mut results: Vec<(usize, Option<String>)> = Vec::with_capacity(sources.len());
+    let mut results: Vec<(usize, EnrichedFetch)> = Vec::with_capacity(sources.len());
     while let Some(res) = set.join_next().await {
         if let Ok(pair) = res {
             results.push(pair);
@@ -1181,8 +1249,19 @@ async fn enrich_sources(
 
     results.sort_by_key(|(idx, _)| *idx);
     let mut out = sources;
-    for (idx, content) in results {
-        out[idx].content = content;
+    for (idx, fetched) in results {
+        let source = &mut out[idx];
+        source.content = fetched.content;
+        // Metadata backfill (issue #21): most Grok citations arrive as bare
+        // URLs, so the fetched page is the only place a title/date can come
+        // from. Fill only what upstream never provided — real upstream
+        // metadata always wins, and un-enriched tail sources keep honest nulls.
+        if source.title.is_none() {
+            source.title = fetched.title;
+        }
+        if source.published_date.is_none() {
+            source.published_date = fetched.published_date;
+        }
     }
     out
 }
@@ -1363,8 +1442,8 @@ impl SourceProvider for FakeSourceProvider {
             .collect())
     }
 
-    async fn fetch(&self, url: &str) -> Result<String> {
-        Ok(format!("Fetched content from {url}"))
+    async fn fetch(&self, url: &str) -> Result<FetchedPage> {
+        Ok(FetchedPage::text(format!("Fetched content from {url}")))
     }
 
     async fn map(&self, url: &str, max_results: usize) -> Result<Vec<Source>> {
@@ -1676,7 +1755,7 @@ mod enrich_tests {
                 .map(|idx| Source::new(format!("https://example.com/source-{idx}"), "tavily"))
                 .collect())
         }
-        async fn fetch(&self, _url: &str) -> Result<String> {
+        async fn fetch(&self, _url: &str) -> Result<FetchedPage> {
             Err(crate::error::GrokSearchError::Provider(
                 "generic fetch unavailable".to_string(),
             ))
@@ -1699,8 +1778,8 @@ mod enrich_tests {
         ) -> Result<Vec<Source>> {
             Ok(Vec::new())
         }
-        async fn fetch(&self, _url: &str) -> Result<String> {
-            Ok("  \n".to_string())
+        async fn fetch(&self, _url: &str) -> Result<FetchedPage> {
+            Ok(FetchedPage::text("  \n"))
         }
         async fn map(&self, _url: &str, _max_results: usize) -> Result<Vec<Source>> {
             Ok(Vec::new())
@@ -1967,12 +2046,13 @@ mod enrich_tests {
     async fn generic_fetch_primary_failure_still_rescued_by_fallback() {
         let primary: Option<Arc<dyn SourceProvider>> = Some(Arc::new(SearchOkFetchErrProvider));
         let fallback: Option<Arc<dyn SourceProvider>> = Some(Arc::new(FakeSourceProvider));
-        let content = generic_source_fetch(&primary, &fallback, "https://example.com")
+        let page = generic_source_fetch(&primary, &fallback, "https://example.com")
             .await
             .expect("fallback must rescue primary failure");
         assert!(
-            content.starts_with("Fetched content from"),
-            "fallback content expected, got: {content:?}"
+            page.content.starts_with("Fetched content from"),
+            "fallback content expected, got: {:?}",
+            page.content
         );
     }
 
@@ -2070,6 +2150,203 @@ mod enrich_tests {
             );
         }
     }
+
+    /// Always-matching extractor returning markdown with a leading heading.
+    struct HeadingExtractor {
+        markdown: &'static str,
+    }
+    #[async_trait]
+    impl SourceExtractor for HeadingExtractor {
+        fn matches(&self, _url: &Url) -> bool {
+            true
+        }
+        fn kind(&self) -> SourceType {
+            SourceType::Wikipedia
+        }
+        async fn fetch_render(
+            &self,
+            _c: &reqwest::Client,
+            _u: &Url,
+            _caps: &SourceCaps,
+        ) -> Result<String> {
+            Ok(self.markdown.to_string())
+        }
+    }
+
+    /// Generic provider whose fetch returns a page with full metadata.
+    struct MetaFetchProvider;
+    #[async_trait]
+    impl SourceProvider for MetaFetchProvider {
+        async fn search_sources(
+            &self,
+            _query: &str,
+            _max_results: usize,
+            _filters: &SearchFilters,
+        ) -> Result<Vec<Source>> {
+            Ok(Vec::new())
+        }
+        async fn fetch(&self, _url: &str) -> Result<FetchedPage> {
+            Ok(FetchedPage {
+                content: "Page body.".to_string(),
+                title: Some("Provider Title".to_string()),
+                published_date: Some("2026-06-19T06:15:24-08:00".to_string()),
+            })
+        }
+        async fn map(&self, _url: &str, _max_results: usize) -> Result<Vec<Source>> {
+            Ok(Vec::new())
+        }
+    }
+
+    /// Drive enrich_sources directly with a permissive deadline/caps so the
+    /// backfill rules can be asserted without a full web_search round-trip.
+    async fn run_enrich(
+        sources: Vec<Source>,
+        router: SourceRouter,
+        primary: Option<Arc<dyn SourceProvider>>,
+        max_sources: usize,
+    ) -> Vec<Source> {
+        enrich_sources(
+            sources,
+            tokio::time::Instant::now() + Duration::from_secs(30),
+            &crate::providers::http::build_client(Duration::from_secs(5)),
+            &Arc::new(router),
+            SourceCaps {
+                max_answers: 3,
+                max_comments: 3,
+            },
+            4,
+            15_000,
+            max_sources,
+            primary,
+            None,
+        )
+        .await
+    }
+
+    fn bare_source(url: &str) -> Source {
+        Source::new(url, "grok_responses")
+    }
+
+    #[tokio::test]
+    async fn backfill_title_from_specialist_heading() {
+        let router = SourceRouter::with_extractors(vec![Box::new(HeadingExtractor {
+            markdown: "# Real Title\n\nBody text.",
+        })]);
+        let out = run_enrich(vec![bare_source("https://example.com/a")], router, None, 5).await;
+
+        assert_eq!(out[0].title.as_deref(), Some("Real Title"));
+        assert_eq!(out[0].published_date, None, "specialists carry no date");
+    }
+
+    #[tokio::test]
+    async fn backfill_metadata_from_generic_provider() {
+        // Empty router → no specialist matches → generic provider fetch path.
+        let out = run_enrich(
+            vec![bare_source("https://example.com/a")],
+            SourceRouter::with_extractors(Vec::new()),
+            Some(Arc::new(MetaFetchProvider)),
+            5,
+        )
+        .await;
+
+        assert_eq!(out[0].title.as_deref(), Some("Provider Title"));
+        assert_eq!(
+            out[0].published_date.as_deref(),
+            Some("2026-06-19T06:15:24-08:00")
+        );
+    }
+
+    #[tokio::test]
+    async fn backfill_never_overwrites_upstream_metadata() {
+        let source = bare_source("https://example.com/a")
+            .with_title("Upstream Title")
+            .with_published_date("2020-01-01");
+        let out = run_enrich(
+            vec![source],
+            SourceRouter::with_extractors(Vec::new()),
+            Some(Arc::new(MetaFetchProvider)),
+            5,
+        )
+        .await;
+
+        assert_eq!(out[0].title.as_deref(), Some("Upstream Title"));
+        assert_eq!(out[0].published_date.as_deref(), Some("2020-01-01"));
+    }
+
+    #[tokio::test]
+    async fn backfill_skipped_on_failed_fetch() {
+        // No specialist + failing generic fetch → failure note, no metadata.
+        let out = run_enrich(
+            vec![bare_source("https://example.com/a")],
+            SourceRouter::with_extractors(Vec::new()),
+            Some(Arc::new(SearchOkFetchErrProvider)),
+            5,
+        )
+        .await;
+
+        assert!(out[0]
+            .content
+            .as_deref()
+            .unwrap_or("")
+            .starts_with("_Failed to retrieve:"));
+        assert_eq!(out[0].title, None, "failure notes must not become titles");
+        assert_eq!(out[0].published_date, None);
+    }
+
+    #[tokio::test]
+    async fn backfill_rejects_junk_heading() {
+        // First heading is a citation-index artifact — no guessing from later
+        // section headings either.
+        let router = SourceRouter::with_extractors(vec![Box::new(HeadingExtractor {
+            markdown: "# 1\n\n## Real Section\n\nBody.",
+        })]);
+        let out = run_enrich(vec![bare_source("https://example.com/a")], router, None, 5).await;
+
+        assert_eq!(out[0].title, None);
+    }
+
+    #[tokio::test]
+    async fn backfill_leaves_tail_beyond_window_untouched() {
+        let router = SourceRouter::with_extractors(vec![Box::new(HeadingExtractor {
+            markdown: "# Real Title\n\nBody.",
+        })]);
+        let sources = vec![
+            bare_source("https://example.com/a"),
+            bare_source("https://example.com/b"),
+        ];
+        let out = run_enrich(sources, router, None, 1).await;
+
+        assert_eq!(out[0].title.as_deref(), Some("Real Title"));
+        assert_eq!(out[1].title, None, "un-enriched tail keeps honest nulls");
+        assert_eq!(out[1].content, None);
+    }
+
+    #[test]
+    fn first_markdown_heading_extracts_and_rejects() {
+        assert_eq!(
+            first_markdown_heading("# Title Line\nbody"),
+            Some("Title Line".to_string())
+        );
+        assert_eq!(
+            first_markdown_heading("prose first\n\n## Section Two\n"),
+            Some("Section Two".to_string()),
+            "first heading may appear after prose"
+        );
+        assert_eq!(first_markdown_heading("no headings at all"), None);
+        assert_eq!(
+            first_markdown_heading("#hashtag is prose"),
+            None,
+            "ATX heading requires whitespace after the marker"
+        );
+        assert_eq!(first_markdown_heading("####### seven hashes"), None);
+        assert_eq!(
+            first_markdown_heading("# 1\n\n# Real"),
+            None,
+            "junk first heading must not fall through to later ones"
+        );
+        let oversized = format!("# {}", "x".repeat(MAX_HEADING_TITLE_CHARS + 1));
+        assert_eq!(first_markdown_heading(&oversized), None);
+    }
 }
 
 #[cfg(test)]
@@ -2134,10 +2411,10 @@ mod request_scope_tests {
             )]))
             .expect("same-tenant scoped service");
         // Seed under the tenant-namespaced key, as web_search would.
-        same.cache
-            .lock()
-            .await
-            .set(same.tenant_cache_key(session), Arc::new(Vec::<Source>::new()));
+        same.cache.lock().await.set(
+            same.tenant_cache_key(session),
+            Arc::new(Vec::<Source>::new()),
+        );
         assert!(
             same.get_sources(session, 0, None).await.is_ok(),
             "same tenant must read its own cached session"
@@ -2145,10 +2422,7 @@ mod request_scope_tests {
 
         // A different caller key must NOT read that session.
         let other = svc
-            .with_config(Config::from_env_map([(
-                "GROK_SEARCH_API_KEY",
-                "xai-other",
-            )]))
+            .with_config(Config::from_env_map([("GROK_SEARCH_API_KEY", "xai-other")]))
             .expect("other-tenant scoped service");
         assert!(
             other.get_sources(session, 0, None).await.is_err(),

--- a/tests/adapter_grok_responses.rs
+++ b/tests/adapter_grok_responses.rs
@@ -90,6 +90,50 @@ fn parses_grok_responses_text_annotations_and_search_call_sources() {
         .any(|source| source.url == "https://platform.openai.com/docs"));
 }
 
+// Live api.x.ai annotation objects have been observed carrying the citation
+// index as the title ("1", "2" — issue #21). Those must be rejected at parse
+// time so the field stays None and enrichment-time backfill can supply a real
+// title; genuine titles must keep flowing through untouched.
+#[test]
+fn rejects_citation_index_titles_keeps_real_ones() {
+    let raw = serde_json::json!({
+        "output": [
+            {
+                "type": "web_search_call",
+                "action": {
+                    "sources": [
+                        {"url": "https://example.com/a", "title": "1"},
+                        {"url": "https://example.com/b", "title": "42"},
+                        {"url": "https://example.com/c", "title": "x"},
+                        {"url": "https://example.com/d", "title": " Real Page Title "}
+                    ]
+                }
+            }
+        ],
+        "output_text": "answer"
+    });
+
+    let parsed = parse_grok_responses(&raw).expect("parsed");
+
+    let title_of = |url: &str| {
+        parsed
+            .sources
+            .iter()
+            .find(|s| s.url == url)
+            .expect("source present")
+            .title
+            .clone()
+    };
+    assert_eq!(title_of("https://example.com/a"), None, "numeric index");
+    assert_eq!(title_of("https://example.com/b"), None, "multi-digit index");
+    assert_eq!(title_of("https://example.com/c"), None, "single char");
+    assert_eq!(
+        title_of("https://example.com/d"),
+        Some(" Real Page Title ".to_string()),
+        "real titles must pass through unchanged"
+    );
+}
+
 #[test]
 fn parses_output_text_fallback() {
     let raw = serde_json::json!({

--- a/tests/firecrawl_parse.rs
+++ b/tests/firecrawl_parse.rs
@@ -1,0 +1,71 @@
+use grok_search_rs::providers::firecrawl::parse_firecrawl_scrape;
+
+// Firecrawl scrape responses carry a rich `data.metadata` object next to the
+// markdown (`title`, `publishedTime`, `article:published_time`, OG tags, …
+// verified live against api.firecrawl.dev). Title and published date must
+// survive parsing so enrichment-time backfill (issue #21) can use them.
+#[test]
+fn scrape_parses_content_title_and_published_time() {
+    let raw = serde_json::json!({
+        "success": true,
+        "data": {
+            "markdown": "# Post\n\nBody.",
+            "metadata": {
+                "title": "Post Title | Site",
+                "publishedTime": "2026-06-19T06:15:24-08:00",
+                "article:published_time": "2026-06-19T06:00:00-08:00",
+                "ogTitle": "Post Title"
+            }
+        }
+    });
+
+    let page = parse_firecrawl_scrape(&raw).expect("page");
+
+    assert_eq!(page.content, "# Post\n\nBody.");
+    assert_eq!(page.title.as_deref(), Some("Post Title | Site"));
+    assert_eq!(
+        page.published_date.as_deref(),
+        Some("2026-06-19T06:15:24-08:00"),
+        "publishedTime wins over article:published_time"
+    );
+}
+
+#[test]
+fn scrape_falls_back_to_article_published_time() {
+    let raw = serde_json::json!({
+        "data": {
+            "markdown": "Body.",
+            "metadata": {"article:published_time": "2026-06-19T06:00:00-08:00"}
+        }
+    });
+
+    let page = parse_firecrawl_scrape(&raw).expect("page");
+
+    assert_eq!(page.title, None);
+    assert_eq!(
+        page.published_date.as_deref(),
+        Some("2026-06-19T06:00:00-08:00")
+    );
+}
+
+#[test]
+fn scrape_flat_shape_without_metadata_yields_bare_page() {
+    // Legacy/flat response shape: markdown at the top level, no metadata.
+    let raw = serde_json::json!({"markdown": "Body."});
+
+    let page = parse_firecrawl_scrape(&raw).expect("page");
+
+    assert_eq!(page.content, "Body.");
+    assert_eq!(page.title, None);
+    assert_eq!(page.published_date, None);
+}
+
+#[test]
+fn scrape_empty_content_still_errors() {
+    let raw = serde_json::json!({
+        "data": {"markdown": " ", "metadata": {"title": "Has Title"}}
+    });
+
+    let err = parse_firecrawl_scrape(&raw).expect_err("empty content must error");
+    assert!(err.to_string().contains("empty content"), "got: {err}");
+}

--- a/tests/response_budget.rs
+++ b/tests/response_budget.rs
@@ -9,7 +9,7 @@
 use async_trait::async_trait;
 use grok_search_rs::error::Result;
 use grok_search_rs::model::search::SearchFilters;
-use grok_search_rs::model::source::Source;
+use grok_search_rs::model::source::{FetchedPage, Source};
 use grok_search_rs::model::tool::WebSearchInput;
 use grok_search_rs::service::{SearchService, SourceProvider};
 
@@ -32,8 +32,8 @@ impl SourceProvider for FixedLenFetchProvider {
             .collect())
     }
 
-    async fn fetch(&self, _url: &str) -> Result<String> {
-        Ok("x".repeat(self.len))
+    async fn fetch(&self, _url: &str) -> Result<FetchedPage> {
+        Ok(FetchedPage::text("x".repeat(self.len)))
     }
 
     async fn map(&self, _url: &str, _max_results: usize) -> Result<Vec<Source>> {
@@ -241,8 +241,8 @@ impl SourceProvider for MetadataHeavyProvider {
             .collect())
     }
 
-    async fn fetch(&self, _url: &str) -> Result<String> {
-        Ok("body".to_string())
+    async fn fetch(&self, _url: &str) -> Result<FetchedPage> {
+        Ok(FetchedPage::text("body"))
     }
 
     async fn map(&self, _url: &str, _max_results: usize) -> Result<Vec<Source>> {

--- a/tests/service_contract.rs
+++ b/tests/service_contract.rs
@@ -1,7 +1,7 @@
 use async_trait::async_trait;
 use grok_search_rs::error::{GrokSearchError, Result};
 use grok_search_rs::model::search::{SearchFilters, SearchRequest, SearchResponse};
-use grok_search_rs::model::source::Source;
+use grok_search_rs::model::source::{FetchedPage, Source};
 use grok_search_rs::model::tool::WebSearchInput;
 use grok_search_rs::service::{AiProvider, SearchService, SourceProvider};
 use grok_search_rs::sources::{SourceCaps, SourceExtractor, SourceRouter, SourceType};
@@ -74,8 +74,8 @@ impl SourceProvider for CountingSourceProvider {
             .collect())
     }
 
-    async fn fetch(&self, _url: &str) -> Result<String> {
-        Ok("fetched".to_string())
+    async fn fetch(&self, _url: &str) -> Result<FetchedPage> {
+        Ok(FetchedPage::text("fetched"))
     }
 
     async fn map(&self, _url: &str, _max_results: usize) -> Result<Vec<Source>> {
@@ -315,7 +315,7 @@ impl SourceProvider for FailingSourceProvider {
         ))
     }
 
-    async fn fetch(&self, _url: &str) -> Result<String> {
+    async fn fetch(&self, _url: &str) -> Result<FetchedPage> {
         Err(grok_search_rs::error::GrokSearchError::Provider(
             "fetch failed".to_string(),
         ))
@@ -343,8 +343,10 @@ impl SourceProvider for FirecrawlLikeSourceProvider {
             .collect())
     }
 
-    async fn fetch(&self, url: &str) -> Result<String> {
-        Ok(format!("firecrawl fallback content for {url}"))
+    async fn fetch(&self, url: &str) -> Result<FetchedPage> {
+        Ok(FetchedPage::text(format!(
+            "firecrawl fallback content for {url}"
+        )))
     }
 
     async fn map(&self, _url: &str, _max_results: usize) -> Result<Vec<Source>> {
@@ -501,8 +503,8 @@ impl SourceProvider for LongFetchSourceProvider {
         Ok(Vec::new())
     }
 
-    async fn fetch(&self, _url: &str) -> Result<String> {
-        Ok("abcdefghijklmnop".to_string())
+    async fn fetch(&self, _url: &str) -> Result<FetchedPage> {
+        Ok(FetchedPage::text("abcdefghijklmnop"))
     }
 
     async fn map(&self, _url: &str, _max_results: usize) -> Result<Vec<Source>> {

--- a/tests/tavily_parse.rs
+++ b/tests/tavily_parse.rs
@@ -1,7 +1,7 @@
 use grok_search_rs::model::search::SearchFilters;
 use grok_search_rs::model::source::Source;
 use grok_search_rs::providers::tavily::{
-    limit_tavily_results, normalize_tavily_results, tavily_map_request_body,
+    limit_tavily_results, normalize_tavily_results, parse_tavily_extract, tavily_map_request_body,
     tavily_search_request_body,
 };
 
@@ -62,6 +62,57 @@ fn tavily_search_body_serializes_filters() {
         serde_json::json!(["github.com", "news.ycombinator.com"])
     );
     assert_eq!(body["exclude_domains"], serde_json::json!(["example.com"]));
+}
+
+// The extract endpoint returns `title` alongside `raw_content` (verified live
+// against api.tavily.com — the docs' sample response omits it) but no
+// published-date field. Metadata must survive parsing so enrichment-time
+// backfill (issue #21) can use it.
+#[test]
+fn extract_parses_content_and_title() {
+    let raw = serde_json::json!({
+        "results": [
+            {
+                "url": "https://example.com/post",
+                "raw_content": "# Heading\n\nBody.",
+                "title": "Example Post Title",
+                "images": []
+            }
+        ],
+        "failed_results": []
+    });
+
+    let page = parse_tavily_extract(&raw).expect("page");
+
+    assert_eq!(page.content, "# Heading\n\nBody.");
+    assert_eq!(page.title.as_deref(), Some("Example Post Title"));
+    assert_eq!(page.published_date, None);
+}
+
+#[test]
+fn extract_tolerates_missing_or_blank_title() {
+    let raw = serde_json::json!({
+        "results": [
+            {"url": "https://example.com/a", "raw_content": "Body.", "title": "   "}
+        ]
+    });
+
+    let page = parse_tavily_extract(&raw).expect("page");
+
+    assert_eq!(page.content, "Body.");
+    assert_eq!(page.title, None, "blank titles must normalize to None");
+}
+
+#[test]
+fn extract_empty_content_still_errors() {
+    let raw = serde_json::json!({
+        "results": [
+            {"url": "https://example.com/a", "raw_content": "  ", "title": "Has Title"}
+        ]
+    });
+
+    let err = parse_tavily_extract(&raw).expect_err("empty content must error");
+    assert!(err.to_string().contains("empty content"), "got: {err}");
 }
 
 #[test]


### PR DESCRIPTION
Closes #21.

## Problem

~100% of `grok_responses` sources ship with `title: null` / `published_date: null`: most Grok citations arrive as bare URL strings (`web_search_call.action.sources`) or inline `[[n]](url)` markdown — both structurally metadata-free — and the few structured annotations carry the citation index (`"1"`, `"2"`) as the title. Merge-layer backfill was prototyped and measured at zero gain (Tavily supplemental URLs rarely collide with Grok citation URLs), so the fix lands where the content is already in hand: enrichment.

## Changes

1. **Parse-layer junk guard** — `collect_one_source` rejects purely-numeric / single-char titles (`is_junk_title` in `model::source`), so citation-index artifacts become `None` and stay eligible for backfill.
2. **Structured fetch** — `SourceProvider::fetch` returns a `FetchedPage { content, title, published_date }` instead of a bare `String`:
   - Tavily extract carries its `title` field (verified against the live API — basic and advanced depth both return it; there is no published-date field, so dates never come from Tavily);
   - Firecrawl scrape carries `metadata.title` + `publishedTime` (fallback `article:published_time`), verified live;
   - `web_fetch` output/behavior is unchanged (`web_fetch_raw` unwraps `.content`).
   - Note: the meta-tag scan floated in the issue is intentionally absent — the pipeline only ever sees provider-converted markdown, so raw `<meta>` tags are gone before any scan could run; structured provider metadata is the only date source.
3. **Enrichment-time backfill** — while `enrich_sources` fills `Source.content`, it now also backfills `title` (provider metadata first, then the first markdown ATX heading, both gated by the junk guard and a 200-char cap) and `published_date` (provider metadata only). Rules: only `None` fields are filled, upstream metadata is never overwritten, failure notes (`_Failed to retrieve: ..._`) backfill nothing, and sources beyond the enrichment window keep honest nulls.

## Verification

- `cargo fmt` / `cargo clippy --all-targets` clean; **244 tests pass** including 13 new ones (parse-layer guard, Tavily/Firecrawl response parsing incl. wrapped + flat shapes, six direct `enrich_sources` backfill-rule tests, heading-extraction unit test).
- Live checks: Tavily `/extract` and Firecrawl `/v1/scrape` raw responses inspected to pin the exact field names; patched stdio binary exercised end-to-end for `web_search` (fallback path) and `web_fetch` (unchanged output).
- Not reproduced locally: a live `grok_responses` citation round-trip (needs the api.x.ai oauth setup from the issue); the parse→enrich chain for that path is covered by the new unit tests, and the reporter's environment can confirm post-deploy.

Expected post-fix coverage: `title` backfilled for every source that enriches successfully; `published_date` backfilled when Firecrawl serves the page (Tavily extract has no date field) — remaining nulls are honest "never fetched / provider gave none" signals.