### PR TITLE
style: reformat with rustfmt 1.9.0; ci: add fmt/clippy/test gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    name: fmt + clippy + test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+
+      - name: cargo fmt --check
+        run: cargo fmt --check
+
+      - name: cargo clippy
+        run: cargo clippy --all-targets -- -D warnings
+
+      - name: cargo test
+        run: cargo test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,8 +31,17 @@ jobs:
       - name: cargo fmt --check
         run: cargo fmt --check
 
-      - name: cargo clippy
-        run: cargo clippy --all-targets -- -D warnings
+      # Both release artifact families are gated here: the default build ships
+      # the stdio binaries, `--features http` ships the server binaries/image
+      # (release.yml builds both with --locked).
+      - name: cargo clippy (stdio)
+        run: cargo clippy --locked --all-targets -- -D warnings
 
-      - name: cargo test
-        run: cargo test
+      - name: cargo clippy (http)
+        run: cargo clippy --locked --all-targets --features http -- -D warnings
+
+      - name: cargo test (stdio)
+        run: cargo test --locked
+
+      - name: cargo test (http)
+        run: cargo test --locked --features http

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,6 +29,8 @@ cargo clippy --all-targets -- -D warnings
 cargo test
 ```
 
+PR CI runs these with `--locked` and repeats clippy/test with `--features http` (the deployed server build); when touching the HTTP path, run the `--features http` variants locally too.
+
 For documentation-only changes, at minimum inspect changed Markdown for stale command names and secret-like values.
 
 ## Releasing

--- a/src/http.rs
+++ b/src/http.rs
@@ -148,9 +148,7 @@ async fn mcp_post(State(state): State<AppState>, request: axum::extract::Request
     // Read the body under a hard size cap, now that the permit is held.
     let body = match axum::body::to_bytes(body, MAX_BODY_BYTES).await {
         Ok(bytes) => bytes,
-        Err(_) => {
-            return (StatusCode::PAYLOAD_TOO_LARGE, "request body too large").into_response()
-        }
+        Err(_) => return (StatusCode::PAYLOAD_TOO_LARGE, "request body too large").into_response(),
     };
 
     // 1. Origin validation (DNS-rebinding defense). Absent Origin (non-browser
@@ -350,8 +348,10 @@ fn sse_response(response: &Value) -> Response {
         CONTENT_TYPE,
         axum::http::HeaderValue::from_static("text/event-stream"),
     );
-    resp.headers_mut()
-        .insert(CACHE_CONTROL, axum::http::HeaderValue::from_static("no-cache"));
+    resp.headers_mut().insert(
+        CACHE_CONTROL,
+        axum::http::HeaderValue::from_static("no-cache"),
+    );
     resp
 }
 
@@ -435,7 +435,12 @@ async fn validate_public_url(
             format!("resolver task failed: {err}"),
         )
     })?
-    .map_err(|err| (StatusCode::BAD_REQUEST, format!("cannot resolve host: {err}")))?;
+    .map_err(|err| {
+        (
+            StatusCode::BAD_REQUEST,
+            format!("cannot resolve host: {err}"),
+        )
+    })?;
 
     if resolved.is_empty() {
         return Err((StatusCode::BAD_REQUEST, "host did not resolve".to_string()));
@@ -702,7 +707,9 @@ mod tests {
         }
         // Non-secret operator knobs survive.
         assert_eq!(
-            stripped.get("GROK_SEARCH_TIMEOUT_SECONDS").map(String::as_str),
+            stripped
+                .get("GROK_SEARCH_TIMEOUT_SECONDS")
+                .map(String::as_str),
             Some("30")
         );
     }
@@ -724,13 +731,13 @@ mod tests {
     async fn validate_public_url_blocks_ssrf_targets() {
         for bad in [
             "http://169.254.169.254/latest/meta-data/", // cloud metadata
-            "http://127.0.0.1/",                         // loopback
-            "http://10.0.0.5/",                          // private
-            "http://192.168.1.1/",                       // private
-            "http://100.64.0.1/",                        // CGNAT
-            "https://[::1]/",                            // IPv6 loopback
-            "file:///etc/passwd",                        // bad scheme
-            "gopher://example.com/",                     // bad scheme
+            "http://127.0.0.1/",                        // loopback
+            "http://10.0.0.5/",                         // private
+            "http://192.168.1.1/",                      // private
+            "http://100.64.0.1/",                       // CGNAT
+            "https://[::1]/",                           // IPv6 loopback
+            "file:///etc/passwd",                       // bad scheme
+            "gopher://example.com/",                    // bad scheme
         ] {
             assert!(
                 validate_public_url(bad, None).await.is_err(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -68,8 +68,7 @@ async fn async_main() -> anyhow::Result<()> {
             let bind: std::net::SocketAddr = addr
                 .parse()
                 .map_err(|err| anyhow::anyhow!("invalid GROK_MCP_BIND '{addr}': {err}"))?;
-            let base_env: std::collections::HashMap<String, String> =
-                std::env::vars().collect();
+            let base_env: std::collections::HashMap<String, String> = std::env::vars().collect();
             return grok_search_rs::http::run_http(base_env, bind).await;
         }
     }

--- a/src/sources/stackexchange.rs
+++ b/src/sources/stackexchange.rs
@@ -256,7 +256,11 @@ pub(crate) async fn fetch(client: &Client, url: &Url, max_answers: usize) -> Res
     };
 
     Ok(SeRaw {
-        title: decode_entities(item.get("title").and_then(|v| v.as_str()).unwrap_or_default()),
+        title: decode_entities(
+            item.get("title")
+                .and_then(|v| v.as_str())
+                .unwrap_or_default(),
+        ),
         body: field_str(item, "body_markdown", "body"),
         site,
         answers,

--- a/tests/integration_service.rs
+++ b/tests/integration_service.rs
@@ -46,7 +46,7 @@ async fn full_service_web_search_via_chat_completions() {
     assert!(!out.content.trim().is_empty(), "content empty");
     eprintln!(
         "content head: {}",
-        &out.content.chars().take(200).collect::<String>()
+        out.content.chars().take(200).collect::<String>()
     );
     eprintln!("sources_count: {}", out.sources_count);
     eprintln!("session_id: {}", out.session_id);


### PR DESCRIPTION
## Summary

Four commits:

**1. `style: reformat with stable rustfmt 1.9.0`** — pure formatting. On main HEAD (bdd75e4, v0.1.22), `cargo fmt --check` fails under stable rustfmt 1.9.0 (2026-04-14), so a clean checkout cannot satisfy the CONTRIBUTING.md Verification Checklist before any change is made. Drift (7 hunks, +27/−17): `src/http.rs` (match-arm brace↔expression rewrite, chain/closure rewrapping, comment column realignment in the SSRF test table), `src/sources/stackexchange.rs` (argument rewrapping), `src/main.rs` (line join). No token-level semantic changes.

**2. `ci: gate PRs on fmt, clippy, and tests`** — lightweight `ci.yml` running the CONTRIBUTING.md checklist on `pull_request` and pushes to `main`. Nothing enforced the checklist before, which is how the drift landed. Reuses the repo's existing action set (`actions/checkout@v4`, `dtolnay/rust-toolchain@stable`) plus `Swatinem/rust-cache@v2`; single job, least-privilege `contents: read`.

**3. `test: drop redundant borrow flagged by clippy 1.97`** — the new CI's first run proved its worth: CI installs latest stable (1.97), whose clippy ships the new `useless_borrows_in_formatting` lint and flagged a redundant `&` on an `eprintln!` argument in `tests/integration_service.rs` (local clippy 1.95 is silent on it). One-character fix, identical output.

**4. `ci: cover the http feature and enforce --locked`** — from Codex review (both P2s taken): clippy/test now run for **both release artifact families** — default (stdio binaries) and `--features http` (server binaries/GHCR image, matching release.yml's flags) — and every dependency-resolving cargo invocation uses `--locked`, so a stale Cargo.lock fails PR CI instead of release. CONTRIBUTING.md gains one line pointing at the CI variants.

## Verification

- CI on this PR: **green** — fmt, clippy ×2 configs, test ×2 configs, all `--locked` (run [29942602054](https://github.com/Episkey-G/GrokSearch-rs/actions/runs/29942602054), 57s warm-cache)
- Local (rust 1.95): all six commands clean; stdio tests 244 passed / 0 failed, http config also all green

## Notes

- No file overlap with open PRs #27/#28, so merge order does not matter. Once this merges, open PRs pick up the CI check on their next synchronize.
- `dtolnay/rust-toolchain@stable` is deliberately unpinned: a new stable that introduces fmt/clippy drift turns CI red immediately (as commit 3 demonstrates) instead of accumulating silently.
- Style/CI only — merging this does not require a release or redeploy.