### PR TITLE
fix(service): fail loudly when the source fallback yields nothing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,7 @@ All notable changes to GrokSearch-rs are documented here.
   (用户实测复现)。现在这种情况返回 `GrokSearchError::Provider`,消息里带上
   进入兜底的原因(如 `grok_provider_error`)、每个来源 provider 各自发生了什么,
   以及「怎样才能改变结果」的明确指引。`GROK_SEARCH_FALLBACK_SOURCES=0` 导致截断
-  为空的情况单独给出自己的原因。兜底拿到来源时行为完全不变。六处 Codex 评审
+  为空的情况单独给出自己的原因。兜底拿到来源时行为完全不变。八处 Codex 评审
   采纳:(1) metadata-only 的 Grok 响应(有引用无正文,`grok_content_empty`)
   其引用是真实证据,现合并进兜底结果而非连同报错一起丢弃——此前该路径本就
   静默丢弃 `response.sources`,现按成功路径同样的 `grok_responses` 标签保留;
@@ -69,7 +69,13 @@ All notable changes to GrokSearch-rs are documented here.
   配置,不再附加「provider 曾返回过结果」这个条件:`extra_sources` 非 0 时 fan-out
   照跑,provider 返回空则原本会掩盖掉真正的原因、转而建议「换 query」——可
   `truncate(0)` 会把任何结果清空,那条建议在该配置下**永远**不可能奏效。现在
-  budget 为 0 时一律优先报告它,同时保留 provider 的诊断。
+  budget 为 0 时一律优先报告它,同时保留 provider 的诊断。(7) 承 (6) 之后,能走到
+  `fallback_remediation` 的 `Config` note 只剩「provider 被 `*_ENABLED` 关掉」
+  一种(fan-out disabled 必然伴随 budget=0,已被前置分支拦截),而调大 budget
+  并不能把关掉的 provider 变出来,故该建议里去掉这半句。(8)「原样重试无用」
+  改为「原样重试会以同样方式失败,直到上述状况解除」:Grok 超时/5xx 会自行恢复,
+  绝对化的断言不成立;但对正在死循环的客户端模型,「此刻重试不会有变化」这个
+  信号必须保留——这正是本次修复的目的。
 - **兜底为什么没产出来源,现在能看见了。** `fetch_raw_extra_sources` 此前用
   `if let Ok(...)` 把 provider 错误整个吞掉,运维无从区分「key 没配」「provider
   被开关关掉」「429/432 限流」「本来就没结果」「带了 filters 所以跳过 Firecrawl」。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,7 @@ All notable changes to GrokSearch-rs are documented here.
   (用户实测复现)。现在这种情况返回 `GrokSearchError::Provider`,消息里带上
   进入兜底的原因(如 `grok_provider_error`)、每个来源 provider 各自发生了什么,
   以及「怎样才能改变结果」的明确指引。`GROK_SEARCH_FALLBACK_SOURCES=0` 导致截断
-  为空的情况单独给出自己的原因。兜底拿到来源时行为完全不变。五处 Codex 评审
+  为空的情况单独给出自己的原因。兜底拿到来源时行为完全不变。六处 Codex 评审
   采纳:(1) metadata-only 的 Grok 响应(有引用无正文,`grok_content_empty`)
   其引用是真实证据,现合并进兜底结果而非连同报错一起丢弃——此前该路径本就
   静默丢弃 `response.sources`,现按成功路径同样的 `grok_responses` 标签保留;
@@ -65,7 +65,11 @@ All notable changes to GrokSearch-rs are documented here.
   两个 normalizer 都只拒绝缺失/非字符串的 `url`(空串照收),而 `merge_sources`
   下游会把空 URL 全部丢弃,此前会导致 notes 连同"成功"一起被丢、最终错误消息
   谎称「no source provider was consulted」。现在要求至少一条可用 URL,否则记为
-  「results carried no usable URLs」。
+  「results carried no usable URLs」。(6) `FALLBACK_SOURCES=0` 的判定改为直接读
+  配置,不再附加「provider 曾返回过结果」这个条件:`extra_sources` 非 0 时 fan-out
+  照跑,provider 返回空则原本会掩盖掉真正的原因、转而建议「换 query」——可
+  `truncate(0)` 会把任何结果清空,那条建议在该配置下**永远**不可能奏效。现在
+  budget 为 0 时一律优先报告它,同时保留 provider 的诊断。
 - **兜底为什么没产出来源,现在能看见了。** `fetch_raw_extra_sources` 此前用
   `if let Ok(...)` 把 provider 错误整个吞掉,运维无从区分「key 没配」「provider
   被开关关掉」「429/432 限流」「本来就没结果」「带了 filters 所以跳过 Firecrawl」。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,7 @@ All notable changes to GrokSearch-rs are documented here.
   (用户实测复现)。现在这种情况返回 `GrokSearchError::Provider`,消息里带上
   进入兜底的原因(如 `grok_provider_error`)、每个来源 provider 各自发生了什么,
   以及「怎样才能改变结果」的明确指引。`GROK_SEARCH_FALLBACK_SOURCES=0` 导致截断
-  为空的情况单独给出自己的原因。兜底拿到来源时行为完全不变。三处 Codex 评审
+  为空的情况单独给出自己的原因。兜底拿到来源时行为完全不变。五处 Codex 评审
   采纳:(1) metadata-only 的 Grok 响应(有引用无正文,`grok_content_empty`)
   其引用是真实证据,现合并进兜底结果而非连同报错一起丢弃——此前该路径本就
   静默丢弃 `response.sources`,现按成功路径同样的 `grok_responses` 标签保留;
@@ -58,6 +58,14 @@ All notable changes to GrokSearch-rs are documented here.
   关掉(两个 budget 都为 0,或 `*_ENABLED` 关闭)说「开启 provider 或调大
   `GROK_SEARCH_FALLBACK_SOURCES`」;只有缺 key 或上游报错才说「修凭据/上游」。
   此前把「配置主动关掉」和「上游坏了」混为一类,会让运维去查根本没问题的凭据。
+  (4) 混合情形改为**组合**而非单选优先级:Tavily 正常返回空、Firecrawl 缺 key
+  时,换个 query 仍可能从 Tavily 拿到结果而无需动 Firecrawl 的凭据,故两条建议
+  同时给出;只有在**没有任何 provider 正常作答**时才附上「原样重试无用」这句
+  ——那正是打断死循环所需的信号。(5) `url` 为空串的结果不再算作 provider 成功:
+  两个 normalizer 都只拒绝缺失/非字符串的 `url`(空串照收),而 `merge_sources`
+  下游会把空 URL 全部丢弃,此前会导致 notes 连同"成功"一起被丢、最终错误消息
+  谎称「no source provider was consulted」。现在要求至少一条可用 URL,否则记为
+  「results carried no usable URLs」。
 - **兜底为什么没产出来源,现在能看见了。** `fetch_raw_extra_sources` 此前用
   `if let Ok(...)` 把 provider 错误整个吞掉,运维无从区分「key 没配」「provider
   被开关关掉」「429/432 限流」「本来就没结果」「带了 filters 所以跳过 Firecrawl」。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,8 +46,16 @@ All notable changes to GrokSearch-rs are documented here.
   于是换个措辞重试,每次都走同一条死路径拿到同样的空壳成功,形成无限重试循环
   (用户实测复现)。现在这种情况返回 `GrokSearchError::Provider`,消息里带上
   进入兜底的原因(如 `grok_provider_error`)、每个来源 provider 各自发生了什么,
-  以及「重试无用」的明确信号。`GROK_SEARCH_FALLBACK_SOURCES=0` 导致截断为空的
-  情况单独给出自己的原因。兜底拿到来源时行为完全不变。
+  以及「怎样才能改变结果」的明确指引。`GROK_SEARCH_FALLBACK_SOURCES=0` 导致截断
+  为空的情况单独给出自己的原因。兜底拿到来源时行为完全不变。三处 Codex 评审
+  采纳:(1) metadata-only 的 Grok 响应(有引用无正文,`grok_content_empty`)
+  其引用是真实证据,现合并进兜底结果而非连同报错一起丢弃——此前该路径本就
+  静默丢弃 `response.sources`,现按成功路径同样的 `grok_responses` 标签保留;
+  (2) provider 错误会原样引用上游响应体(可为任意大的 HTML 错误页),而这些
+  诊断现在走的是不受响应预算约束的错误通道,故每条 note 截断至 300 字符;
+  (3) provider 正常返回空结果(或因 filters 被有意跳过 Firecrawl)时,建议改为
+  「换 query 或放宽 filters」,不再一律说「修凭据/上游」——那种情况下换个查询
+  恰恰是唯一有用的动作。
 - **兜底为什么没产出来源,现在能看见了。** `fetch_raw_extra_sources` 此前用
   `if let Ok(...)` 把 provider 错误整个吞掉,运维无从区分「key 没配」「provider
   被开关关掉」「429/432 限流」「本来就没结果」「带了 filters 所以跳过 Firecrawl」。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,7 @@ All notable changes to GrokSearch-rs are documented here.
   (用户实测复现)。现在这种情况返回 `GrokSearchError::Provider`,消息里带上
   进入兜底的原因(如 `grok_provider_error`)、每个来源 provider 各自发生了什么,
   以及「怎样才能改变结果」的明确指引。`GROK_SEARCH_FALLBACK_SOURCES=0` 导致截断
-  为空的情况单独给出自己的原因。兜底拿到来源时行为完全不变。十处 Codex 评审
+  为空的情况单独给出自己的原因。兜底拿到来源时行为完全不变。十一处 Codex 评审
   采纳:(1) metadata-only 的 Grok 响应(有引用无正文,`grok_content_empty`)
   其引用是真实证据,现合并进兜底结果而非连同报错一起丢弃——此前该路径本就
   静默丢弃 `response.sources`,现按成功路径同样的 `grok_responses` 标签保留;
@@ -83,7 +83,12 @@ All notable changes to GrokSearch-rs are documented here.
   通过判定,随后 `truncate(budget)` 先执行、`merge_sources` 丢空 URL 后执行——
   budget=1 时那条有效来源会被空条目挤掉,整个请求以硬错误告终(enrichment 主
   路径同理,该问题早于本 PR 存在)。现在在构造 `RawSources::found` 前就滤掉空
-  URL,截断只作用于确定能存活的来源。
+  URL,截断只作用于确定能存活的来源。(11) 空白的 `TAVILY_API_KEY` /
+  `FIRECRAWL_API_KEY` 归一化为「未配置」:此前 `Some("")` 会照常构造出 provider,
+  那个 provider 只能对每次调用 401,而所有可用性判断(含本次新增的 filters 闸门、
+  以及 `doctor`)都会把它报成「已配置」。相邻字段(`grok_auth_file`、
+  `openai_compatible_*`)本就有这层过滤,两个 source key 是漏了;现补齐并按
+  `trim()` 判断——全空白的 key 不比空串更可用。
 - **兜底为什么没产出来源,现在能看见了。** `fetch_raw_extra_sources` 此前用
   `if let Ok(...)` 把 provider 错误整个吞掉,运维无从区分「key 没配」「provider
   被开关关掉」「429/432 限流」「本来就没结果」「带了 filters 所以跳过 Firecrawl」。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,7 @@ All notable changes to GrokSearch-rs are documented here.
   (用户实测复现)。现在这种情况返回 `GrokSearchError::Provider`,消息里带上
   进入兜底的原因(如 `grok_provider_error`)、每个来源 provider 各自发生了什么,
   以及「怎样才能改变结果」的明确指引。`GROK_SEARCH_FALLBACK_SOURCES=0` 导致截断
