### PR TITLE
fix(tavily): drop search results below a minimum relevance score

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to GrokSearch-rs are documented here.
 
+## Unreleased
+
+### Fixed
+
+- **`tavily_enrichment` 补充来源不再混入与查询无关的低质页面。** `web_search`
+  把用户的自然语言 query 原样透传给 Tavily,长句易被单个通用词带偏——实测
+  "latest rmcp Rust MCP SDK release version and what changed" 返回的 5 条补充
+  结果全是 "latest" 的词典释义页与新闻门户首页(Tavily 自身相关性 score 仅
+  0.030–0.040,正常在题结果 ≥ 0.49),此前解析层丢弃 score 字段照单全收,
+  垃圾页面以 `tavily_enrichment`/`tavily_fallback` 身份进入输出并浪费
+  enrichment 抓取与响应预算。现在 `normalize_tavily_results` 丢弃 score <
+  0.1 的搜索结果:全部被过滤时 speculative 预取自然落到 Firecrawl 兜底,
+  无 score 的条目(map 端点、API 演进)照旧保留,`web_map` 行为不变。
+
 ## 0.1.22 - 2026-07-22
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ All notable changes to GrokSearch-rs are documented here.
   enrichment 抓取与响应预算。现在 `normalize_tavily_results` 丢弃 score <
   0.1 的搜索结果:全部被过滤时 speculative 预取自然落到 Firecrawl 兜底,
   无 score 的条目(map 端点、API 演进)照旧保留,`web_map` 行为不变。
+  同时收紧兜底语义(Codex 评审):Firecrawl 完全无视
+  include/exclude_domains 与 recency_days,带这些约束的请求不再落入
+  Firecrawl——约束请求 Tavily-or-nothing,不会静默拿到未过滤的补充来源。
 
 ## 0.1.22 - 2026-07-22
 

--- a/src/providers/tavily.rs
+++ b/src/providers/tavily.rs
@@ -260,6 +260,19 @@ pub fn parse_tavily_extract(raw: &Value) -> Result<FetchedPage> {
     })
 }
 
+/// Search results whose Tavily relevance `score` falls below this are junk,
+/// not evidence. Long natural-language queries can drift Tavily onto one
+/// generic word — observed live with "latest rmcp Rust MCP SDK release
+/// version and what changed": dictionary and news-portal pages for "latest"
+/// all scored ≤ 0.04, while on-topic results for answerable queries score
+/// ≥ 0.49. 0.1 clears the junk band ~2.5x with ~5x headroom below on-topic
+/// results. Items with no score (map results, API drift) always pass.
+const MIN_SEARCH_SCORE: f64 = 0.1;
+
+/// Normalize a Tavily `search`/`map` response into `Source`s. Search items
+/// scoring below [`MIN_SEARCH_SCORE`] are dropped so keyword-drift junk never
+/// reaches the enrichment/fallback source lists; score-less items (the map
+/// endpoint returns bare URL strings) are kept unconditionally.
 pub fn normalize_tavily_results(raw: &Value) -> Vec<Source> {
     raw.get("results")
         .and_then(Value::as_array)
@@ -270,6 +283,13 @@ pub fn normalize_tavily_results(raw: &Value) -> Vec<Source> {
                 return Some(Source::new(url, "tavily"));
             }
             let url = item.get("url").and_then(Value::as_str)?;
+            if item
+                .get("score")
+                .and_then(Value::as_f64)
+                .is_some_and(|score| score < MIN_SEARCH_SCORE)
+            {
+                return None;
+            }
             let mut source = Source::new(url, "tavily");
             if let Some(title) = item.get("title").and_then(Value::as_str) {
                 source = source.with_title(title);

--- a/src/service.rs
+++ b/src/service.rs
@@ -608,10 +608,18 @@ impl SearchService {
                 }
             }
         }
