### PR TITLE
feat(release): ship http server binaries and multi-arch GHCR image

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   build-release:
-    name: Build ${{ matrix.target }}
+    name: Build ${{ matrix.asset_name }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -30,6 +30,25 @@ jobs:
             asset_name: grok-search-rs_Linux_aarch64.tar.gz
             universal: false
             cross: true
+          # HTTP server builds (`--features http`, release-http profile): the
+          # Streamable HTTP transport is compile-time gated, so the default
+          # assets above cannot serve remote MCP. These two Linux assets are
+          # what self-hosters (and the GHCR image below) run; macOS/Windows
+          # stay stdio-only on purpose.
+          - target: x86_64-unknown-linux-musl
+            os: ubuntu-latest
+            artifact_name: grok-search-rs
+            asset_name: grok-search-rs-http_Linux_x86_64.tar.gz
+            universal: false
+            cross: false
+            http: true
+          - target: aarch64-unknown-linux-musl
+            os: ubuntu-latest
+            artifact_name: grok-search-rs
+            asset_name: grok-search-rs-http_Linux_aarch64.tar.gz
+            universal: false
+            cross: true
+            http: true
           - target: universal-apple-darwin
             os: macos-latest
             artifact_name: grok-search-rs
@@ -94,7 +113,7 @@ jobs:
 
       - name: Build with cross
         if: matrix.cross == true
-        run: cross build --release --target ${{ matrix.target }} --locked
+        run: cross build ${{ matrix.http == true && '--profile release-http --features http' || '--release' }} --target ${{ matrix.target }} --locked
 
       - name: Build universal macOS
         if: matrix.universal == true
@@ -107,19 +126,18 @@ jobs:
 
       - name: Build
         if: matrix.universal != true && matrix.cross != true
-        run: cargo build --release --target ${{ matrix.target }} --locked
+        run: cargo build ${{ matrix.http == true && '--profile release-http --features http' || '--release' }} --target ${{ matrix.target }} --locked
 
       - name: Package Unix
         if: matrix.os != 'windows-latest'
         run: |
+          # http builds land in the release-http profile directory.
+          PROFILE_DIR=${{ matrix.http == true && 'release-http' || 'release' }}
           if [ "${{ matrix.universal }}" = "true" ]; then
             cd target/release
             tar czf ../../${{ matrix.asset_name }} ${{ matrix.artifact_name }}
-          elif [ "${{ matrix.cross }}" = "true" ]; then
-            cd target/${{ matrix.target }}/release
-            tar czf ../../../${{ matrix.asset_name }} ${{ matrix.artifact_name }}
           else
-            cd target/${{ matrix.target }}/release
+            cd target/${{ matrix.target }}/$PROFILE_DIR
             tar czf ../../../${{ matrix.asset_name }} ${{ matrix.artifact_name }}
           fi
 
@@ -183,6 +201,68 @@ jobs:
             flat/*.tar.gz
             flat/*.zip
             flat/SHA256SUMS
+
+  publish-image:
+    name: Publish multi-arch image to GHCR
+    needs: build-release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Download http binaries
+        uses: actions/download-artifact@v4
+        with:
+          pattern: grok-search-rs-http_Linux_*.tar.gz
+          path: http-artifacts
+
+      # Dockerfile.deploy COPYs dist/${TARGETPLATFORM}/grok-search-rs; its
+      # .dockerignore keeps the build context to dist/ alone.
+      - name: Lay out dist/ for Dockerfile.deploy
+        run: |
+          mkdir -p dist/linux/amd64 dist/linux/arm64
+          tar -xzf http-artifacts/grok-search-rs-http_Linux_x86_64.tar.gz/grok-search-rs-http_Linux_x86_64.tar.gz -C dist/linux/amd64
+          tar -xzf http-artifacts/grok-search-rs-http_Linux_aarch64.tar.gz/grok-search-rs-http_Linux_aarch64.tar.gz -C dist/linux/arm64
+          chmod 0755 dist/linux/amd64/grok-search-rs dist/linux/arm64/grok-search-rs
+          ls -lR dist
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Image metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/grok-search-rs
+          tags: |
+            type=semver,pattern={{version}}
+            type=raw,value=latest
+
+      # The image always builds (validating Dockerfile.deploy + dist layout
+      # even on workflow_dispatch runs); pushing is tag-gated.
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.deploy
+          platforms: linux/amd64,linux/arm64
+          push: ${{ startsWith(github.ref, 'refs/tags/v') }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
 
   publish-npm-platforms:
     name: Publish ${{ matrix.platform }} to npm

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to GrokSearch-rs are documented here.
 
+## Unreleased
+
+### Added
+
+- **发版产物新增 HTTP 服务端形态(免本机编译)。** 此前 GitHub Release / npm 的
+  全部二进制均为 stdio-only(HTTP 传输在编译期 feature 门控),想自托管远程
+  MCP 只能源码编译——低内存/小硬盘的 ARM 板(如 RK3399)上极易 OOM、爆盘。
+  现在 tag 发版额外产出:(1) `grok-search-rs-http_Linux_{x86_64,aarch64}.tar.gz`
+  静态 musl 服务端二进制(`--features http` + `release-http` profile),下载
+  即可 `--http` 起服;(2) 多架构(amd64/arm64)运行时镜像推送到
+  `ghcr.io/episkey-g/grok-search-rs`(`X.Y.Z` + `latest` 标签,基于
+  `Dockerfile.deploy`),`docker pull` 即得对应架构。macOS/Windows 资产保持
+  stdio-only 不变。
+
 ## 0.1.21 - 2026-07-21
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -258,6 +258,19 @@ A missing required key returns `401` (fail‑closed); OAuth is rejected on this 
 `X-Grok-Base-Url` header (any public gateway is honored; internal/private addresses are rejected).
 The remote transport uses the Grok **Responses** API only; the OpenAI-compatible chat-completions transport is stdio-only.
 
+**No local build needed.** Every release ships ready‑to‑run server artifacts for Linux
+`x86_64` + `aarch64` (static musl) — ideal for low‑RAM/small‑disk boards where a native
+`cargo build` would OOM or fill the disk:
+
+- **Prebuilt binary** — download `grok-search-rs-http_Linux_<arch>.tar.gz` from the
+  [latest release](https://github.com/Episkey-G/GrokSearch-rs/releases/latest) and run
+  `GROK_MCP_BIND=0.0.0.0:8080 ./grok-search-rs --http`. (The plain `grok-search-rs_…`
+  assets are **stdio‑only**: the HTTP transport is compile‑time gated and not in them.)
+- **Docker image** — multi‑arch `amd64`/`arm64`:
+  `docker pull ghcr.io/episkey-g/grok-search-rs:latest` (serves on `:8080`).
+
+Building from source instead:
+
 ```bash
 cargo build --profile release-http --features http    # release-http => panic=unwind (handler panic won't kill the server)
 GROK_MCP_BIND=127.0.0.1:8080 target/release-http/grok-search-rs --http   # bind loopback; terminate TLS upstream

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -41,10 +41,16 @@ Both predate the tag-triggered auto-sync and remain for offline use.
 
 - `secrets.NPM_TOKEN` configured
 - No branch protection rule on `main` blocking `github-actions[bot]`
+- **One-time, after the first tagged release that pushes the image**: set
+  `ghcr.io/episkey-g/grok-search-rs` to **public** in the package settings
+  (profile → Packages → grok-search-rs → Package settings → Change visibility).
+  GHCR creates new packages private by default and offers no API to change
+  visibility from CI, so until this flip anonymous `docker pull` returns 401
+  even though the workflow succeeded. Later pushes keep the public setting.
 
 ## Verify after release
 
 - GitHub release page lists 7 archives (5 stdio + 2 `-http` Linux) + `SHA256SUMS`
 - `npx grok-search-rs@X.Y.Z --help` works
-- `docker pull ghcr.io/episkey-g/grok-search-rs:X.Y.Z` resolves on both amd64 and arm64
+- `docker pull ghcr.io/episkey-g/grok-search-rs:X.Y.Z` resolves on both amd64 and arm64 **without logging in** (a 401 means the package is still private — see Prerequisites)
 - `main` has a `chore: sync manifests to X.Y.Z` commit from `github-actions[bot]`

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -15,10 +15,11 @@ git push origin v0.1.5
 
 That's all. Pushing the tag triggers `release.yml`, which then:
 
-1. Injects `0.1.5` into `Cargo.toml` (in CI working tree) and builds cross-platform binaries
+1. Injects `0.1.5` into `Cargo.toml` (in CI working tree) and builds cross-platform binaries — stdio builds for all five platforms, plus `-http` server builds (`--features http`, `release-http` profile) for Linux x86_64/aarch64
 2. Creates the GitHub Release with archives + `SHA256SUMS`
-3. Publishes the 6 npm packages (main + 5 platform sub-packages) with version `0.1.5`
-4. **Commits the version bump back to `main`** so `Cargo.toml`, `Cargo.lock`, and all `package.json` files stay in sync with the latest release
+3. Pushes the multi-arch (`amd64`/`arm64`) server image to `ghcr.io/episkey-g/grok-search-rs` tagged `X.Y.Z` + `latest` (built from the `-http` binaries via `Dockerfile.deploy`)
+4. Publishes the 6 npm packages (main + 5 platform sub-packages) with version `0.1.5`
+5. **Commits the version bump back to `main`** so `Cargo.toml`, `Cargo.lock`, and all `package.json` files stay in sync with the latest release
 
 ## Manual fallback (rarely needed)
 
@@ -43,6 +44,7 @@ Both predate the tag-triggered auto-sync and remain for offline use.
 
 ## Verify after release
 
-- GitHub release page lists 5 archives + `SHA256SUMS`
+- GitHub release page lists 7 archives (5 stdio + 2 `-http` Linux) + `SHA256SUMS`
 - `npx grok-search-rs@X.Y.Z --help` works
+- `docker pull ghcr.io/episkey-g/grok-search-rs:X.Y.Z` resolves on both amd64 and arm64
 - `main` has a `chore: sync manifests to X.Y.Z` commit from `github-actions[bot]`


### PR DESCRIPTION
## Motivation

A user tried to self-host the remote MCP on an RK3399 board and had to build from source — slow, and it filled the disk. Root cause: every official artifact (GitHub Release + npm) is a stdio-only build. The HTTP transport is compile-time gated (`http` feature), so no downloadable binary can serve remote MCP, and no image was ever published anywhere (#23 added the multi-platform `Dockerfile.deploy` but nothing consumes it in CI).

## Changes

**A — HTTP server binaries in the Release.** Two new `build-release` matrix entries build Linux x86_64/aarch64 musl with `--features http --profile release-http` (same combination as `scripts/build-deploy-dist.sh`), packaged as `grok-search-rs-http_Linux_{x86_64,aarch64}.tar.gz`. The existing `create-release` glob and `SHA256SUMS` pick them up with no changes; npm jobs download by exact stdio asset names and are unaffected. macOS/Windows stay stdio-only by design.

**B — Multi-arch image on GHCR.** New `publish-image` job (needs `build-release`): downloads the two http artifacts, lays them out as `dist/linux/{amd64,arm64}/grok-search-rs` (mode 0755), and `buildx`-builds `linux/amd64,linux/arm64` with the existing `Dockerfile.deploy` (its per-Dockerfile ignore keeps the context to `dist/` only). Tags come from `docker/metadata-action` (`X.Y.Z` semver + `latest`), pushed to `ghcr.io/episkey-g/grok-search-rs` — **push is tag-gated**; `workflow_dispatch` runs still build the image as validation without pushing. Job-scoped `permissions: packages: write`, auth via `GITHUB_TOKEN` (no new secrets).

Docs: README self-hosting section now leads with the two no-build paths (prebuilt `-http` binary / `docker pull`), RELEASING.md pipeline + verify checklists updated, CHANGELOG entry added.

## Verification

- `actionlint`: zero findings on the added/changed parts (remaining output is pre-existing info/style notes and the known `${{ }}` placeholder false positive in old npm steps).
- The exact cargo flag combination (`--features http --profile release-http`, both musl targets) is the one `build-deploy-dist.sh` has been building locally — known-good.
- Local smoke: `docker buildx build -f Dockerfile.deploy` for linux/amd64 and linux/arm64 individually against a real `dist/` layout; the amd64 container runs `--version` correctly (multi-platform single-command build needs a container driver, which `setup-buildx-action` provides in CI).
- Full pipeline proof comes with the next tag release; a `workflow_dispatch` run after merge validates the http builds + image build without publishing anything.