-  为空的情况单独给出自己的原因。兜底拿到来源时行为完全不变。八处 Codex 评审
+  为空的情况单独给出自己的原因。兜底拿到来源时行为完全不变。九处 Codex 评审
   采纳:(1) metadata-only 的 Grok 响应(有引用无正文,`grok_content_empty`)
   其引用是真实证据,现合并进兜底结果而非连同报错一起丢弃——此前该路径本就
   静默丢弃 `response.sources`,现按成功路径同样的 `grok_responses` 标签保留;
@@ -75,7 +75,10 @@ All notable changes to GrokSearch-rs are documented here.
   并不能把关掉的 provider 变出来,故该建议里去掉这半句。(8)「原样重试无用」
   改为「原样重试会以同样方式失败,直到上述状况解除」:Grok 超时/5xx 会自行恢复,
   绝对化的断言不成立;但对正在死循环的客户端模型,「此刻重试不会有变化」这个
-  信号必须保留——这正是本次修复的目的。
+  信号必须保留——这正是本次修复的目的。(9) filters 跳过 Firecrawl 那条 note 不再
+  无条件记为「正常空结果」:只有 Firecrawl 确实配好时,「放宽 filters」才是真能
+  奏效的补救;若 Firecrawl 本就没配或被关掉,放宽 filters 也够不到任何 provider,
+  此时改记为对应的不可用 note(两条事实都保留:被 filters 跳过 + 本来也不可用)。
 - **兜底为什么没产出来源,现在能看见了。** `fetch_raw_extra_sources` 此前用
   `if let Ok(...)` 把 provider 错误整个吞掉,运维无从区分「key 没配」「provider
   被开关关掉」「429/432 限流」「本来就没结果」「带了 filters 所以跳过 Firecrawl」。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,7 @@ All notable changes to GrokSearch-rs are documented here.
   (用户实测复现)。现在这种情况返回 `GrokSearchError::Provider`,消息里带上
   进入兜底的原因(如 `grok_provider_error`)、每个来源 provider 各自发生了什么,
   以及「怎样才能改变结果」的明确指引。`GROK_SEARCH_FALLBACK_SOURCES=0` 导致截断
-  为空的情况单独给出自己的原因。兜底拿到来源时行为完全不变。九处 Codex 评审
+  为空的情况单独给出自己的原因。兜底拿到来源时行为完全不变。十处 Codex 评审
   采纳:(1) metadata-only 的 Grok 响应(有引用无正文,`grok_content_empty`)
   其引用是真实证据,现合并进兜底结果而非连同报错一起丢弃——此前该路径本就
   静默丢弃 `response.sources`,现按成功路径同样的 `grok_responses` 标签保留;
@@ -79,6 +79,11 @@ All notable changes to GrokSearch-rs are documented here.
   无条件记为「正常空结果」:只有 Firecrawl 确实配好时,「放宽 filters」才是真能
   奏效的补救;若 Firecrawl 本就没配或被关掉,放宽 filters 也够不到任何 provider,
   此时改记为对应的不可用 note(两条事实都保留:被 filters 跳过 + 本来也不可用)。
+  (10) 空 URL 改为**过滤**而非仅**判定**:此前 `[空, 有效]` 这样的结果会整体
+  通过判定,随后 `truncate(budget)` 先执行、`merge_sources` 丢空 URL 后执行——
+  budget=1 时那条有效来源会被空条目挤掉,整个请求以硬错误告终(enrichment 主
+  路径同理,该问题早于本 PR 存在)。现在在构造 `RawSources::found` 前就滤掉空
+  URL,截断只作用于确定能存活的来源。
 - **兜底为什么没产出来源,现在能看见了。** `fetch_raw_extra_sources` 此前用
   `if let Ok(...)` 把 provider 错误整个吞掉,运维无从区分「key 没配」「provider
   被开关关掉」「429/432 限流」「本来就没结果」「带了 filters 所以跳过 Firecrawl」。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,9 +53,11 @@ All notable changes to GrokSearch-rs are documented here.
   静默丢弃 `response.sources`,现按成功路径同样的 `grok_responses` 标签保留;
   (2) provider 错误会原样引用上游响应体(可为任意大的 HTML 错误页),而这些
   诊断现在走的是不受响应预算约束的错误通道,故每条 note 截断至 300 字符;
-  (3) provider 正常返回空结果(或因 filters 被有意跳过 Firecrawl)时,建议改为
-  「换 query 或放宽 filters」,不再一律说「修凭据/上游」——那种情况下换个查询
-  恰恰是唯一有用的动作。
+  (3) 补救建议按 note 三态给出而非一刀切——provider 正常返回空结果(或因
+  filters 被有意跳过 Firecrawl)说「换 query 或放宽 filters」;fan-out 被配置
+  关掉(两个 budget 都为 0,或 `*_ENABLED` 关闭)说「开启 provider 或调大
+  `GROK_SEARCH_FALLBACK_SOURCES`」;只有缺 key 或上游报错才说「修凭据/上游」。
+  此前把「配置主动关掉」和「上游坏了」混为一类,会让运维去查根本没问题的凭据。
 - **兜底为什么没产出来源,现在能看见了。** `fetch_raw_extra_sources` 此前用
   `if let Ok(...)` 把 provider 错误整个吞掉,运维无从区分「key 没配」「provider
   被开关关掉」「429/432 限流」「本来就没结果」「带了 filters 所以跳过 Firecrawl」。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,30 @@ All notable changes to GrokSearch-rs are documented here.
   来源误判为补充来源。该错位源自最初 firecrawl 分支硬编码标签、忽略路径参数,
   后续重构机械保留。现修正标签并补 fallback 路径 provenance 测试,
   docs/ARCHITECTURE.md 的 provenance 枚举同步新增 `firecrawl_fallback`。
+- **兜底一条来源都没拿到时,`web_search` 不再返回「成功但空」的结果——改为报错。**
+  Grok 上游挂掉后走 `finalize_fallback`,若 Tavily/Firecrawl 也没产出任何来源,
+  此前仍返回 `Ok`:`sources_count: 0`、无 `isError`,正文写着「Source fallback
+  returned 0 source(s); evaluate them directly」——而一条来源都没有,原始 Grok
+  文本在这条路径上也是被丢弃的。客户端模型把它读成「工具是好的,只是这次没搜到」,
+  于是换个措辞重试,每次都走同一条死路径拿到同样的空壳成功,形成无限重试循环
+  (用户实测复现)。现在这种情况返回 `GrokSearchError::Provider`,消息里带上
+  进入兜底的原因(如 `grok_provider_error`)、每个来源 provider 各自发生了什么,
+  以及「重试无用」的明确信号。`GROK_SEARCH_FALLBACK_SOURCES=0` 导致截断为空的
+  情况单独给出自己的原因。兜底拿到来源时行为完全不变。
+- **兜底为什么没产出来源,现在能看见了。** `fetch_raw_extra_sources` 此前用
+  `if let Ok(...)` 把 provider 错误整个吞掉,运维无从区分「key 没配」「provider
+  被开关关掉」「429/432 限流」「本来就没结果」「带了 filters 所以跳过 Firecrawl」。
+  现在每条失败路径都记录成一句 note(如 `tavily: provider error: Tavily returned
+  HTTP 432 …`、`firecrawl: no API key (FIRECRAWL_API_KEY for stdio,
+  x-firecrawl-api-key header for the HTTP transport)`、`firecrawl: skipped
+  (request carries domain/recency filters …)`),汇总进上面那条错误消息。
+  note 只含 endpoint 与上游响应体,不含任何凭据。
+- **HTTP 传输启动时,会对被忽略的服务端凭据环境变量告警。** 远程传输按设计
+  剥离服务端的 `TAVILY_API_KEY` / `FIRECRAWL_API_KEY` 等(凭据只来自请求头),
+  但此前是静默剥离:自托管者在 docker-compose 里配好 key,服务端看起来一切正常,
+  实际每个请求都在没有任何兜底 provider 的状态下跑,且没有任何线索指向原因。
+  现在 `run_http` 启动时对每个存在的被剥离变量打一行 warning,并指明应改用哪个
+  请求头(如 `x-tavily-api-key`)。只打变量名与请求头名,绝不打值。
 
 ## 0.1.22 - 2026-07-22
 

--- a/README.md
+++ b/README.md
@@ -252,6 +252,11 @@ each pays with their own keys:
 - `X-Grok-Api-Key`, `X-Tavily-Api-Key`, `X-Firecrawl-Api-Key` (optional `X-GitHub-Token`)
 - Optional non‑secret overrides: `X-Grok-Base-Url` (gateway), `X-Grok-Model` (model name, since model ids are gateway‑specific)
 
+This cuts both ways: setting `TAVILY_API_KEY` / `FIRECRAWL_API_KEY` in the **server's** own
+environment (compose file, `.env`, systemd unit) has no effect — those are stripped from every
+per‑request config, so requests that don't carry the header run with no source fallback at all.
+The server logs a warning at startup for each such variable it finds.
+
 A missing required key returns `401` (fail‑closed); OAuth is rejected on this transport
 (stdio only). The operator sets the default Grok‑compatible gateway via `GROK_SEARCH_URL`
 (default `https://api.x.ai`), and callers may point at any other Grok‑compatible gateway with an

--- a/src/config.rs
+++ b/src/config.rs
@@ -279,14 +279,26 @@ impl Config {
                 "TAVILY_API_URL",
                 "https://api.tavily.com",
             )),
-            tavily_api_key: map.get("TAVILY_API_KEY").cloned(),
+            // Blank means absent, as it already does for the auth file and the
+            // OpenAI-compatible settings below. Kept as `Some("")` these build
+            // a provider that exists only to 401 on every call, which makes
+            // `doctor` and every availability check report a source that is
+            // configured when nothing can come of it. Trimmed, because a
+            // whitespace-only key is no more usable than an empty one.
+            tavily_api_key: map
+                .get("TAVILY_API_KEY")
+                .cloned()
+                .filter(|value| !value.trim().is_empty()),
             tavily_enabled: bool_value(&map, "TAVILY_ENABLED", true),
             firecrawl_api_url: normalize_v1_base(&get(
                 &map,
                 "FIRECRAWL_API_URL",
                 "https://api.firecrawl.dev",
             )),
-            firecrawl_api_key: map.get("FIRECRAWL_API_KEY").cloned(),
+            firecrawl_api_key: map
+                .get("FIRECRAWL_API_KEY")
+                .cloned()
+                .filter(|value| !value.trim().is_empty()),
             firecrawl_enabled: bool_value(&map, "FIRECRAWL_ENABLED", true),
             default_extra_sources: usize_value(&map, "GROK_SEARCH_EXTRA_SOURCES", 3),
             fallback_sources: usize_value(&map, "GROK_SEARCH_FALLBACK_SOURCES", 5),
@@ -643,6 +655,23 @@ mod source_config_tests {
         let cfg = Config::from_env_map(Vec::<(String, String)>::new());
         assert_eq!(cfg.source_max_answers, 5);
         assert_eq!(cfg.source_max_comments, 30);
+    }
+
+    // A blank key must read as absent, not as a configured provider: kept as
+    // `Some("")` it builds a source provider that can only 401, and every
+    // availability check downstream then reports a source that cannot work.
+    #[test]
+    fn blank_source_keys_read_as_absent() {
+        let cfg = Config::from_env_map([("TAVILY_API_KEY", ""), ("FIRECRAWL_API_KEY", "   ")]);
+        assert_eq!(cfg.tavily_api_key, None);
+        assert_eq!(cfg.firecrawl_api_key, None);
+
+        let configured = Config::from_env_map([
+            ("TAVILY_API_KEY", "tvly-real"),
+            ("FIRECRAWL_API_KEY", "fc-1"),
+        ]);
+        assert_eq!(configured.tavily_api_key.as_deref(), Some("tvly-real"));
+        assert_eq!(configured.firecrawl_api_key.as_deref(), Some("fc-1"));
     }
 
     #[test]