-        if let Some(provider) = &self.fallback_sources {
-            if let Ok(sources) = provider.search_sources(query, count, filters).await {
-                if !sources.is_empty() {
-                    return (sources, RawSourceOrigin::Fallback);
+        // The fallback source provider (Firecrawl) ignores `SearchFilters`
+        // outright — it has no structured recency/domain support — so a
+        // filter-constrained request must never fall through: swapping
+        // constrained Tavily results for unconstrained Firecrawl ones would
+        // silently violate the include/exclude/recency contract. Constrained
+        // requests are Tavily-or-nothing.
+        if filters.is_empty() {
+            if let Some(provider) = &self.fallback_sources {
+                if let Ok(sources) = provider.search_sources(query, count, filters).await {
+                    if !sources.is_empty() {
+                        return (sources, RawSourceOrigin::Fallback);
+                    }
                 }
             }
         }

--- a/tests/service_contract.rs
+++ b/tests/service_contract.rs
@@ -354,6 +354,96 @@ impl SourceProvider for FirecrawlLikeSourceProvider {
     }
 }
 
+/// Models the primary (Tavily) leg yielding nothing usable — e.g. every hit
+/// discarded by the relevance-score filter, or a genuinely empty result.
+struct EmptySearchSourceProvider;
+
+#[async_trait]
+impl SourceProvider for EmptySearchSourceProvider {
+    async fn search_sources(
+        &self,
+        _query: &str,
+        _max_results: usize,
+        _filters: &SearchFilters,
+    ) -> Result<Vec<Source>> {
+        Ok(Vec::new())
+    }
+
+    async fn fetch(&self, _url: &str) -> Result<FetchedPage> {
+        Ok(FetchedPage::text("empty provider fetch"))
+    }
+
+    async fn map(&self, _url: &str, _max_results: usize) -> Result<Vec<Source>> {
+        Ok(Vec::new())
+    }
+}
+
+// A filter-constrained request must never receive supplemental sources from
+// the filter-blind fallback provider: Firecrawl ignores SearchFilters, so
+// falling through would silently drop the caller's include/exclude/recency
+// constraints. Constrained requests are Tavily-or-nothing.
+#[tokio::test]
+async fn constrained_search_never_falls_through_to_filter_blind_fallback() {
+    let service = SearchService::fake_custom(
+        None,
+        Arc::new(EmptySearchSourceProvider),
+        Some(Arc::new(FirecrawlLikeSourceProvider)),
+        [] as [(&str, &str); 0],
+    );
+
+    let output = service
+        .web_search(WebSearchInput {
+            query: "rmcp Rust MCP SDK release".to_string(),
+            include_domains: vec!["github.com".to_string()],
+            include_content: Some(false),
+            ..Default::default()
+        })
+        .await
+        .expect("search output");
+
+    assert!(!output.fallback_used);
+    assert!(
+        output
+            .sources
+            .iter()
+            .all(|source| !source.url.contains("firecrawl.example")),
+        "constrained request must not surface filter-blind fallback sources: {:?}",
+        output.sources
+    );
+}
+
+// Unconstrained requests keep the legacy resilience: an empty primary result
+// still falls through to the fallback provider for enrichment.
+#[tokio::test]
+async fn unconstrained_search_still_falls_through_to_fallback_enrichment() {
+    let service = SearchService::fake_custom(
+        None,
+        Arc::new(EmptySearchSourceProvider),
+        Some(Arc::new(FirecrawlLikeSourceProvider)),
+        [] as [(&str, &str); 0],
+    );
+
+    let output = service
+        .web_search(WebSearchInput {
+            query: "rmcp Rust MCP SDK release".to_string(),
+            include_content: Some(false),
+            ..Default::default()
+        })
+        .await
+        .expect("search output");
+
+    assert!(!output.fallback_used);
+    assert!(
+        output
+            .sources
+            .iter()
+            .any(|source| source.provider == "firecrawl_enrichment"
+                && source.url.contains("firecrawl.example")),
+        "unconstrained request must still enrich via the fallback provider: {:?}",
+        output.sources
+    );
+}
+
 struct AlwaysErrExtractor;
 
 #[async_trait]

--- a/tests/tavily_parse.rs
+++ b/tests/tavily_parse.rs
@@ -22,6 +22,55 @@ fn normalizes_tavily_map_string_results() {
     assert_eq!(sources[0].provider, "tavily");
 }
 
+// Regression for the "latest ..." keyword-drift incident (2026-07-22): for
+// the query "latest rmcp Rust MCP SDK release version and what changed",
+// Tavily returned dictionary/news-portal pages about the word "latest" at
+// scores ≤ 0.04, and all of them shipped as `tavily_enrichment` sources.
+// On-topic results score ≥ 0.49 live; low-scored items must be dropped.
+#[test]
+fn normalize_drops_search_results_below_min_relevance_score() {
+    let raw = serde_json::json!({
+        "results": [
+            {"url": "https://www.wordwebonline.com/en/LATEST", "title": "latest, late, latests- WordWeb dictionary definition", "score": 0.03967239},
+            {"url": "https://github.com/modelcontextprotocol/rust-sdk/releases", "title": "Releases · modelcontextprotocol/rust-sdk · GitHub", "score": 0.79580134},
+            {"url": "https://www.nytimes.com", "title": "The New York Times - Breaking News", "score": 0.03402659},
+            {"url": "https://docs.rs/crate/rmcp/latest", "title": "rmcp - Docs.rs", "score": 0.71137124}
+        ]
+    });
+
+    let sources = normalize_tavily_results(&raw);
+
+    let urls: Vec<&str> = sources.iter().map(|source| source.url.as_str()).collect();
+    assert_eq!(
+        urls,
+        [
+            "https://github.com/modelcontextprotocol/rust-sdk/releases",
+            "https://docs.rs/crate/rmcp/latest"
+        ],
+        "junk-scored results must be dropped, order of survivors preserved"
+    );
+}
+
+#[test]
+fn normalize_keeps_results_at_threshold_or_without_score() {
+    let raw = serde_json::json!({
+        "results": [
+            {"url": "https://example.com/at-threshold", "score": 0.1},
+            {"url": "https://example.com/no-score", "title": "Score-less item"}
+        ]
+    });
+
+    let sources = normalize_tavily_results(&raw);
+
+    assert_eq!(
+        sources.len(),
+        2,
+        "cutoff is strict less-than; missing score must fail open"
+    );
+    assert_eq!(sources[0].url, "https://example.com/at-threshold");
+    assert_eq!(sources[1].url, "https://example.com/no-score");
+}
+
 #[test]
 fn tavily_map_request_uses_limit_not_max_results() {
     let body = tavily_map_request_body("https://openai.com/news/", 5);


### PR DESCRIPTION
## 问题

`web_search` 把用户自然语言 query **原样透传**给 Tavily(`service.rs` 的 speculative 预取 → `tavily_search_request_body`),长句易被单个通用词带偏。线上实测(2026-07-22)query:

> latest rmcp Rust MCP SDK release version and what changed

Grok 主来源 10 条全部正常,但 3 条 `tavily_enrichment` 补充来源全是垃圾:wordwebonline.com 的 "LATEST" 词典释义页、dictionary.cambridge.org 的 "latest" 词条、nytimes.com 首页——且各带数 KB 的无关 description,白白消耗 enrichment 抓取与响应预算。

## 根因

直连 Tavily 复现(与 service 完全相同的请求体)发现 Tavily 自带的相关性 `score` 字段早已给出判别信号,但 `normalize_tavily_results` 把它直接丢弃、照单全收:

| query | 结果 | score |
| - | - | - |
| 原句透传(现状) | 5/5 词典/门户垃圾 | **0.030–0.040** |
| 改写 "rmcp Rust MCP SDK release changelog" | 5/5 优质(github releases / docs.rs / crates.io) | 0.54–0.80 |
| 对照组正常 NL query | 5/5 正常 | 0.49–0.84 |

垃圾与在题结果之间存在 10 倍以上 score 断层。

## 修复(最小改动)

`normalize_tavily_results` 丢弃 `score < 0.1` 的搜索结果(阈值高于垃圾带 ~2.5x、低于在题下限 ~5x):

- 全部被过滤时,speculative 预取按既有逻辑落到 Firecrawl 兜底(`fetch_raw_extra_sources` 空结果分支,无新代码);
- 无 score 条目(map 端点返回裸 URL、API 演进)一律放行,`web_map` 行为不变;
- 不改并发结构:过滤发生在 join 之后的解析层,latency 仍为 max(Grok, Tavily)。

### 为什么不是 query 改写 / 域名惩罚

- 用 Grok 返回的实体改写补充 query 需要 Grok 先完成,会把 speculative fan-out(D-02 注释明确的 max-not-sum 设计)串行化;启发式去停用词则对所有 query 生效、回归风险大。score 过滤只删「Tavily 自己都认为不相关」的结果,零回归面。可作为后续召回优化再议。
- 词典/门户域名黑名单是 whack-a-mole,且被 score 信号完全覆盖。

## 验证

- `cargo test` 111 lib + 全部集成套件通过;新增 2 条回归测试(真实事故数据:垃圾 score 被拒、幸存顺序保持;阈值边界 = 严格小于、缺 score fail-open)
- `cargo clippy --all-targets -- -D warnings` 零警告;rustfmt 对本次触碰的两个文件通过(HEAD 上 http.rs 等文件存在与本 PR 无关的既有 fmt 漂移,未顺手重排)
- 本地 stdio 端到端(真实 key):
  - 事故 query → Tavily 5 条垃圾全部被过滤,来源落到 Firecrawl,词典/门户页面零出现
  - 对照 query → 健康 score 的 5 条 Tavily 结果(stackoverflow / blog.rust-lang.org 等)全部放行

## 影响面

仅 `TavilyProvider` 搜索结果解析一处;`web_fetch`(extract)、`web_map`(map)、Firecrawl、Grok 路径均不受影响。