### PR TITLE
feat(sources): add GitHub release specialist for web_fetch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to GrokSearch-rs are documented here.
 
+## Unreleased
+
+### Added
+
+- **`web_fetch` 新增 GitHub Release 专项抽取器(`source_type: github_release`)。**
+  此前 release 页只能走 generic 抓取,而 GitHub 前端是 JS 渲染的,抓到的多为
+  "{{ message }}"、fork/star 按钮等模板噪音(实测 original_length 仅 ~1.4k,
+  release notes 基本丢失)。现在 `/releases/tag/<tag>` 与 `/releases/latest`
+  两类 URL 改走 GitHub REST API(`GET /repos/{owner}/{repo}/releases/tags/{tag}`
+  / `…/releases/latest`),输出 tag、发布日期、作者、prerelease 标记与完整
+  release notes Markdown。复用 `GITHUB_TOKEN` 认证(未配置时走匿名限流路径);
+  API 失败时按既有语义回退 generic 并携带 `fallback_reason`。release 列表页
+  (`/releases`)与资产下载链接(`/releases/download/…`)保持 generic 路径不变。
+
 ## 0.1.22 - 2026-07-22
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 - 🔎 **Live web search** with cited sources, cached for follow‑up `get_sources` calls. Opt‑in `include_content` enriches the top sources with full extracted text in one call.
 - 📏 **Response budgeting** — `web_search` keeps responses inside agent context limits: only the top `max_inline_sources` carry inline text, a whole‑response char budget (`response_max_chars`, default 45k — sized to stay under the MCP client token ceiling after JSON serialization) trims tail sources with recovery notes, `response_format: "concise" | "detailed"` picks the payload size, and `get_sources` pages through cached sources with `offset`/`limit`. The session cache always keeps full content.
-- 🧩 **Structured `web_fetch`** — GitHub issues/PRs, StackExchange/MathOverflow, arXiv, and Wikipedia URLs are parsed by specialist extractors into clean Markdown (title, state/labels, accepted‑answer ordering, abstracts, vote‑sorted answers). Anything else falls back to the generic Tavily → Firecrawl chain. Output carries `source_type` and a `fallback_reason` when a specialist was skipped.
+- 🧩 **Structured `web_fetch`** — GitHub issues/PRs/releases, StackExchange/MathOverflow, arXiv, and Wikipedia URLs are parsed by specialist extractors into clean Markdown (title, state/labels, release notes, accepted‑answer ordering, abstracts, vote‑sorted answers). Anything else falls back to the generic Tavily → Firecrawl chain. Output carries `source_type` and a `fallback_reason` when a specialist was skipped.
 - 🔀 **Two transports** — native xAI Responses (`/v1/responses`) **or** any OpenAI‑compatible chat‑completions gateway (`/v1/chat/completions`). Pick by env vars; no flag.
 - 🔐 **Optional Grok OAuth mode** — `login/status/logout` commands store a local xAI OAuth token for Responses auth, so the MCP server can run without `GROK_SEARCH_API_KEY`.
 - 🌐 **Optional remote mode** — build with `--features http` to serve the same tools over **Streamable HTTP** (multi‑tenant, bring‑your‑own‑key via request headers) for mobile / multi‑device access. See [self-hosting](#self-hosting-remote-http).
@@ -195,7 +195,7 @@ Notes:
 
 | Variable | Default | Purpose |
 |---|---|---|
-| `GITHUB_TOKEN` | unset | Authenticates GitHub issue/PR fetches (higher API rate limit; private repos). Specialist works unauthenticated but is rate‑limited. |
+| `GITHUB_TOKEN` | unset | Authenticates GitHub issue/PR/release fetches (higher API rate limit; private repos). Specialist works unauthenticated but is rate‑limited. |
 | `GROK_SEARCH_SOURCE_MAX_ANSWERS` | `5` | StackExchange answers rendered before folding. |
 | `GROK_SEARCH_SOURCE_MAX_COMMENTS` | `30` | GitHub / StackExchange comments rendered before folding. |
 | `GROK_SEARCH_ENRICH_CONCURRENCY` | `3` | Parallel source enrichments for `web_search` `include_content` (clamped 1..5). |

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -147,7 +147,7 @@ Tavily/Firecrawl key required.
 
 | Variable | Default | Description |
 |---|---|---|
-| `GITHUB_TOKEN` | unset | GitHub token for issue/PR fetches. Anonymous works but is capped at ~60 req/hr; a token raises the limit and allows private repos. |
+| `GITHUB_TOKEN` | unset | GitHub token for issue/PR/release fetches. Anonymous works but is capped at ~60 req/hr; a token raises the limit and allows private repos. |
 | `GROK_SEARCH_SOURCE_MAX_ANSWERS` | `5` | StackExchange answers rendered before the "more answers" fold. |
 | `GROK_SEARCH_SOURCE_MAX_COMMENTS` | `30` | GitHub / StackExchange comments rendered before folding. |
 | `GROK_SEARCH_ENRICH_CONCURRENCY` | `3` | Parallel source enrichments when `web_search` is called with `include_content: true`. Clamped to `1..=5`. |

--- a/src/sources/github.rs
+++ b/src/sources/github.rs
@@ -27,11 +27,25 @@ pub struct GithubComment {
     pub created_at: String,
 }
 
+#[derive(Debug, Clone)]
+pub struct GithubReleaseRaw {
+    pub tag: String,
+    pub name: String,
+    pub author: String,
+    pub published_at: String,
+    pub prerelease: bool,
+    pub body: String,
+}
+
 pub struct GithubIssueExtractor {
     pub token: Option<String>,
 }
 
 pub struct GithubPrExtractor {
+    pub token: Option<String>,
+}
+
+pub struct GithubReleaseExtractor {
     pub token: Option<String>,
 }
 
@@ -44,6 +58,27 @@ fn matches_github(url: &Url, segment_kind: &str) -> bool {
         None => return false,
     };
     segs.len() == 4 && segs[2] == segment_kind && segs[3].parse::<u64>().is_ok()
+}
+
+/// `/owner/repo/releases/tag/<tag>` and `/owner/repo/releases/latest` pages.
+/// The release list (`/releases`) and asset downloads (`/releases/download/…`)
+/// stay on the generic path.
+fn matches_github_release(url: &Url) -> bool {
+    if url.host_str() != Some("github.com") {
+        return false;
+    }
+    let segs: Vec<&str> = match url.path_segments() {
+        Some(it) => it.filter(|s| !s.is_empty()).collect(),
+        None => return false,
+    };
+    if segs.len() < 4 || segs[2] != "releases" {
+        return false;
+    }
+    match segs.len() {
+        4 => segs[3] == "latest",
+        5 => segs[3] == "tag",
+        _ => false,
+    }
 }
 
 /// Page size for any comment list. `/comments` endpoints default to 30 results