--- a/src/http.rs
+++ b/src/http.rs
@@ -109,6 +109,7 @@ pub async fn run_http(base_env: HashMap<String, String>, bind: SocketAddr) -> an
     let http_client = crate::providers::http::build_restricted_client(operator_cfg.timeout);
     let cache = Arc::new(Mutex::new(SourceCache::new(operator_cfg.cache_size)));
     let allowed_origins = parse_allowed_origins(&base_env);
+    warn_ignored_secret_env(&base_env);
 
     let state = AppState {
         http_client,
@@ -589,6 +590,38 @@ fn strip_secrets(mut env: HashMap<String, String>) -> HashMap<String, String> {
     env
 }
 
+/// Warn once at startup for every credential env var the operator set that this
+/// transport ignores. [`strip_secrets`] drops them from every per-request config
+/// by design — keys come from headers — but it did so silently, so a self-hoster
+/// who put `TAVILY_API_KEY` in their compose file got a server that looked
+/// configured while every request ran with no source fallback at all. Prints
+/// variable and header *names* only, never a value.
+fn warn_ignored_secret_env(env: &HashMap<String, String>) {
+    for key in SECRET_ENV_KEYS {
+        if !env.get(*key).is_some_and(|value| !value.trim().is_empty()) {
+            continue;
+        }
+        match header_for_env(key) {
+            Some(header) => eprintln!(
+                "grok-search-rs: {key} is set in the server environment but the HTTP transport ignores it — callers must send the {header} request header instead"
+            ),
+            None => eprintln!(
+                "grok-search-rs: {key} is set in the server environment but the HTTP transport ignores it"
+            ),
+        }
+    }
+}
+
+/// The request header that carries `env_key` on this transport, if any. Header
+/// names are matched case-insensitively; this returns the lowercase spelling
+/// [`HEADER_TO_ENV`] stores.
+fn header_for_env(env_key: &str) -> Option<&'static str> {
+    HEADER_TO_ENV
+        .iter()
+        .find(|(_, key)| *key == env_key)
+        .map(|(header, _)| *header)
+}
+
 /// Parse `GROK_MCP_ALLOWED_ORIGINS` (comma-separated) into an allowlist.
 /// Unset/empty -> `None` (no browser-origin restriction; keys are per-request).
 fn parse_allowed_origins(env: &HashMap<String, String>) -> Option<HashSet<String>> {
@@ -621,6 +654,24 @@ mod tests {
 
     fn base() -> HashMap<String, String> {
         HashMap::new()
+    }
+
+    // Every stripped credential that has a header equivalent must be able to
+    // name it, so the startup warning tells the operator what to do instead of
+    // just what was ignored.
+    #[test]
+    fn header_for_env_names_the_credential_headers() {
+        assert_eq!(header_for_env("TAVILY_API_KEY"), Some("x-tavily-api-key"));
+        assert_eq!(
+            header_for_env("FIRECRAWL_API_KEY"),
+            Some("x-firecrawl-api-key")
+        );
+        assert_eq!(
+            header_for_env("GROK_SEARCH_API_KEY"),
+            Some("x-grok-api-key")
+        );
+        // Stripped but header-less: the warning falls back to the short form.
+        assert_eq!(header_for_env("GROK_SEARCH_AUTH_FILE"), None);
     }
 
     fn headers(pairs: &[(&str, &str)]) -> HeaderMap {

--- a/src/service.rs
+++ b/src/service.rs
@@ -595,7 +595,7 @@ impl SearchService {
         filters: &SearchFilters,
     ) -> RawSources {
         if count == 0 {
-            return RawSources::empty(vec![SourceNote::faulty(
+            return RawSources::empty(vec![SourceNote::config(
                 "source fan-out disabled (extra_sources and fallback_sources are both 0)",
             )]);
         }
@@ -605,18 +605,16 @@ impl SearchService {
                 Ok(sources) if !sources.is_empty() => {
                     return RawSources::found(sources, RawSourceOrigin::Primary)
                 }
-                Ok(_) => notes.push(SourceNote::healthy("tavily: no results")),
-                Err(err) => notes.push(SourceNote::faulty(format!("tavily: {err}"))),
+                Ok(_) => notes.push(SourceNote::no_results("tavily: no results")),
+                Err(err) => notes.push(SourceNote::broken(format!("tavily: {err}"))),
             },
-            None => notes.push(SourceNote::faulty(format!(
-                "tavily: {}",
-                unavailable_note(
-                    self.config.tavily_enabled,
-                    "TAVILY_ENABLED",
-                    "TAVILY_API_KEY",
-                    "x-tavily-api-key",
-                )
-            ))),
+            None => notes.push(unavailable_note(
+                "tavily",
+                self.config.tavily_enabled,
+                "TAVILY_ENABLED",
+                "TAVILY_API_KEY",
+                "x-tavily-api-key",
+            )),
         }
         // The fallback source provider (Firecrawl) ignores `SearchFilters`
         // outright — it has no structured recency/domain support — so a
@@ -625,7 +623,7 @@ impl SearchService {
         // silently violate the include/exclude/recency contract. Constrained
         // requests are Tavily-or-nothing.
         if !filters.is_empty() {
-            notes.push(SourceNote::healthy(
+            notes.push(SourceNote::no_results(
                 "firecrawl: skipped (request carries domain/recency filters, which firecrawl cannot honor)",
             ));
             return RawSources::empty(notes);
@@ -635,18 +633,16 @@ impl SearchService {
                 Ok(sources) if !sources.is_empty() => {
                     return RawSources::found(sources, RawSourceOrigin::Fallback)
                 }
-                Ok(_) => notes.push(SourceNote::healthy("firecrawl: no results")),
-                Err(err) => notes.push(SourceNote::faulty(format!("firecrawl: {err}"))),
+                Ok(_) => notes.push(SourceNote::no_results("firecrawl: no results")),
+                Err(err) => notes.push(SourceNote::broken(format!("firecrawl: {err}"))),
             },
-            None => notes.push(SourceNote::faulty(format!(
-                "firecrawl: {}",
-                unavailable_note(
-                    self.config.firecrawl_enabled,
-                    "FIRECRAWL_ENABLED",
-                    "FIRECRAWL_API_KEY",
-                    "x-firecrawl-api-key",
-                )
-            ))),
+            None => notes.push(unavailable_note(
+                "firecrawl",
+                self.config.firecrawl_enabled,
+                "FIRECRAWL_ENABLED",
+                "FIRECRAWL_API_KEY",
+                "x-firecrawl-api-key",
+            )),
         }
         RawSources::empty(notes)
     }
@@ -1057,29 +1053,48 @@ impl RawSources {
 /// so each one is capped where it is recorded.
 const MAX_SOURCE_NOTE_CHARS: usize = 300;
 
+/// What kind of dead end a provider hit, which is what decides the useful
+/// remedy. Collapsing these into "did it work" would hand every failure the
+/// same advice, and the advice differs sharply: a deliberately disabled
+/// fan-out is not a broken upstream, and neither is an honest empty result.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum NoteKind {
+    /// The provider answered normally and simply had no matches, or was
+    /// deliberately skipped by the filter gate. The query is the thing to
+    /// change.
+    NoResults,
+    /// The operator switched this path off — a disabled provider, or a source
+    /// budget of zero. Nothing is broken; the configuration says no.
+    Config,
+    /// A missing credential or an upstream failure. Something has to be fixed
+    /// before this path can work at all.
+    Broken,
+}
+
 /// One provider's account of why it produced nothing.
 struct SourceNote {
-    /// The provider answered normally and simply had no matches, or was
-    /// deliberately skipped by the filter gate. Kept apart from a missing key,
-    /// a disabled provider, or an upstream error because the useful
-    /// remediation differs: change the query, not the credentials.
-    healthy: bool,
+    kind: NoteKind,
     detail: String,
 }
 
 impl SourceNote {
-    fn healthy(detail: impl Into<String>) -> Self {
+    fn new(kind: NoteKind, detail: impl Into<String>) -> Self {
         Self {
-            healthy: true,
+            kind,
             detail: truncate_note(detail.into()),
         }
     }
 
-    fn faulty(detail: impl Into<String>) -> Self {
-        Self {
-            healthy: false,
-            detail: truncate_note(detail.into()),
-        }
+    fn no_results(detail: impl Into<String>) -> Self {
+        Self::new(NoteKind::NoResults, detail)
+    }
+
+    fn config(detail: impl Into<String>) -> Self {
+        Self::new(NoteKind::Config, detail)
+    }
+
+    fn broken(detail: impl Into<String>) -> Self {
+        Self::new(NoteKind::Broken, detail)
     }
 }
 
@@ -1113,28 +1128,41 @@ fn source_diagnosis(notes: &[SourceNote]) -> String {
     }
 }
 
-/// What would actually change the outcome. Providers that answered normally
-/// with nothing to show are not a broken upstream: there the query or the
-/// filters are the thing to change, and telling the caller that retrying
-/// cannot help would rule out the one move that works.
+/// What would actually change the outcome, picked from the most actionable
+/// note present: something genuinely broken outranks a configuration gate,
+/// which outranks an honest empty result. Telling a caller with a healthy but
+/// empty result set to go fix credentials would rule out the one move that
+/// works — and so would telling an operator who switched the fan-out off that
+/// their upstream is at fault.
 fn fallback_remediation(notes: &[SourceNote]) -> &'static str {
-    if !notes.is_empty() && notes.iter().all(|note| note.healthy) {
-        "The source providers answered normally with no matches, so a different query or looser filters may help; repeating this one will not."
-    } else {
-        "Retrying will not help until the Grok upstream or the source-provider credentials are fixed."
+    if notes.is_empty() || notes.iter().any(|note| note.kind == NoteKind::Broken) {
+        return "Retrying will not help until the Grok upstream or the source-provider credentials are fixed.";
     }
+    if notes.iter().any(|note| note.kind == NoteKind::Config) {
+        return "No source provider was available to consult; enable one (TAVILY_ENABLED / FIRECRAWL_ENABLED) or raise GROK_SEARCH_FALLBACK_SOURCES to get evidence on this path.";
+    }
+    "The source providers answered normally with no matches, so a different query or looser filters may help; repeating this one will not."
 }
 
 /// Why a source provider is absent from the service: the operator switched it
-/// off, or no key ever reached the process. The key hint names both channels
-/// because the HTTP transport ignores server-side env keys entirely — a
-/// self-hoster who set the key in their compose file needs to be told that the
-/// request header is the only one that counts there.
-fn unavailable_note(enabled: bool, enable_var: &str, key_var: &str, header: &str) -> String {
+/// off (a configuration choice), or no key ever reached the process (something
+/// to fix). The key hint names both channels because the HTTP transport
+/// ignores server-side env keys entirely — a self-hoster who set the key in
+/// their compose file needs to be told that the request header is the only one
+/// that counts there.
+fn unavailable_note(
+    provider: &str,
+    enabled: bool,
+    enable_var: &str,
+    key_var: &str,
+    header: &str,
+) -> SourceNote {
     if enabled {
-        format!("no API key ({key_var} for stdio, {header} header for the HTTP transport)")
+        SourceNote::broken(format!(
+            "{provider}: no API key ({key_var} for stdio, {header} header for the HTTP transport)"
+        ))
     } else {
-        format!("disabled via {enable_var}")
+        SourceNote::config(format!("{provider}: disabled via {enable_var}"))
     }
 }
 

--- a/src/service.rs
+++ b/src/service.rs
@@ -494,8 +494,7 @@ impl SearchService {
         let grok_future = self.ai.search(&request);
         let speculative_future =
             self.fetch_raw_extra_sources(&input.query, speculative_count, &filters);
-        let (grok_result, (raw_sources, raw_origin)) =
-            tokio::join!(grok_future, speculative_future);
+        let (grok_result, raw) = tokio::join!(grok_future, speculative_future);
 
         let response = match grok_result {
             Ok(response) => response,
@@ -508,8 +507,7 @@ impl SearchService {
                             content: String::new(),
                             sources: Vec::new(),
                         },
-                        raw_sources,
-                        raw_origin,
+                        raw,
                         grok_error_reason(&err),
                         include_content,
                     )
@@ -519,21 +517,13 @@ impl SearchService {
 
         if let Some(reason) = grok_unverifiable_reason(&response) {
             return self
-                .finalize_fallback(
-                    deadline,
-                    session_id,
-                    response,
-                    raw_sources,
-                    raw_origin,
-                    reason,
-                    include_content,
-                )
+                .finalize_fallback(deadline, session_id, response, raw, reason, include_content)
                 .await;
         }
 
-        let mut enrichment = raw_sources;
+        let mut enrichment = raw.sources;
         enrichment.truncate(effective_extra_sources);
-        let enrichment = with_provider(enrichment, enrichment_label(raw_origin));
+        let enrichment = with_provider(enrichment, enrichment_label(raw.origin));
         let merged = merge_sources(response.sources, enrichment);
         // SRCH-04 dual gate (zero-regression): skip enrichment when the caller
         // opted out OR there are no supplemental sources. Gating on
@@ -592,21 +582,42 @@ impl SearchService {
     /// returned Vec carries each provider's native label ("tavily"/"firecrawl");
     /// the caller re-labels via `with_provider` once the path (enrichment vs
     /// fallback) is known.
+    ///
+    /// Every path that yields nothing records *why* in [`RawSources::notes`].
+    /// Provider errors used to be swallowed outright, which left a request that
+    /// ended with zero sources indistinguishable from one where every upstream
+    /// was simply out of results — the operator had no way to tell an unset key
+    /// from a rate-limited one.
     async fn fetch_raw_extra_sources(
         &self,
         query: &str,
         count: usize,
         filters: &SearchFilters,
-    ) -> (Vec<Source>, RawSourceOrigin) {
+    ) -> RawSources {
         if count == 0 {
-            return (Vec::new(), RawSourceOrigin::None);
+            return RawSources::empty(vec![
+                "source fan-out disabled (extra_sources and fallback_sources are both 0)"
+                    .to_string(),
+            ]);
         }
-        if let Some(provider) = &self.sources {
-            if let Ok(sources) = provider.search_sources(query, count, filters).await {
-                if !sources.is_empty() {
-                    return (sources, RawSourceOrigin::Primary);
+        let mut notes = Vec::new();
+        match &self.sources {
+            Some(provider) => match provider.search_sources(query, count, filters).await {
+                Ok(sources) if !sources.is_empty() => {
+                    return RawSources::found(sources, RawSourceOrigin::Primary)
                 }
-            }
+                Ok(_) => notes.push("tavily: no results".to_string()),
+                Err(err) => notes.push(format!("tavily: {err}")),
+            },
+            None => notes.push(format!(
+                "tavily: {}",
+                unavailable_note(
+                    self.config.tavily_enabled,
+                    "TAVILY_ENABLED",
+                    "TAVILY_API_KEY",
+                    "x-tavily-api-key",
+                )
+            )),
         }
         // The fallback source provider (Firecrawl) ignores `SearchFilters`
         // outright — it has no structured recency/domain support — so a
@@ -614,16 +625,32 @@ impl SearchService {
         // constrained Tavily results for unconstrained Firecrawl ones would
         // silently violate the include/exclude/recency contract. Constrained
         // requests are Tavily-or-nothing.
-        if filters.is_empty() {
-            if let Some(provider) = &self.fallback_sources {
-                if let Ok(sources) = provider.search_sources(query, count, filters).await {
-                    if !sources.is_empty() {
-                        return (sources, RawSourceOrigin::Fallback);
-                    }
-                }
-            }
+        if !filters.is_empty() {
+            notes.push(
+                "firecrawl: skipped (request carries domain/recency filters, which firecrawl cannot honor)"
+                    .to_string(),
+            );
+            return RawSources::empty(notes);
         }
-        (Vec::new(), RawSourceOrigin::None)
+        match &self.fallback_sources {
+            Some(provider) => match provider.search_sources(query, count, filters).await {
+                Ok(sources) if !sources.is_empty() => {
+                    return RawSources::found(sources, RawSourceOrigin::Fallback)
+                }
+                Ok(_) => notes.push("firecrawl: no results".to_string()),
+                Err(err) => notes.push(format!("firecrawl: {err}")),
+            },
+            None => notes.push(format!(
+                "firecrawl: {}",
+                unavailable_note(
+                    self.config.firecrawl_enabled,
+                    "FIRECRAWL_ENABLED",
+                    "FIRECRAWL_API_KEY",
+                    "x-firecrawl-api-key",
+                )
+            )),
+        }
+        RawSources::empty(notes)
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -632,14 +659,38 @@ impl SearchService {
         deadline: tokio::time::Instant,
         session_id: String,
         response: SearchResponse,
-        raw_sources: Vec<Source>,
-        raw_origin: RawSourceOrigin,
+        raw: RawSources,
         reason: &str,
         include_content: bool,
     ) -> Result<WebSearchOutput> {
-        let mut fallback = raw_sources;
+        let RawSources {
+            sources,
+            origin,
+            notes,
+        } = raw;
+
+        // A degraded response with zero sources carries no evidence *and* no
+        // answer — the original Grok text is deliberately not echoed on this
+        // path. Returning `Ok` here handed the caller a successful-looking
+        // empty result, which client models read as "the tool works, this
+        // query just missed" and answer by retrying the same dead path
+        // forever. Fail loudly instead, naming the upstream reason, what each
+        // source provider did, and that retrying is pointless.
+        if sources.is_empty() {
+            return Err(GrokSearchError::Provider(format!(
+                "web_search returned no sources: {reason}, and the source fallback produced nothing ({}). Retrying will not help until the Grok upstream or the source-provider credentials are fixed.",
+                source_diagnosis(&notes)
+            )));
+        }
+
+        let mut fallback = sources;
         fallback.truncate(self.config.fallback_sources);
-        let fallback = with_provider(fallback, fallback_label(raw_origin));
+        if fallback.is_empty() {
+            return Err(GrokSearchError::Provider(format!(
+                "web_search returned no sources: {reason}, and the fallback source budget is 0 (GROK_SEARCH_FALLBACK_SOURCES). Retrying will not help until that budget or the Grok upstream is fixed."
+            )));
+        }
+        let fallback = with_provider(fallback, fallback_label(origin));
 
         // D-03: the degraded path enriches eagerly — one-hand evidence is most
         // valuable when there is no verifiable summary, so there is no
@@ -961,6 +1012,60 @@ enum RawSourceOrigin {
     None,
     Primary,
     Fallback,
+}
+
+/// Outcome of the speculative source fan-out: the sources plus a per-provider
+/// account of what happened. `notes` stays empty on the happy path (a provider
+/// that returns results short-circuits before anything is recorded); it is
+/// populated only when a provider yields nothing, so a request that ends with
+/// zero sources can say why.
+struct RawSources {
+    sources: Vec<Source>,
+    origin: RawSourceOrigin,
+    notes: Vec<String>,
+}
+
+impl RawSources {
+    fn found(sources: Vec<Source>, origin: RawSourceOrigin) -> Self {
+        Self {
+            sources,
+            origin,
+            notes: Vec::new(),
+        }
+    }
+
+    fn empty(notes: Vec<String>) -> Self {
+        Self {
+            sources: Vec::new(),
+            origin: RawSourceOrigin::None,
+            notes,
+        }
+    }
+}
+
+/// One-line account of why no source provider produced anything, for the
+/// zero-source failure message. Carries provider error text (status codes,
+/// upstream detail) but never any credential: keys travel in headers, and the
+/// provider errors these notes wrap quote only the endpoint and response body.
+fn source_diagnosis(notes: &[String]) -> String {
+    if notes.is_empty() {
+        "no source provider was consulted".to_string()
+    } else {
+        notes.join("; ")
+    }
+}
+
+/// Why a source provider is absent from the service: the operator switched it
+/// off, or no key ever reached the process. The key hint names both channels
+/// because the HTTP transport ignores server-side env keys entirely — a
+/// self-hoster who set the key in their compose file needs to be told that the
+/// request header is the only one that counts there.
+fn unavailable_note(enabled: bool, enable_var: &str, key_var: &str, header: &str) -> String {
+    if enabled {
+        format!("no API key ({key_var} for stdio, {header} header for the HTTP transport)")
+    } else {
+        format!("disabled via {enable_var}")
+    }
 }
 
 /// Pick the model the active transport actually understands. Responses speaks

--- a/src/service.rs
+++ b/src/service.rs
@@ -595,10 +595,9 @@ impl SearchService {
         filters: &SearchFilters,
     ) -> RawSources {
         if count == 0 {
-            return RawSources::empty(vec![
-                "source fan-out disabled (extra_sources and fallback_sources are both 0)"
-                    .to_string(),
-            ]);
+            return RawSources::empty(vec![SourceNote::faulty(
+                "source fan-out disabled (extra_sources and fallback_sources are both 0)",
+            )]);
         }
         let mut notes = Vec::new();
         match &self.sources {
@@ -606,10 +605,10 @@ impl SearchService {
                 Ok(sources) if !sources.is_empty() => {
                     return RawSources::found(sources, RawSourceOrigin::Primary)
                 }
-                Ok(_) => notes.push("tavily: no results".to_string()),
-                Err(err) => notes.push(format!("tavily: {err}")),
+                Ok(_) => notes.push(SourceNote::healthy("tavily: no results")),
+                Err(err) => notes.push(SourceNote::faulty(format!("tavily: {err}"))),
             },
-            None => notes.push(format!(
+            None => notes.push(SourceNote::faulty(format!(
                 "tavily: {}",
                 unavailable_note(
                     self.config.tavily_enabled,
@@ -617,7 +616,7 @@ impl SearchService {
                     "TAVILY_API_KEY",
                     "x-tavily-api-key",
                 )
-            )),
+            ))),
         }
         // The fallback source provider (Firecrawl) ignores `SearchFilters`
         // outright — it has no structured recency/domain support — so a
@@ -626,10 +625,9 @@ impl SearchService {
         // silently violate the include/exclude/recency contract. Constrained
         // requests are Tavily-or-nothing.
         if !filters.is_empty() {
-            notes.push(
-                "firecrawl: skipped (request carries domain/recency filters, which firecrawl cannot honor)"
-                    .to_string(),
-            );
+            notes.push(SourceNote::healthy(
+                "firecrawl: skipped (request carries domain/recency filters, which firecrawl cannot honor)",
+            ));
             return RawSources::empty(notes);
         }
         match &self.fallback_sources {
@@ -637,10 +635,10 @@ impl SearchService {
                 Ok(sources) if !sources.is_empty() => {
                     return RawSources::found(sources, RawSourceOrigin::Fallback)
                 }
-                Ok(_) => notes.push("firecrawl: no results".to_string()),
-                Err(err) => notes.push(format!("firecrawl: {err}")),
+                Ok(_) => notes.push(SourceNote::healthy("firecrawl: no results")),
+                Err(err) => notes.push(SourceNote::faulty(format!("firecrawl: {err}"))),
             },
-            None => notes.push(format!(
+            None => notes.push(SourceNote::faulty(format!(
                 "firecrawl: {}",
                 unavailable_note(
                     self.config.firecrawl_enabled,
@@ -648,7 +646,7 @@ impl SearchService {
                     "FIRECRAWL_API_KEY",
                     "x-firecrawl-api-key",
                 )
-            )),
+            ))),
         }
         RawSources::empty(notes)
     }
@@ -668,6 +666,18 @@ impl SearchService {
             origin,
             notes,
         } = raw;
+        // Distinguished before truncation: an operator who set the budget to 0
+        // needs a different message from one whose providers came back empty.
+        let budget_starved = !sources.is_empty() && self.config.fallback_sources == 0;
+
+        let mut fallback = sources;
+        fallback.truncate(self.config.fallback_sources);
+        let fallback = with_provider(fallback, fallback_label(origin));
+        // A metadata-only Grok response — citations but no prose — routes here
+        // as `grok_content_empty`, and its citations are real evidence. Merge
+        // them rather than dropping them: they keep their `grok_responses`
+        // label, exactly as on the success path.
+        let fallback = merge_sources(response.sources, fallback);
 
         // A degraded response with zero sources carries no evidence *and* no
         // answer — the original Grok text is deliberately not echoed on this
@@ -675,22 +685,20 @@ impl SearchService {
         // empty result, which client models read as "the tool works, this
         // query just missed" and answer by retrying the same dead path
         // forever. Fail loudly instead, naming the upstream reason, what each
-        // source provider did, and that retrying is pointless.
-        if sources.is_empty() {
-            return Err(GrokSearchError::Provider(format!(
-                "web_search returned no sources: {reason}, and the source fallback produced nothing ({}). Retrying will not help until the Grok upstream or the source-provider credentials are fixed.",
-                source_diagnosis(&notes)
-            )));
-        }
-
-        let mut fallback = sources;
-        fallback.truncate(self.config.fallback_sources);
+        // source provider did, and what would actually change the outcome.
         if fallback.is_empty() {
-            return Err(GrokSearchError::Provider(format!(
-                "web_search returned no sources: {reason}, and the fallback source budget is 0 (GROK_SEARCH_FALLBACK_SOURCES). Retrying will not help until that budget or the Grok upstream is fixed."
-            )));
+            return Err(GrokSearchError::Provider(if budget_starved {
+                format!(
+                    "web_search returned no sources: {reason}, and the fallback source budget is 0 (GROK_SEARCH_FALLBACK_SOURCES). Raise that budget to get evidence on the degraded path."
+                )
+            } else {
+                format!(
+                    "web_search returned no sources: {reason}, and the source fallback produced nothing ({}). {}",
+                    source_diagnosis(&notes),
+                    fallback_remediation(&notes)
+                )
+            }));
         }
-        let fallback = with_provider(fallback, fallback_label(origin));
 
         // D-03: the degraded path enriches eagerly — one-hand evidence is most
         // valuable when there is no verifiable summary, so there is no
@@ -1022,7 +1030,7 @@ enum RawSourceOrigin {
 struct RawSources {
     sources: Vec<Source>,
     origin: RawSourceOrigin,
-    notes: Vec<String>,
+    notes: Vec<SourceNote>,
 }
 
 impl RawSources {
@@ -1034,7 +1042,7 @@ impl RawSources {
         }
     }
 
-    fn empty(notes: Vec<String>) -> Self {
+    fn empty(notes: Vec<SourceNote>) -> Self {
         Self {
             sources: Vec::new(),
             origin: RawSourceOrigin::None,
@@ -1043,15 +1051,77 @@ impl RawSources {
     }
 }
 
+/// Upstream error text is quoted verbatim by the provider layer, and a gateway
+/// or intermediary can answer with an arbitrarily large HTML page. Notes now
+/// reach the caller inside a tool error, which no response budget applies to,
+/// so each one is capped where it is recorded.
+const MAX_SOURCE_NOTE_CHARS: usize = 300;
+
+/// One provider's account of why it produced nothing.
+struct SourceNote {
+    /// The provider answered normally and simply had no matches, or was
+    /// deliberately skipped by the filter gate. Kept apart from a missing key,
+    /// a disabled provider, or an upstream error because the useful
+    /// remediation differs: change the query, not the credentials.
+    healthy: bool,
+    detail: String,
+}
+
+impl SourceNote {
+    fn healthy(detail: impl Into<String>) -> Self {
+        Self {
+            healthy: true,
+            detail: truncate_note(detail.into()),
+        }
+    }
+
+    fn faulty(detail: impl Into<String>) -> Self {
+        Self {
+            healthy: false,
+            detail: truncate_note(detail.into()),
+        }
+    }
+}
+
+fn truncate_note(mut detail: String) -> String {
+    if detail.chars().count() <= MAX_SOURCE_NOTE_CHARS {
+        return detail;
+    }
+    let cut = detail
+        .char_indices()
+        .nth(MAX_SOURCE_NOTE_CHARS)
+        .map(|(idx, _)| idx)
+        .unwrap_or(detail.len());
+    detail.truncate(cut);
+    detail.push('…');
+    detail
+}
+
 /// One-line account of why no source provider produced anything, for the
 /// zero-source failure message. Carries provider error text (status codes,
 /// upstream detail) but never any credential: keys travel in headers, and the
 /// provider errors these notes wrap quote only the endpoint and response body.
-fn source_diagnosis(notes: &[String]) -> String {
+fn source_diagnosis(notes: &[SourceNote]) -> String {
     if notes.is_empty() {
         "no source provider was consulted".to_string()
     } else {
-        notes.join("; ")
+        notes
+            .iter()
+            .map(|note| note.detail.as_str())
+            .collect::<Vec<_>>()
+            .join("; ")
+    }
+}
+
+/// What would actually change the outcome. Providers that answered normally
+/// with nothing to show are not a broken upstream: there the query or the
+/// filters are the thing to change, and telling the caller that retrying
+/// cannot help would rule out the one move that works.
+fn fallback_remediation(notes: &[SourceNote]) -> &'static str {
+    if !notes.is_empty() && notes.iter().all(|note| note.healthy) {
+        "The source providers answered normally with no matches, so a different query or looser filters may help; repeating this one will not."
+    } else {
+        "Retrying will not help until the Grok upstream or the source-provider credentials are fixed."
     }
 }
 

--- a/src/service.rs
+++ b/src/service.rs
@@ -670,10 +670,6 @@ impl SearchService {
             origin,
             notes,
         } = raw;
-        // Distinguished before truncation: an operator who set the budget to 0
-        // needs a different message from one whose providers came back empty.
-        let budget_starved = !sources.is_empty() && self.config.fallback_sources == 0;
-
         let mut fallback = sources;
         fallback.truncate(self.config.fallback_sources);
         let fallback = with_provider(fallback, fallback_label(origin));
@@ -691,17 +687,33 @@ impl SearchService {
         // forever. Fail loudly instead, naming the upstream reason, what each
         // source provider did, and what would actually change the outcome.
         if fallback.is_empty() {
-            return Err(GrokSearchError::Provider(if budget_starved {
-                format!(
-                    "web_search returned no sources: {reason}, and the fallback source budget is 0 (GROK_SEARCH_FALLBACK_SOURCES). Raise that budget to get evidence on the degraded path."
-                )
-            } else {
-                format!(
-                    "web_search returned no sources: {reason}, and the source fallback produced nothing ({}). {}",
-                    source_diagnosis(&notes),
-                    fallback_remediation(&notes)
-                )
-            }));
+            // A zero budget truncates the fan-out to nothing whatever the
+            // providers returned, so it outranks every other account of the
+            // failure: no reformulated query can rescue this path while it
+            // holds. Testing the config directly rather than inferring it from
+            // an empty source list is what keeps that true when the providers
+            // also came back empty.
+            return Err(GrokSearchError::Provider(
+                if self.config.fallback_sources == 0 {
+                    // Providers that were consulted still get to say what they
+                    // saw; when the budget alone is at fault there are no notes
+                    // and nothing to append.
+                    let detail = if notes.is_empty() {
+                        String::new()
+                    } else {
+                        format!(" ({})", source_diagnosis(&notes))
+                    };
+                    format!(
+                        "web_search returned no sources: {reason}, and the fallback source budget is 0 (GROK_SEARCH_FALLBACK_SOURCES), so nothing from the source fan-out can survive{detail}. Raise that budget to get evidence on this path; no change of query can help while it is 0."
+                    )
+                } else {
+                    format!(
+                        "web_search returned no sources: {reason}, and the source fallback produced nothing ({}). {}",
+                        source_diagnosis(&notes),
+                        fallback_remediation(&notes)
+                    )
+                },
+            ));
         }
 
         // D-03: the degraded path enriches eagerly — one-hand evidence is most

--- a/src/service.rs
+++ b/src/service.rs
@@ -602,10 +602,13 @@ impl SearchService {
         let mut notes = Vec::new();
         match &self.sources {
             Some(provider) => match provider.search_sources(query, count, filters).await {
-                Ok(sources) if !sources.is_empty() => {
+                Ok(sources) if has_usable_url(&sources) => {
                     return RawSources::found(sources, RawSourceOrigin::Primary)
                 }
-                Ok(_) => notes.push(SourceNote::no_results("tavily: no results")),
+                Ok(sources) if sources.is_empty() => {
+                    notes.push(SourceNote::no_results("tavily: no results"))
+                }
+                Ok(_) => notes.push(SourceNote::broken("tavily: results carried no usable URLs")),
                 Err(err) => notes.push(SourceNote::broken(format!("tavily: {err}"))),
             },
             None => notes.push(unavailable_note(
@@ -630,10 +633,15 @@ impl SearchService {
         }
         match &self.fallback_sources {
             Some(provider) => match provider.search_sources(query, count, filters).await {
-                Ok(sources) if !sources.is_empty() => {
+                Ok(sources) if has_usable_url(&sources) => {
                     return RawSources::found(sources, RawSourceOrigin::Fallback)
                 }
-                Ok(_) => notes.push(SourceNote::no_results("firecrawl: no results")),
+                Ok(sources) if sources.is_empty() => {
+                    notes.push(SourceNote::no_results("firecrawl: no results"))
+                }
+                Ok(_) => notes.push(SourceNote::broken(
+                    "firecrawl: results carried no usable URLs",
+                )),
                 Err(err) => notes.push(SourceNote::broken(format!("firecrawl: {err}"))),
             },
             None => notes.push(unavailable_note(
@@ -1128,20 +1136,42 @@ fn source_diagnosis(notes: &[SourceNote]) -> String {
     }
 }
 
-/// What would actually change the outcome, picked from the most actionable
-/// note present: something genuinely broken outranks a configuration gate,
-/// which outranks an honest empty result. Telling a caller with a healthy but
-/// empty result set to go fix credentials would rule out the one move that
-/// works — and so would telling an operator who switched the fan-out off that
-/// their upstream is at fault.
-fn fallback_remediation(notes: &[SourceNote]) -> &'static str {
-    if notes.is_empty() || notes.iter().any(|note| note.kind == NoteKind::Broken) {
-        return "Retrying will not help until the Grok upstream or the source-provider credentials are fixed.";
+/// Whether a provider's answer contains anything the rest of the pipeline can
+/// use. Both normalizers accept an entry whose `url` is an empty string, and
+/// `merge_sources` drops those later — so counting such an answer as a success
+/// here would throw away the notes and leave the zero-source failure claiming
+/// no provider was ever consulted.
+fn has_usable_url(sources: &[Source]) -> bool {
+    sources.iter().any(|source| !source.url.trim().is_empty())
+}
+
+/// What would actually change the outcome, composed from every kind of dead
+/// end present rather than one chosen by precedence. Mixed outcomes are the
+/// common case — Tavily answering normally with no matches while Firecrawl has
+/// no key — and there a different query can still succeed through the healthy
+/// provider without anyone touching the other one's credentials. Suppressing
+/// that advice would rule out the move that works; equally, the "do not just
+/// repeat this" signal has to survive whenever nothing answered normally,
+/// since that is what a client model needs to stop retrying a dead path.
+fn fallback_remediation(notes: &[SourceNote]) -> String {
+    if notes.is_empty() {
+        return "Retrying will not help until the Grok upstream or the source-provider credentials are fixed.".to_string();
     }
-    if notes.iter().any(|note| note.kind == NoteKind::Config) {
-        return "No source provider was available to consult; enable one (TAVILY_ENABLED / FIRECRAWL_ENABLED) or raise GROK_SEARCH_FALLBACK_SOURCES to get evidence on this path.";
+    let has = |kind: NoteKind| notes.iter().any(|note| note.kind == kind);
+    let mut parts = Vec::new();
+    if has(NoteKind::NoResults) {
+        parts.push("A source provider answered normally with no matches, so a different query or looser filters may help.");
     }
-    "The source providers answered normally with no matches, so a different query or looser filters may help; repeating this one will not."
+    if has(NoteKind::Config) {
+        parts.push("A source provider is switched off; enable it (TAVILY_ENABLED / FIRECRAWL_ENABLED) or raise GROK_SEARCH_FALLBACK_SOURCES.");
+    }
+    if has(NoteKind::Broken) {
+        parts.push("A source provider is unusable until its credentials or upstream are fixed.");
+    }
+    if !has(NoteKind::NoResults) {
+        parts.push("Repeating this query unchanged will not help.");
+    }
+    parts.join(" ")
 }
 
 /// Why a source provider is absent from the service: the operator switched it

--- a/src/service.rs
+++ b/src/service.rs
@@ -626,9 +626,31 @@ impl SearchService {
         // silently violate the include/exclude/recency contract. Constrained
         // requests are Tavily-or-nothing.
         if !filters.is_empty() {
-            notes.push(SourceNote::no_results(
-                "firecrawl: skipped (request carries domain/recency filters, which firecrawl cannot honor)",
-            ));
+            const SKIPPED: &str =
+                "skipped (request carries domain/recency filters, which firecrawl cannot honor)";
+            // Whether the gate is the *only* thing in the way decides what to
+            // advise. A configured Firecrawl really would have answered, so
+            // dropping the filters is a genuine remedy and this is an honest
+            // empty outcome. An absent one changes nothing when the filters go,
+            // so recording that as a healthy no-match would promise a remedy
+            // that cannot work — while hiding the configuration problem behind
+            // it.
+            notes.push(match &self.fallback_sources {
+                Some(_) => SourceNote::no_results(format!("firecrawl: {SKIPPED}")),
+                None => {
+                    let unavailable = unavailable_note(
+                        "firecrawl",
+                        self.config.firecrawl_enabled,
+                        "FIRECRAWL_ENABLED",
+                        "FIRECRAWL_API_KEY",
+                        "x-firecrawl-api-key",
+                    );
+                    SourceNote::new(
+                        unavailable.kind,
+                        format!("{} — also {SKIPPED}", unavailable.detail),
+                    )
+                }
+            });
             return RawSources::empty(notes);
         }
         match &self.fallback_sources {

--- a/src/service.rs
+++ b/src/service.rs
@@ -1175,13 +1175,24 @@ fn fallback_remediation(notes: &[SourceNote]) -> String {
         parts.push("A source provider answered normally with no matches, so a different query or looser filters may help.");
     }
     if has(NoteKind::Config) {
-        parts.push("A source provider is switched off; enable it (TAVILY_ENABLED / FIRECRAWL_ENABLED) or raise GROK_SEARCH_FALLBACK_SOURCES.");
+        // Only a provider disabled through its own switch reaches this far: the
+        // other producer of `Config` is the zero fan-out, which cannot happen
+        // without a zero fallback budget, and `finalize_fallback` reports that
+        // before asking for a remediation. Raising the budget would not
+        // instantiate a switched-off provider, so it is not offered here.
+        parts.push(
+            "A source provider is switched off; enable it (TAVILY_ENABLED / FIRECRAWL_ENABLED).",
+        );
     }
     if has(NoteKind::Broken) {
         parts.push("A source provider is unusable until its credentials or upstream are fixed.");
     }
     if !has(NoteKind::NoResults) {
-        parts.push("Repeating this query unchanged will not help.");
+        // Deliberately not an absolute claim. A Grok timeout or 5xx clears on
+        // its own, and an unchanged retry does succeed once it does — but not
+        // before, which is what a client model looping on the same dead path
+        // needs to hear.
+        parts.push("Repeating this query unchanged will fail the same way until the condition above clears.");
     }
     parts.join(" ")
 }
@@ -1205,6 +1216,65 @@ fn unavailable_note(
         ))
     } else {
         SourceNote::config(format!("{provider}: disabled via {enable_var}"))
+    }
+}
+
+#[cfg(test)]
+mod remediation_tests {
+    use super::*;
+
+    // A switched-off provider is the only `Config` note that can reach the
+    // remediation — the zero fan-out is reported by `finalize_fallback` before
+    // this runs — and raising the source budget cannot instantiate one, so that
+    // advice must not appear.
+    #[test]
+    fn disabled_provider_is_told_to_enable_not_to_raise_the_budget() {
+        let notes = vec![unavailable_note(
+            "tavily",
+            false,
+            "TAVILY_ENABLED",
+            "TAVILY_API_KEY",
+            "x-tavily-api-key",
+        )];
+        let remediation = fallback_remediation(&notes);
+        assert!(remediation.contains("TAVILY_ENABLED"), "{remediation}");
+        assert!(
+            !remediation.contains("GROK_SEARCH_FALLBACK_SOURCES"),
+            "{remediation}"
+        );
+    }
+
+    // A Grok timeout or 5xx clears on its own, so the no-retry line must stop
+    // short of claiming a repeat can never work — while still telling a looping
+    // client that repeating it *now* changes nothing.
+    #[test]
+    fn retry_guidance_is_conditional_not_absolute() {
+        let notes = vec![SourceNote::broken("tavily: provider error: HTTP 500")];
+        let remediation = fallback_remediation(&notes);
+        assert!(
+            remediation.contains("until the condition above clears"),
+            "{remediation}"
+        );
+        assert!(!remediation.contains("will not help"), "{remediation}");
+    }
+
+    // A provider that answered normally leaves a reformulated query on the
+    // table, so the no-retry line stays out of the way entirely.
+    #[test]
+    fn a_healthy_empty_result_keeps_the_retry_door_open() {
+        let notes = vec![
+            SourceNote::no_results("tavily: no results"),
+            SourceNote::broken("firecrawl: no API key"),
+        ];
+        let remediation = fallback_remediation(&notes);
+        assert!(
+            remediation.contains("a different query or looser filters"),
+            "{remediation}"
+        );
+        assert!(
+            !remediation.contains("Repeating this query unchanged"),
+            "{remediation}"
+        );
     }
 }
 

--- a/src/service.rs
+++ b/src/service.rs
@@ -602,13 +602,10 @@ impl SearchService {
         let mut notes = Vec::new();
         match &self.sources {
             Some(provider) => match provider.search_sources(query, count, filters).await {
-                Ok(sources) if has_usable_url(&sources) => {
-                    return RawSources::found(sources, RawSourceOrigin::Primary)
-                }
-                Ok(sources) if sources.is_empty() => {
-                    notes.push(SourceNote::no_results("tavily: no results"))
-                }
-                Ok(_) => notes.push(SourceNote::broken("tavily: results carried no usable URLs")),
+                Ok(sources) => match usable_or_note("tavily", sources) {
+                    Ok(usable) => return RawSources::found(usable, RawSourceOrigin::Primary),
+                    Err(note) => notes.push(note),
+                },
                 Err(err) => notes.push(SourceNote::broken(format!("tavily: {err}"))),
             },
             None => notes.push(unavailable_note(
@@ -655,15 +652,10 @@ impl SearchService {
         }
         match &self.fallback_sources {
             Some(provider) => match provider.search_sources(query, count, filters).await {
-                Ok(sources) if has_usable_url(&sources) => {
-                    return RawSources::found(sources, RawSourceOrigin::Fallback)
-                }
-                Ok(sources) if sources.is_empty() => {
-                    notes.push(SourceNote::no_results("firecrawl: no results"))
-                }
-                Ok(_) => notes.push(SourceNote::broken(
-                    "firecrawl: results carried no usable URLs",
-                )),
+                Ok(sources) => match usable_or_note("firecrawl", sources) {
+                    Ok(usable) => return RawSources::found(usable, RawSourceOrigin::Fallback),
+                    Err(note) => notes.push(note),
+                },
                 Err(err) => notes.push(SourceNote::broken(format!("firecrawl: {err}"))),
             },
             None => notes.push(unavailable_note(
@@ -1170,13 +1162,36 @@ fn source_diagnosis(notes: &[SourceNote]) -> String {
     }
 }
 
-/// Whether a provider's answer contains anything the rest of the pipeline can
-/// use. Both normalizers accept an entry whose `url` is an empty string, and
-/// `merge_sources` drops those later — so counting such an answer as a success
-/// here would throw away the notes and leave the zero-source failure claiming
-/// no provider was ever consulted.
-fn has_usable_url(sources: &[Source]) -> bool {
-    sources.iter().any(|source| !source.url.trim().is_empty())
+/// Keep only what the rest of the pipeline can act on, or explain what the
+/// provider did instead.
+///
+/// Both normalizers accept an entry whose `url` is an empty string, and
+/// `merge_sources` discards those — but only far downstream, after the caller
+/// has already truncated to its source budget. Left in place, a blank entry
+/// consumes a budget slot and silently displaces real evidence: a budget of 1
+/// against `[blank, valid]` used to keep the blank, drop the valid source in
+/// `merge_sources`, and fail the whole request. Filtering here means truncation
+/// only ever applies to sources that will survive.
+fn usable_or_note(
+    provider: &str,
+    sources: Vec<Source>,
+) -> std::result::Result<Vec<Source>, SourceNote> {
+    let returned = sources.len();
+    let usable: Vec<Source> = sources
+        .into_iter()
+        .filter(|source| !source.url.trim().is_empty())
+        .collect();
+    if !usable.is_empty() {
+        return Ok(usable);
+    }
+    // An empty answer is an honest no-match; an answer made entirely of blanks
+    // is a provider returning something unusable, which is a different problem
+    // with a different remedy.
+    Err(if returned == 0 {
+        SourceNote::no_results(format!("{provider}: no results"))
+    } else {
+        SourceNote::broken(format!("{provider}: results carried no usable URLs"))
+    })
 }
 
 /// What would actually change the outcome, composed from every kind of dead

--- a/tests/service_contract.rs
+++ b/tests/service_contract.rs
@@ -584,6 +584,41 @@ async fn web_search_error_names_the_disabled_fan_out_rather_than_credentials() {
     assert!(!message.contains("credentials"), "{message}");
 }
 
+// A zero fallback budget truncates the fan-out to nothing regardless of what
+// the providers returned, so no reformulated query can rescue this path. The
+// error has to say that instead of sending the caller off to rewrite a query
+// that provably cannot succeed.
+#[tokio::test]
+async fn web_search_error_names_a_zero_fallback_budget_even_when_providers_answered() {
+    let service = SearchService::fake_custom(
+        Some(Arc::new(ProviderErrAiProvider)),
+        Arc::new(EmptyResultSourceProvider),
+        None,
+        [
+            ("GROK_SEARCH_EXTRA_SOURCES", "3"),
+            ("GROK_SEARCH_FALLBACK_SOURCES", "0"),
+        ],
+    );
+
+    let err = service
+        .web_search(WebSearchInput {
+            query: "anything".to_string(),
+            ..Default::default()
+        })
+        .await
+        .expect_err("a zero budget leaves nothing to return");
+
+    let message = err.to_string();
+    assert!(message.contains("fallback source budget is 0"), "{message}");
+    assert!(message.contains("no change of query can help"), "{message}");
+    // What the providers saw is still worth reporting.
+    assert!(message.contains("tavily: no results"), "{message}");
+    assert!(
+        !message.contains("a different query or looser filters"),
+        "{message}"
+    );
+}
+
 struct BlankUrlSourceProvider;
 
 #[async_trait]

--- a/tests/service_contract.rs
+++ b/tests/service_contract.rs
@@ -290,6 +290,92 @@ async fn web_search_falls_back_to_firecrawl_when_tavily_returns_nothing() {
         .all(|source| source.provider == "firecrawl_fallback"));
 }
 
+// A dead Grok upstream plus a source fallback that produces nothing leaves
+// nothing to return at all — no answer, no evidence. Reporting that as a
+// successful empty search is what drove client models into endless retry
+// loops, so it must be a hard error naming the upstream reason and what each
+// source provider did.
+#[tokio::test]
+async fn web_search_errors_when_grok_and_every_source_provider_fail() {
+    let service = SearchService::fake_custom(
+        Some(Arc::new(ProviderErrAiProvider)),
+        Arc::new(FailingSourceProvider),
+        None,
+        [] as [(&str, &str); 0],
+    );
+
+    let err = service
+        .web_search(WebSearchInput {
+            query: "anything".to_string(),
+            ..Default::default()
+        })
+        .await
+        .expect_err("a zero-source fallback must fail rather than report success");
+
+    let message = err.to_string();
+    assert!(message.contains("grok_provider_error"), "{message}");
+    assert!(
+        message.contains("tavily: provider error: source failed"),
+        "{message}"
+    );
+    // An absent provider must name the header too: a self-hosted HTTP
+    // deployment ignores the server-side env key outright.
+    assert!(message.contains("firecrawl: no API key"), "{message}");
+    assert!(message.contains("x-firecrawl-api-key"), "{message}");
+    assert!(message.contains("Retrying will not help"), "{message}");
+}
+
+// Filter-constrained requests are Tavily-or-nothing by design (Firecrawl
+// cannot honor domain/recency filters). When that gate is what leaves the
+// response empty, the error has to say so — otherwise the operator sees a
+// configured Firecrawl key that never fires and no reason why.
+#[tokio::test]
+async fn web_search_error_names_the_filter_gate_that_skipped_firecrawl() {
+    let service = SearchService::fake_custom(
+        Some(Arc::new(EmptySourcesAiProvider)),
+        Arc::new(FailingSourceProvider),
+        Some(Arc::new(FirecrawlLikeSourceProvider)),
+        [] as [(&str, &str); 0],
+    );
+
+    let err = service
+        .web_search(WebSearchInput {
+            query: "anything".to_string(),
+            include_domains: vec!["example.com".to_string()],
+            ..Default::default()
+        })
+        .await
+        .expect_err("a filter-gated fallback with no tavily results must fail");
+
+    let message = err.to_string();
+    assert!(message.contains("grok_sources_empty"), "{message}");
+    assert!(message.contains("firecrawl: skipped"), "{message}");
+    assert!(message.contains("filters"), "{message}");
+}
+
+// The zero-source guard must stay off the degraded-but-useful path: a fallback
+// that produced evidence still returns Ok.
+#[tokio::test]
+async fn web_search_still_succeeds_when_fallback_has_sources() {
+    let service = SearchService::fake_custom(
+        Some(Arc::new(ProviderErrAiProvider)),
+        Arc::new(FailingSourceProvider),
+        Some(Arc::new(FirecrawlLikeSourceProvider)),
+        [("GROK_SEARCH_FALLBACK_SOURCES", "2")],
+    );
+
+    let output = service
+        .web_search(WebSearchInput {
+            query: "anything".to_string(),
+            ..Default::default()
+        })
+        .await
+        .expect("a fallback that found sources still succeeds");
+
+    assert!(output.fallback_used);
+    assert_eq!(output.sources_count, 2);
+}
+
 #[tokio::test]
 async fn fallback_honors_include_content_false() {
     // include_content=false is an explicit opt-out and must suppress inline

--- a/tests/service_contract.rs
+++ b/tests/service_contract.rs
@@ -657,6 +657,57 @@ async fn web_search_error_names_a_zero_fallback_budget_even_when_providers_answe
     );
 }
 
+struct BlankThenValidSourceProvider;
+
+#[async_trait]
+impl SourceProvider for BlankThenValidSourceProvider {
+    async fn search_sources(
+        &self,
+        _query: &str,
+        _max_results: usize,
+        _filters: &SearchFilters,
+    ) -> Result<Vec<Source>> {
+        Ok(vec![
+            Source::new(String::new(), "tavily"),
+            Source::new("https://example.com/valid".to_string(), "tavily"),
+        ])
+    }
+
+    async fn fetch(&self, _url: &str) -> Result<FetchedPage> {
+        Ok(FetchedPage::text("fetched"))
+    }
+
+    async fn map(&self, _url: &str, _max_results: usize) -> Result<Vec<Source>> {
+        Ok(Vec::new())
+    }
+}
+
+// A blank URL ahead of a real one must not consume the source budget: the
+// budget is applied before `merge_sources` drops blanks, so keeping it would
+// discard the only usable evidence and fail a request that had some.
+#[tokio::test]
+async fn web_search_fallback_keeps_valid_sources_behind_a_blank_url() {
+    let service = SearchService::fake_custom(
+        Some(Arc::new(ProviderErrAiProvider)),
+        Arc::new(BlankThenValidSourceProvider),
+        None,
+        [("GROK_SEARCH_FALLBACK_SOURCES", "1")],
+    );
+
+    let output = service
+        .web_search(WebSearchInput {
+            query: "anything".to_string(),
+            include_content: Some(false),
+            ..Default::default()
+        })
+        .await
+        .expect("a usable source behind a blank one is still evidence");
+
+    assert!(output.fallback_used);
+    assert_eq!(output.sources_count, 1);
+    assert_eq!(output.sources[0].url, "https://example.com/valid");
+}
+
 struct BlankUrlSourceProvider;
 
 #[async_trait]

--- a/tests/service_contract.rs
+++ b/tests/service_contract.rs
@@ -374,6 +374,171 @@ async fn web_search_still_succeeds_when_fallback_has_sources() {
 
     assert!(output.fallback_used);
     assert_eq!(output.sources_count, 2);
+    // Guards D-03's eager enrichment on the degraded path: nothing in the
+    // suite noticed when that block went missing, so pin it here.
+    assert!(
+        output.sources.iter().any(|source| source.content.is_some()),
+        "fallback path must still enrich inline content: {:?}",
+        output.sources
+    );
+}
+
+struct MetadataOnlyAiProvider;
+
+#[async_trait]
+impl AiProvider for MetadataOnlyAiProvider {
+    async fn search(&self, _request: &SearchRequest) -> Result<SearchResponse> {
+        Ok(SearchResponse {
+            content: String::new(),
+            sources: vec![Source::new(
+                "https://grok.example/cited".to_string(),
+                "grok_responses",
+            )],
+        })
+    }
+}
+
+struct EmptyResultSourceProvider;
+
+#[async_trait]
+impl SourceProvider for EmptyResultSourceProvider {
+    async fn search_sources(
+        &self,
+        _query: &str,
+        _max_results: usize,
+        _filters: &SearchFilters,
+    ) -> Result<Vec<Source>> {
+        Ok(Vec::new())
+    }
+
+    async fn fetch(&self, _url: &str) -> Result<FetchedPage> {
+        Ok(FetchedPage::text("fetched"))
+    }
+
+    async fn map(&self, _url: &str, _max_results: usize) -> Result<Vec<Source>> {
+        Ok(Vec::new())
+    }
+}
+
+struct HugeErrorSourceProvider;
+
+#[async_trait]
+impl SourceProvider for HugeErrorSourceProvider {
+    async fn search_sources(
+        &self,
+        _query: &str,
+        _max_results: usize,
+        _filters: &SearchFilters,
+    ) -> Result<Vec<Source>> {
+        // What an intermediary answering with a full HTML error page looks like
+        // once the provider layer quotes the body verbatim.
+        Err(GrokSearchError::Provider(format!(
+            "Tavily returned HTTP 502: {}",
+            "x".repeat(20_000)
+        )))
+    }
+
+    async fn fetch(&self, _url: &str) -> Result<FetchedPage> {
+        Ok(FetchedPage::text("fetched"))
+    }
+
+    async fn map(&self, _url: &str, _max_results: usize) -> Result<Vec<Source>> {
+        Ok(Vec::new())
+    }
+}
+
+// A metadata-only Grok response (citations, no prose) is a supported upstream
+// shape that routes through the degraded path as `grok_content_empty`. Those
+// citations are real evidence, so the zero-source guard must not fire on them
+// — and they must survive into the response rather than being dropped.
+#[tokio::test]
+async fn web_search_keeps_grok_citations_when_the_response_has_no_prose() {
+    let service = SearchService::fake_custom(
+        Some(Arc::new(MetadataOnlyAiProvider)),
+        Arc::new(FailingSourceProvider),
+        None,
+        [] as [(&str, &str); 0],
+    );
+
+    let output = service
+        .web_search(WebSearchInput {
+            query: "anything".to_string(),
+            include_content: Some(false),
+            ..Default::default()
+        })
+        .await
+        .expect("grok citations are evidence even with no prose");
+
+    assert!(output.fallback_used);
+    assert_eq!(
+        output.fallback_reason,
+        Some("grok_content_empty".to_string())
+    );
+    assert_eq!(output.sources_count, 1);
+    assert_eq!(output.sources[0].url, "https://grok.example/cited");
+    assert_eq!(output.sources[0].provider, "grok_responses");
+}
+
+// Providers that answered normally with nothing to show are not a broken
+// upstream: the query is the thing to change, so the error must not tell the
+// caller that retrying is futile until credentials are fixed.
+#[tokio::test]
+async fn web_search_error_tells_healthy_providers_to_change_the_query() {
+    let service = SearchService::fake_custom(
+        Some(Arc::new(ProviderErrAiProvider)),
+        Arc::new(EmptyResultSourceProvider),
+        Some(Arc::new(EmptyResultSourceProvider)),
+        [] as [(&str, &str); 0],
+    );
+
+    let err = service
+        .web_search(WebSearchInput {
+            query: "anything".to_string(),
+            ..Default::default()
+        })
+        .await
+        .expect_err("no sources anywhere is still a failure");
+
+    let message = err.to_string();
+    assert!(message.contains("tavily: no results"), "{message}");
+    assert!(message.contains("firecrawl: no results"), "{message}");
+    assert!(
+        message.contains("a different query or looser filters"),
+        "{message}"
+    );
+    assert!(!message.contains("credentials"), "{message}");
+}
+
+// Provider errors quote the upstream body verbatim, and these notes now travel
+// inside a tool error that no response budget applies to.
+#[tokio::test]
+async fn web_search_error_bounds_a_huge_provider_diagnostic() {
+    let service = SearchService::fake_custom(
+        Some(Arc::new(ProviderErrAiProvider)),
+        Arc::new(HugeErrorSourceProvider),
+        None,
+        [] as [(&str, &str); 0],
+    );
+
+    let err = service
+        .web_search(WebSearchInput {
+            query: "anything".to_string(),
+            ..Default::default()
+        })
+        .await
+        .expect_err("zero sources still fails");
+
+    let message = err.to_string();
+    assert!(message.contains("Tavily returned HTTP 502"), "{message}");
+    assert!(
+        message.contains('…'),
+        "truncation marker missing: {message}"
+    );
+    assert!(
+        message.chars().count() < 1_000,
+        "diagnostic not bounded, got {} chars",
+        message.chars().count()
+    );
 }
 
 #[tokio::test]

--- a/tests/service_contract.rs
+++ b/tests/service_contract.rs
@@ -541,6 +541,39 @@ async fn web_search_error_bounds_a_huge_provider_diagnostic() {
     );
 }
 
+// Both source budgets at 0 disables the fan-out entirely: no provider is ever
+// consulted, so nothing is broken and no credential is missing. Raising the
+// budget is the remedy, and the error has to say that rather than sending the
+// operator off to check keys.
+#[tokio::test]
+async fn web_search_error_names_the_disabled_fan_out_rather_than_credentials() {
+    let service = SearchService::fake_custom(
+        Some(Arc::new(ProviderErrAiProvider)),
+        Arc::new(CountingSourceProvider::default()),
+        None,
+        [
+            ("GROK_SEARCH_EXTRA_SOURCES", "0"),
+            ("GROK_SEARCH_FALLBACK_SOURCES", "0"),
+        ],
+    );
+
+    let err = service
+        .web_search(WebSearchInput {
+            query: "anything".to_string(),
+            ..Default::default()
+        })
+        .await
+        .expect_err("no sources anywhere is still a failure");
+
+    let message = err.to_string();
+    assert!(message.contains("source fan-out disabled"), "{message}");
+    assert!(
+        message.contains("GROK_SEARCH_FALLBACK_SOURCES"),
+        "{message}"
+    );
+    assert!(!message.contains("credentials"), "{message}");
+}
+
 #[tokio::test]
 async fn fallback_honors_include_content_false() {
     // include_content=false is an explicit opt-out and must suppress inline

--- a/tests/service_contract.rs
+++ b/tests/service_contract.rs
@@ -328,9 +328,9 @@ async fn web_search_errors_when_grok_and_every_source_provider_fail() {
     );
     // Nothing answered normally here, so the do-not-just-retry signal — the
     // whole point of failing instead of returning an empty success — must be
-    // present.
+    // present, without overclaiming that a repeat can never work.
     assert!(
-        message.contains("Repeating this query unchanged will not help"),
+        message.contains("Repeating this query unchanged will fail the same way"),
         "{message}"
     );
 }

--- a/tests/service_contract.rs
+++ b/tests/service_contract.rs
@@ -322,7 +322,17 @@ async fn web_search_errors_when_grok_and_every_source_provider_fail() {
     // deployment ignores the server-side env key outright.
     assert!(message.contains("firecrawl: no API key"), "{message}");
     assert!(message.contains("x-firecrawl-api-key"), "{message}");
-    assert!(message.contains("Retrying will not help"), "{message}");
+    assert!(
+        message.contains("credentials or upstream are fixed"),
+        "{message}"
+    );
+    // Nothing answered normally here, so the do-not-just-retry signal — the
+    // whole point of failing instead of returning an empty success — must be
+    // present.
+    assert!(
+        message.contains("Repeating this query unchanged will not help"),
+        "{message}"
+    );
 }
 
 // Filter-constrained requests are Tavily-or-nothing by design (Firecrawl
@@ -572,6 +582,100 @@ async fn web_search_error_names_the_disabled_fan_out_rather_than_credentials() {
         "{message}"
     );
     assert!(!message.contains("credentials"), "{message}");
+}
+
+struct BlankUrlSourceProvider;
+
+#[async_trait]
+impl SourceProvider for BlankUrlSourceProvider {
+    async fn search_sources(
+        &self,
+        _query: &str,
+        _max_results: usize,
+        _filters: &SearchFilters,
+    ) -> Result<Vec<Source>> {
+        // Both normalizers accept an entry whose `url` is an empty string.
+        Ok(vec![Source::new(String::new(), "tavily")])
+    }
+
+    async fn fetch(&self, _url: &str) -> Result<FetchedPage> {
+        Ok(FetchedPage::text("fetched"))
+    }
+
+    async fn map(&self, _url: &str, _max_results: usize) -> Result<Vec<Source>> {
+        Ok(Vec::new())
+    }
+}
+
+// A provider whose results carry no usable URL has not really answered:
+// `merge_sources` drops those entries downstream. Counting it as a success
+// would discard the notes and leave the failure claiming nothing was ever
+// consulted, which is the opposite of what happened.
+#[tokio::test]
+async fn web_search_error_names_a_provider_that_returned_unusable_urls() {
+    let service = SearchService::fake_custom(
+        Some(Arc::new(ProviderErrAiProvider)),
+        Arc::new(BlankUrlSourceProvider),
+        None,
+        [] as [(&str, &str); 0],
+    );
+
+    let err = service
+        .web_search(WebSearchInput {
+            query: "anything".to_string(),
+            ..Default::default()
+        })
+        .await
+        .expect_err("blank URLs leave nothing to return");
+
+    let message = err.to_string();
+    assert!(
+        message.contains("tavily: results carried no usable URLs"),
+        "{message}"
+    );
+    assert!(
+        !message.contains("no source provider was consulted"),
+        "{message}"
+    );
+}
+
+// Mixed outcome: Tavily answered normally with no matches while Firecrawl has
+// no key. A different query can still succeed through Tavily without anyone
+// touching Firecrawl's credentials, so both remedies have to survive.
+#[tokio::test]
+async fn web_search_error_keeps_query_advice_when_only_one_provider_is_broken() {
+    let service = SearchService::fake_custom(
+        Some(Arc::new(ProviderErrAiProvider)),
+        Arc::new(EmptyResultSourceProvider),
+        None,
+        [] as [(&str, &str); 0],
+    );
+
+    let err = service
+        .web_search(WebSearchInput {
+            query: "anything".to_string(),
+            ..Default::default()
+        })
+        .await
+        .expect_err("no sources anywhere is still a failure");
+
+    let message = err.to_string();
+    assert!(message.contains("tavily: no results"), "{message}");
+    assert!(message.contains("firecrawl: no API key"), "{message}");
+    assert!(
+        message.contains("a different query or looser filters"),
+        "{message}"
+    );
+    assert!(
+        message.contains("credentials or upstream are fixed"),
+        "{message}"
+    );
+    // Tavily is alive, so a reformulated query is a legitimate next move and
+    // must not be ruled out.
+    assert!(
+        !message.contains("Repeating this query unchanged"),
+        "{message}"
+    );
 }
 
 #[tokio::test]

--- a/tests/service_contract.rs
+++ b/tests/service_contract.rs
@@ -361,6 +361,44 @@ async fn web_search_error_names_the_filter_gate_that_skipped_firecrawl() {
     assert!(message.contains("grok_sources_empty"), "{message}");
     assert!(message.contains("firecrawl: skipped"), "{message}");
     assert!(message.contains("filters"), "{message}");
+    // Firecrawl is configured here, so dropping the filters really would reach
+    // it — the remedy is honest.
+    assert!(
+        message.contains("a different query or looser filters"),
+        "{message}"
+    );
+}
+
+// The filter gate only justifies "loosen the filters" when there is a Firecrawl
+// on the other side of it. With none configured, dropping the filters reaches
+// nothing, so the note must carry the configuration problem instead of reading
+// as an honest empty result.
+#[tokio::test]
+async fn web_search_error_does_not_blame_filters_when_firecrawl_is_absent() {
+    let service = SearchService::fake_custom(
+        Some(Arc::new(EmptySourcesAiProvider)),
+        Arc::new(FailingSourceProvider),
+        None,
+        [] as [(&str, &str); 0],
+    );
+
+    let err = service
+        .web_search(WebSearchInput {
+            query: "anything".to_string(),
+            include_domains: vec!["example.com".to_string()],
+            ..Default::default()
+        })
+        .await
+        .expect_err("filter-gated fallback with no firecrawl must fail");
+
+    let message = err.to_string();
+    // Both facts survive: the gate skipped it, and it was not there anyway.
+    assert!(message.contains("firecrawl: no API key"), "{message}");
+    assert!(message.contains("also skipped"), "{message}");
+    assert!(
+        !message.contains("a different query or looser filters"),
+        "{message}"
+    );
 }
 
 // The zero-source guard must stay off the degraded-but-useful path: a fallback


### PR DESCRIPTION
## 背景

用户报告:自部署的远程 MCP,grok2api 网关故障时 Tavily / Firecrawl 兜底没有被调用,客户端随后陷入无限重试循环。

在生产端点实测(`doctor`):grok 网关 `reachable: false`、Tavily `HTTP 432`(套餐额度用尽)、Firecrawl 可达。请求头带齐 key 时兜底链**工作正常**。所以兜底逻辑本身没坏,坏的是两件事——key 没到达时服务端一声不吭,以及兜底空手而归时我们把它报告成"成功"。

## 核心改动

**1. 零来源不再伪装成成功(死循环的直接成因)**

`finalize_fallback` 此前无条件返回 `Ok`。Grok 挂掉且兜底没拿到任何来源时,客户端收到 `sources_count: 0`、无 `isError`、正文写着「Source fallback returned 0 source(s); evaluate them directly」——而这条路径上原始 Grok 文本本就被丢弃,等于什么都没有。模型把它读成"工具是好的,只是这次没搜到",换个措辞重试,每次都走同一条死路径。

现在返回 `GrokSearchError::Provider`,消息包含进入兜底的原因、每个 provider 各自发生了什么、以及怎样才能改变结果。**兜底拿到来源时行为完全不变。**

**2. 兜底失败原因可见**

`fetch_raw_extra_sources` 此前用 `if let Ok(...)` 吞掉全部 provider 错误。现在每条失败路径记一句 note 并汇总进错误消息:

```
provider error: web_search returned no sources: grok_provider_error, and the source
fallback produced nothing (tavily: provider error: Tavily returned HTTP 432 …;
firecrawl: no API key (FIRECRAWL_API_KEY for stdio, x-firecrawl-api-key header for
the HTTP transport)). A source provider is unusable until its credentials or upstream
are fixed. Repeating this query unchanged will fail the same way until the condition
above clears.
```

note 只含 endpoint 与上游响应体,不含任何凭据,每条截断至 300 字符。

**3. HTTP 启动时对被忽略的服务端 key 告警**

用户踩坑的根因:远程传输按设计剥离服务端 `TAVILY_API_KEY` / `FIRECRAWL_API_KEY`,但此前**静默**剥离。自托管者在 compose 里配好 key,服务端看起来一切正常,实际每个请求都没有兜底 provider。现在 `run_http` 对每个存在的被剥离变量打一行 warning 并指明该用的请求头;只打名字不打值。README 自托管章节同步补了显式说明。

## 评审过程中修掉的其它缺陷

八轮 Codex 评审,11 条 P2 全部核实成立后修复。其中几条是独立的真缺陷:

- **metadata-only 响应丢引用** — `grok_unverifiable_reason` 只看 `content` 不看 `response.sources`,该路径本就在静默丢弃 Grok 引用;现合并保留。
- **空 URL 挤掉有效来源** — `[空, 有效]` + budget=1 时,截断先于 `merge_sources` 去空,唯一有效来源被丢、请求硬失败。改为构造前过滤(enrichment 主路径同样受益,该问题早于本 PR)。
- **`FALLBACK_SOURCES=0` 判定错误** — 附加了「provider 曾返回过结果」条件,导致 provider 返回空时掩盖真正原因,转而建议「换 query」——而 `truncate(0)` 使该建议永不可能奏效。
- **空白 key 未归一化** — `Some("")` 会造出只能 401 的 provider,`doctor` 与所有可用性判断都报「已配置」。相邻字段本就有这层过滤,两个 source key 漏了。

其余为补救建议的精确化(三态 note kind、组合而非单选、filters 闸门仅在 Firecrawl 确实在场时才建议放宽)。

## 验证

- `cargo fmt --check` / `cargo clippy --all-targets --features http -- -D warnings` 干净
- `cargo test --features http` 全绿:132 单测 + 31 集成测试(service_contract 由 22 增至 31),0 失败
- CI(fmt + clippy + test,stdio 与 `--features http` 双配置)通过

## 注意

「零来源返回错误」把原本 `Ok` 的响应变成了错误,属行为变更 —— 但仅限"没有任何来源可返回"的场景,那个响应本来也不含任何可用信息。

另:修复 `finalize_fallback` 期间曾误删 D-03 的 eager enrichment 整块,已恢复并补断言钉住 —— 原测试套件对此无感知。
