### PR TITLE
fix(service): label firecrawl fallback sources firecrawl_fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,14 @@ All notable changes to GrokSearch-rs are documented here.
   同时收紧兜底语义(Codex 评审):Firecrawl 完全无视
   include/exclude_domains 与 recency_days,带这些约束的请求不再落入
   Firecrawl——约束请求 Tavily-or-nothing,不会静默拿到未过滤的补充来源。
+- **fallback 路径的 Firecrawl 来源 `provider` 标签从 `firecrawl_enrichment` 修正为
+  `firecrawl_fallback`。** Grok 失败或不可验证、且 Tavily 无结果时,Firecrawl 兜底
+  来源此前被标为 `firecrawl_enrichment`,与同一响应的 `search_provider=source_fallback`
+  / `fallback_used=true` 自相矛盾——标签语义是「provider 名 + 路径后缀」,
+  `_enrichment` 仅指 Grok 成功后的补充来源,按后缀区分补充/兜底的客户端会把兜底
+  来源误判为补充来源。该错位源自最初 firecrawl 分支硬编码标签、忽略路径参数,
+  后续重构机械保留。现修正标签并补 fallback 路径 provenance 测试,
+  docs/ARCHITECTURE.md 的 provenance 枚举同步新增 `firecrawl_fallback`。
 
 ## 0.1.22 - 2026-07-22
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -46,7 +46,8 @@ Sources retain their origin through the `provider` field:
 - `grok_responses`: native Responses citation or web search source.
 - `tavily_enrichment`: supplemental Tavily source after Grok succeeds.
 - `tavily_fallback`: Tavily source used because Grok failed or was unverifiable.
-- `firecrawl_enrichment`: Firecrawl source used when Tavily supplemental or fallback source lookup returns nothing.
+- `firecrawl_enrichment`: supplemental Firecrawl source after Grok succeeds, used when Tavily returns nothing.
+- `firecrawl_fallback`: Firecrawl source used because Grok failed or was unverifiable and Tavily returned nothing.
 - `tavily` / `firecrawl`: direct provider source before orchestration rewrites provenance.
 
 ## Fallback Rules

--- a/src/service.rs
+++ b/src/service.rs
@@ -991,7 +991,7 @@ fn enrichment_label(origin: RawSourceOrigin) -> &'static str {
 fn fallback_label(origin: RawSourceOrigin) -> &'static str {
     match origin {
         RawSourceOrigin::Primary => "tavily_fallback",
-        RawSourceOrigin::Fallback => "firecrawl_enrichment",
+        RawSourceOrigin::Fallback => "firecrawl_fallback",
         RawSourceOrigin::None => "tavily_fallback",
     }
 }

--- a/tests/service_contract.rs
+++ b/tests/service_contract.rs
@@ -247,6 +247,49 @@ async fn web_search_falls_back_to_tavily_when_grok_has_no_sources() {
         .all(|item| item.provider == "tavily_fallback"));
 }
 
+// The `_fallback` suffix on `provider` is the per-source counterpart of
+// `fallback_used=true`: Firecrawl-origin fallback sources must be labeled
+// `firecrawl_fallback`, never the enrichment label.
+#[tokio::test]
+async fn web_search_falls_back_to_firecrawl_when_tavily_returns_nothing() {
+    let service = SearchService::fake_custom(
+        Some(Arc::new(EmptySourcesAiProvider)),
+        Arc::new(FailingSourceProvider),
+        Some(Arc::new(FirecrawlLikeSourceProvider)),
+        [("GROK_SEARCH_FALLBACK_SOURCES", "3")],
+    );
+
+    let output = service
+        .web_search(WebSearchInput {
+            query: "OpenAI official updates".to_string(),
+            ..Default::default()
+        })
+        .await
+        .expect("fallback output");
+
+    assert_eq!(output.search_provider, "source_fallback");
+    assert!(output.fallback_used);
+    assert_eq!(
+        output.fallback_reason,
+        Some("grok_sources_empty".to_string())
+    );
+    assert_eq!(output.sources_count, 3);
+    assert!(output
+        .sources
+        .iter()
+        .all(|source| source.provider == "firecrawl_fallback"));
+
+    let cached = service
+        .get_sources(&output.session_id, 0, None)
+        .await
+        .expect("cached fallback sources");
+    assert_eq!(cached.sources_count, 3);
+    assert!(cached
+        .sources
+        .iter()
+        .all(|source| source.provider == "firecrawl_fallback"));
+}
+
 #[tokio::test]
 async fn fallback_honors_include_content_false() {
     // include_content=false is an explicit opt-out and must suppress inline


### PR DESCRIPTION
## 问题

`web_search` 走 source-fallback 路径(Grok 失败或不可验证)且来源由 Firecrawl 兜底时,`sources[].provider` 被标为 `firecrawl_enrichment`,与同一响应的 `search_provider=source_fallback` / `fallback_used=true` 自相矛盾(stdio 实测可复现)。按 `provider` 后缀区分补充/兜底来源的客户端会把兜底来源误判为补充来源。

## 考古结论:笔误,非有意兼容

- `firecrawl_fallback` 字符串在整个 git 历史中从未存在过(`git log -S` 零命中),不存在“曾有后改”的兼容回退。
- d847050 引入时,共享 helper `search_extra_sources(..., primary_provider)` 专门用参数区分 enrichment/fallback 两条路径的 tavily 标签,但 firecrawl 分支硬编码 `"firecrawl_enrichment"`、忽略该参数——为路径区分而设计的机制被 firecrawl 分支遗漏。
- 9240be6 重构成对称的 `enrichment_label`/`fallback_label` 时机械保留旧字符串;`fallback_label` 的 Fallback 分支返回 `_enrichment` 后缀与函数自身语义矛盾。
- ARCHITECTURE.md 旧措辞照抄代码现状,且与同节 `_enrichment`/`_fallback` 后缀定义自相矛盾;CHANGELOG 从未将该标签作为兼容契约记载;无任何测试断言 fallback 路径的 firecrawl 标签。

## 改动

- [src/service.rs](../blob/fix/firecrawl-fallback-provider-label/src/service.rs): `fallback_label(RawSourceOrigin::Fallback)` → `"firecrawl_fallback"`(一行)。
- [tests/service_contract.rs](../blob/fix/firecrawl-fallback-provider-label/tests/service_contract.rs): 新增 `web_search_falls_back_to_firecrawl_when_tavily_returns_nothing`,pin 住 fallback 路径 firecrawl 来源的 provenance(响应与 `get_sources` 缓存均断言),补上 CONTRIBUTING 要求的 source provenance / fallback behavior 覆盖。
- [docs/ARCHITECTURE.md](../blob/fix/firecrawl-fallback-provider-label/docs/ARCHITECTURE.md): provenance 枚举新增 `firecrawl_fallback`,`firecrawl_enrichment` 描述收窄为 Grok 成功路径。README 未枚举 provider 标签,无需改。
- CHANGELOG:Unreleased 新增 Fixed 条目。

## 验证

- `cargo clippy --all-targets -- -D warnings` 零告警;`cargo test` 全绿(含新测试)。
- `cargo fmt --check`:本 PR 改动文件无 diff。main 上 src/http.rs 等 3 个未触碰文件存在预存格式漂移(本机 rustfmt 1.9.0 规则差异),按外科式收敛不混入本 PR。

## 兼容性说明

输出标签属行为变化:此前依赖 fallback 路径返回 `firecrawl_enrichment` 的消费者(未发现有文档或测试依赖)会看到新标签 `firecrawl_fallback`。已在 CHANGELOG 显式记录。