@@ -253,6 +288,94 @@ pub fn render(raw: &GithubRaw, caps: &SourceCaps) -> String {
     out
 }
 
+/// REST endpoint for a matched release URL. `segs` are the non-empty path
+/// segments. The tag segment is spliced still percent-encoded: `path_segments`
+/// does not decode, and the API path expects the same encoding the web URL
+/// uses (tags containing `/` arrive as one `%2F` segment).
+fn release_api_url(segs: &[String]) -> String {
+    let (owner, repo) = (&segs[0], &segs[1]);
+    if segs.len() == 5 {
+        format!(
+            "https://api.github.com/repos/{owner}/{repo}/releases/tags/{}",
+            segs[4]
+        )
+    } else {
+        format!("https://api.github.com/repos/{owner}/{repo}/releases/latest")
+    }
+}
+
+/// Map a `GET /repos/{o}/{r}/releases/…` response to `GithubReleaseRaw`.
+/// Pure (no I/O) so it can be unit-tested offline against a fixture. A payload
+/// without `tag_name` is rejected rather than rendered as an empty shell.
+pub fn parse_release(json: &serde_json::Value) -> Result<GithubReleaseRaw> {
+    let tag = str_field(json, "tag_name");
+    if tag.is_empty() {
+        return Err(crate::error::GrokSearchError::Provider(
+            "github: release payload missing tag_name".into(),
+        ));
+    }
+    Ok(GithubReleaseRaw {
+        tag,
+        name: str_field(json, "name"),
+        author: json
+            .get("author")
+            .and_then(|u| u.get("login"))
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string(),
+        published_at: str_field(json, "published_at"),
+        prerelease: json
+            .get("prerelease")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false),
+        body: str_field(json, "body"),
+    })
+}
+
+pub(crate) async fn fetch_release(
+    client: &Client,
+    url: &Url,
+    token: Option<&str>,
+) -> Result<GithubReleaseRaw> {
+    let segs: Vec<String> = url
+        .path_segments()
+        .map(|it| it.filter(|s| !s.is_empty()).map(String::from).collect())
+        .unwrap_or_default();
+    if segs.len() < 4 {
+        return Err(crate::error::GrokSearchError::Parse(
+            "github: unexpected release URL shape".into(),
+        ));
+    }
+
+    let auth = token.map(|t| format!("Bearer {t}"));
+    let mut headers: Vec<(reqwest::header::HeaderName, &str)> = vec![(USER_AGENT, UA)];
+    if let Some(ref a) = auth {
+        headers.push((AUTHORIZATION, a.as_str()));
+    }
+
+    let json = get_json(client, &release_api_url(&segs), &headers, "github_release").await?;
+    parse_release(&json)
+}
+
+/// Releases have no comment thread to fold, so caps are unused; the parameter
+/// keeps the render signature uniform across specialists.
+pub fn render_release(raw: &GithubReleaseRaw, _caps: &SourceCaps) -> String {
+    let title = if raw.name.trim().is_empty() {
+        &raw.tag
+    } else {
+        &raw.name
+    };
+    let mut out = format!("# {title}\n\n");
+    let pre_suffix = if raw.prerelease { " (prerelease)" } else { "" };
+    out.push_str(&format!("**Tag:** {}{}\n", raw.tag, pre_suffix));
+    if !raw.published_at.is_empty() {
+        out.push_str(&format!("**Published:** {}\n", raw.published_at));
+    }
+    out.push_str(&format!("**Author:** {}\n", raw.author));
+    out.push_str(&format!("\n{}\n", raw.body));
+    out
+}
+
 #[async_trait]
 impl SourceExtractor for GithubIssueExtractor {
     fn matches(&self, url: &Url) -> bool {
@@ -278,6 +401,20 @@ impl SourceExtractor for GithubPrExtractor {
     async fn fetch_render(&self, client: &Client, url: &Url, caps: &SourceCaps) -> Result<String> {
         let raw = fetch(client, url, self.token.as_deref(), true, caps.max_comments).await?;
         Ok(render(&raw, caps))
+    }
+}
+
+#[async_trait]
+impl SourceExtractor for GithubReleaseExtractor {
+    fn matches(&self, url: &Url) -> bool {
+        matches_github_release(url)
+    }
+    fn kind(&self) -> SourceType {
+        SourceType::GithubRelease
+    }
+    async fn fetch_render(&self, client: &Client, url: &Url, caps: &SourceCaps) -> Result<String> {
+        let raw = fetch_release(client, url, self.token.as_deref()).await?;
+        Ok(render_release(&raw, caps))
     }
 }
 
@@ -332,5 +469,35 @@ mod tests {
         assert_eq!(out[0].author, "dave");
         assert_eq!(out[0].body, "hi");
         assert_eq!(out[0].created_at, "2024-01-01T00:00:00Z");
+    }
+
+    #[test]
+    fn release_api_url_targets_tag_and_latest_endpoints() {
+        let tag: Vec<String> = ["o", "r", "releases", "tag", "v1.2.3"]
+            .map(String::from)
+            .to_vec();
+        assert_eq!(
+            release_api_url(&tag),
+            "https://api.github.com/repos/o/r/releases/tags/v1.2.3"
+        );
+        let latest: Vec<String> = ["o", "r", "releases", "latest"].map(String::from).to_vec();
+        assert_eq!(
+            release_api_url(&latest),
+            "https://api.github.com/repos/o/r/releases/latest"
+        );
+    }
+
+    #[test]
+    fn release_api_url_keeps_tag_percent_encoding() {
+        // Tags containing `/` arrive percent-encoded as a single path segment
+        // and must stay encoded in the API path.
+        let segs: Vec<String> = ["o", "r", "releases", "tag", "releases%2Fv1.0"]
+            .map(String::from)
+            .to_vec();
+        assert!(
+            release_api_url(&segs).ends_with("/releases/tags/releases%2Fv1.0"),
+            "got: {}",
+            release_api_url(&segs)
+        );
     }
 }

--- a/src/sources/mod.rs
+++ b/src/sources/mod.rs
@@ -21,6 +21,7 @@ pub const NO_SPECIALIST_MATCH: &str = "no_specialist_match";
 pub enum SourceType {
     GithubIssue,
     GithubPull,
+    GithubRelease,
     Stackexchange,
     Arxiv,
     Wikipedia,
@@ -34,6 +35,7 @@ impl SourceType {
         match self {
             SourceType::GithubIssue => "github_issue",
             SourceType::GithubPull => "github_pull",
+            SourceType::GithubRelease => "github_release",
             SourceType::Stackexchange => "stackexchange",
             SourceType::Arxiv => "arxiv",
             SourceType::Wikipedia => "wikipedia",
@@ -105,6 +107,9 @@ impl SourceRouter {
                 token: config.github_token.clone(),
             }),
             Box::new(github::GithubPrExtractor {
+                token: config.github_token.clone(),
+            }),
+            Box::new(github::GithubReleaseExtractor {
                 token: config.github_token.clone(),
             }),
             Box::new(stackexchange::StackExchangeExtractor),
@@ -336,6 +341,10 @@ mod tests {
         assert_eq!(
             serde_json::to_string(&SourceType::GithubPull).unwrap(),
             "\"github_pull\""
+        );
+        assert_eq!(
+            serde_json::to_string(&SourceType::GithubRelease).unwrap(),
+            "\"github_release\""
         );
         assert_eq!(
             serde_json::to_string(&SourceType::Stackexchange).unwrap(),

--- a/tests/fixtures/sources/github_release.json
+++ b/tests/fixtures/sources/github_release.json
@@ -1,0 +1,8 @@
+{
+  "tag_name": "rmcp-v2.2.0",
+  "name": "rmcp v2.2.0",
+  "prerelease": false,
+  "published_at": "2026-07-18T09:30:00Z",
+  "author": { "login": "alice" },
+  "body": "## What's Changed\n\n* feat: streamable HTTP transport by @alice in https://github.com/modelcontextprotocol/rust-sdk/pull/123\n* fix: session cleanup race by @bob in https://github.com/modelcontextprotocol/rust-sdk/pull/124\n\n**Full Changelog**: https://github.com/modelcontextprotocol/rust-sdk/compare/rmcp-v2.1.0...rmcp-v2.2.0"
+}

--- a/tests/sources_render.rs
+++ b/tests/sources_render.rs
@@ -1,6 +1,7 @@
 use grok_search_rs::sources::arxiv::{render as arxiv_render, ArxivExtractor};
 use grok_search_rs::sources::github::{
-    render as gh_render, GithubIssueExtractor, GithubPrExtractor, GithubRaw,
+    parse_release as gh_parse_release, render as gh_render, render_release as gh_render_release,
+    GithubIssueExtractor, GithubPrExtractor, GithubRaw, GithubReleaseExtractor, GithubReleaseRaw,
 };
 use grok_search_rs::sources::stackexchange::{render as se_render, SeRaw, StackExchangeExtractor};
 use grok_search_rs::sources::wikipedia::{
@@ -63,9 +64,93 @@ fn github_matcher_strict_positive_and_negative() {
         "https://gist.github.com/user/abc",
         "https://github.com/owner/repo/discussions/1",
         "https://github.com/owner/repo/blob/main/README.md",
+        "https://github.com/owner/repo/releases/tag/v1.0.0",
     ] {
         assert!(!issue.matches(&m(neg)), "issue should reject {neg}");
         assert!(!pr.matches(&m(neg)), "pr should reject {neg}");
+    }
+}
+
+fn release_fixture() -> GithubReleaseRaw {
+    let json: serde_json::Value =
+        serde_json::from_str(include_str!("fixtures/sources/github_release.json")).unwrap();
+    gh_parse_release(&json).expect("parse")
+}
+
+#[test]
+fn github_release_parse_extracts_tag_notes_and_metadata() {
+    let raw = release_fixture();
+    assert_eq!(raw.tag, "rmcp-v2.2.0");
+    assert_eq!(raw.name, "rmcp v2.2.0");
+    assert_eq!(raw.author, "alice");
+    assert_eq!(raw.published_at, "2026-07-18T09:30:00Z");
+    assert!(!raw.prerelease);
+    assert!(raw.body.contains("streamable HTTP transport"));
+}
+
+#[test]
+fn github_release_parse_rejects_payload_without_tag() {
+    let json = serde_json::json!({ "name": "x", "body": "notes" });
+    assert!(gh_parse_release(&json).is_err());
+}
+
+#[test]
+fn github_release_render_shows_title_tag_date_and_notes() {
+    let out = gh_render_release(&release_fixture(), &SourceCaps::default());
+    assert!(out.contains("# rmcp v2.2.0"), "title: {out}");
+    assert!(out.contains("**Tag:** rmcp-v2.2.0"), "tag: {out}");
+    assert!(
+        out.contains("**Published:** 2026-07-18T09:30:00Z"),
+        "date: {out}"
+    );
+    assert!(out.contains("**Author:** alice"), "author: {out}");
+    assert!(out.contains("What's Changed"), "notes: {out}");
+}
+
+#[test]
+fn github_release_render_falls_back_to_tag_title_and_marks_prerelease() {
+    let raw = GithubReleaseRaw {
+        tag: "v0.9.0-rc.1".into(),
+        name: "  ".into(),
+        author: "alice".into(),
+        published_at: String::new(),
+        prerelease: true,
+        body: "release candidate".into(),
+    };
+    let out = gh_render_release(&raw, &SourceCaps::default());
+    assert!(out.contains("# v0.9.0-rc.1"), "tag title: {out}");
+    assert!(out.contains("(prerelease)"), "prerelease marker: {out}");
+    assert!(
+        !out.contains("**Published:**"),
+        "empty date must fold: {out}"
+    );
+}
+
+#[test]
+fn github_release_matcher_tag_and_latest_positive() {
+    let rel = GithubReleaseExtractor { token: None };
+    let m = |u: &str| Url::parse(u).unwrap();
+    assert!(rel.matches(&m("https://github.com/owner/repo/releases/tag/v1.2.3")));
+    assert!(rel.matches(&m(
+        "https://github.com/modelcontextprotocol/rust-sdk/releases/tag/rmcp-v2.2.0"
+    )));
+    assert!(rel.matches(&m("https://github.com/owner/repo/releases/latest")));
+}
+
+#[test]
+fn github_release_matcher_negative() {
+    let rel = GithubReleaseExtractor { token: None };
+    let m = |u: &str| Url::parse(u).unwrap();
+    for neg in [
+        "https://github.com/owner/repo/releases",
+        "https://github.com/owner/repo/releases/tag/",
+        "https://github.com/owner/repo/releases/download/v1.0/pkg.tar.gz",
+        "https://github.com/owner/repo/releases/tag/v1.0/extra",
+        "https://github.com/owner/repo/releases/latest/extra",
+        "https://github.com/owner/repo/issues/42",
+        "https://gist.github.com/user/abc",
+    ] {
+        assert!(!rel.matches(&m(neg)), "should reject {neg}");
     }
 }
 


### PR DESCRIPTION
## 动机

线上实测(2026-07-22):`web_fetch("https://github.com/modelcontextprotocol/rust-sdk/releases/tag/rmcp-v2.2.0")` 走 generic 路径,GitHub 前端 JS 渲染导致只抓到 `{{ message }}`、fork/star 按钮等模板噪音,`original_length` 仅 ~1.4k,release notes 基本丢失。现有 GitHub specialist 只覆盖 issue/PR。

## 改动

- `/releases/tag/<tag>` 与 `/releases/latest` 两类 URL 改走 GitHub REST API(`GET /repos/{owner}/{repo}/releases/tags/{tag}` / `…/releases/latest`),新增 `source_type: github_release`,输出 tag、发布日期、作者、prerelease 标记与完整 release notes Markdown。
- 复用现有 `GITHUB_TOKEN` 认证与匿名限流路径、`get_json` 错误归一化,API 失败按既有语义回退 generic 并携带 `fallback_reason`;`web_search` enrichment 走同一 `resolve_content` 管道自动受益。
- release 列表页(`/releases`)与资产下载(`/releases/download/…`)保持 generic 不变;tag 段保持 percent-encoded 原样拼入 API 路径(含 `/` 的 tag 以 `%2F` 单段到达)。
- 文档同步:README、docs/CONFIGURATION.md 的 `GITHUB_TOKEN` 说明,CHANGELOG Unreleased 段。

## 验证

- `cargo fmt` / `cargo clippy --all-targets -- -D warnings` / `cargo test` 全绿(新增 8 个测试:URL builder ×2、parse ×2、render ×2、matcher ×2,全部离线 fixture)。
- 真实 API 校验:对用户实测同一 release 调 `GET …/releases/tags/rmcp-v2.2.0`,payload 字段名与解析器一一对应(`tag_name`/`name`/`prerelease`/`published_at`/`author.login`/`body`,notes 580 字符完整拿到);`/releases/latest` 同形。
- 顺带把 release URL 加进 issue/PR matcher 的负例清单,防止误路由。