### PR TITLE
feat(sources): pluggable source-provider chain with TinyFish and Exa

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,6 +24,23 @@ TAVILY_API_URL=https://api.tavily.com
 # FIRECRAWL_API_URL=https://api.firecrawl.dev
 # FIRECRAWL_ENABLED=false
 
+# TinyFish Search & Fetch: free (no credits, rate-limited) search + JS-rendering fetch.
+# Optional link in the source chain. https://agent.tinyfish.ai/api-keys
+# TINYFISH_API_KEY=your-tinyfish-key
+# TINYFISH_SEARCH_API_URL=https://api.search.tinyfish.ai
+# TINYFISH_FETCH_API_URL=https://api.fetch.tinyfish.ai
+# TINYFISH_ENABLED=false
+
+# Exa: semantic search with native domain/date filters (paid, per-request).
+# Optional link in the source chain. https://dashboard.exa.ai/api-keys
+# EXA_API_KEY=your-exa-key
+# EXA_API_URL=https://api.exa.ai
+# EXA_ENABLED=false
+
+# Source chain order for supplemental sources + generic fetch. Default (omit):
+# configured providers in canonical order tavily,exa,tinyfish,firecrawl.
+# GROK_SEARCH_SOURCE_PROVIDERS=tavily,tinyfish,firecrawl
+
 # ── OpenAI-compatible transport (alternative to GROK_SEARCH_*) ───
 # When GROK_SEARCH_API_KEY above is unset and these three are set,
 # grok-search-rs talks to /v1/chat/completions instead of /v1/responses.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,12 @@ All notable changes to GrokSearch-rs are documented here.
     零结果诊断语义全部保持不变。
   - `doctor` 新增 `exa`/`tinyfish` 探针节点与 `source_chain` 字段,报告
     生效的链序。
+  - 链遍历受请求全局 deadline(`GROK_SEARCH_TIMEOUT_SECONDS`)约束:某个
+    provider 挂起不会让后续每一位各拿一份完整超时,把总预算按链长翻倍。
+  - `web_map` 是独立能力而非链上一环:即使 `GROK_SEARCH_SOURCE_PROVIDERS`
+    把 Tavily 排除出补充源链,只要配了 `TAVILY_API_KEY`,map 依旧可用。
+  - HTTP 模式在 bind 监听端口**之前**校验 `GROK_SEARCH_SOURCE_PROVIDERS`,
+    非法名不会变成"进程起来了但每个请求都失败"。
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,9 @@ All notable changes to GrokSearch-rs are documented here.
     生效的链序。
   - 链遍历受请求全局 deadline(`GROK_SEARCH_TIMEOUT_SECONDS`)约束:某个
     provider 挂起不会让后续每一位各拿一份完整超时,把总预算按链长翻倍。
+    `web_fetch` 直连路径同样按 D-02 收口——入口算一个 deadline,专项抽取器
+    与 generic 链共享(此前该路径完全无 deadline,专项与每个 provider 各吃
+    一份完整 client timeout)。
   - `web_map` 是独立能力而非链上一环:即使 `GROK_SEARCH_SOURCE_PROVIDERS`
     把 Tavily 排除出补充源链,只要配了 `TAVILY_API_KEY`,map 依旧可用。
   - HTTP 模式在 bind 监听端口**之前**校验 `GROK_SEARCH_SOURCE_PROVIDERS`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,9 @@ All notable changes to GrokSearch-rs are documented here.
   - **TinyFish**(closes #12):免费 Search & Fetch(不耗 credits,免费档限速
     30 req/min),`TINYFISH_API_KEY` 一把 key 同时驱动
     `api.search.tinyfish.ai`(GET)与 `api.fetch.tinyfish.ai`(POST,JS 渲染 +
-    PDF 抽取)。domain 过滤经 `site:`/`-site:` 操作符注入 query,
-    `recency_days` 映射为 `recency_minutes`。
+    PDF 抽取)。domain 过滤走官方专用参数 `include_domains`/`exclude_domains`
+    (`site:`/`-site:` 操作符上游已标记为 domain filtering 的 deprecated 路径,
+    会与用户 query 自带语法冲突),`recency_days` 映射为 `recency_minutes`。
   - **Exa**:语义(embeddings-first)检索,原生支持
     `includeDomains`/`excludeDomains`/`startPublishedDate`,fetch 走
     `/contents`。按量计费,适合描述式查询、论文与官方域名发现。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,34 @@
 
 All notable changes to GrokSearch-rs are documented here.
 
-## 0.1.23 - 2026-08-01
+## Unreleased
+
+### Added
+
+- **可插拔的补充源链(source chain),新增 TinyFish 与 Exa 两个 provider。**
+  借鉴 smart-search 的 capability-chain 设计,把原先硬编码的 Tavily(primary)+
+  Firecrawl(fallback) 两槽位泛化为有序 provider 链:补充源与 generic fetch 按
+  链序尝试,第一个返回可用结果的 provider 胜出。默认链序为
+  `tavily → exa → tinyfish → firecrawl`(仅遍历已配置的 provider),
+  `GROK_SEARCH_SOURCE_PROVIDERS` 可显式重排/裁剪(非法名启动即报错)。
+  - **TinyFish**(closes #12):免费 Search & Fetch(不耗 credits,免费档限速
+    30 req/min),`TINYFISH_API_KEY` 一把 key 同时驱动
+    `api.search.tinyfish.ai`(GET)与 `api.fetch.tinyfish.ai`(POST,JS 渲染 +
+    PDF 抽取)。domain 过滤经 `site:`/`-site:` 操作符注入 query,
+    `recency_days` 映射为 `recency_minutes`。
+  - **Exa**:语义(embeddings-first)检索,原生支持
+    `includeDomains`/`excludeDomains`/`startPublishedDate`,fetch 走
+    `/contents`。按量计费,适合描述式查询、论文与官方域名发现。
+  - 远端 HTTP 传输新增 `X-Tinyfish-Api-Key` / `X-Exa-Api-Key` 两个
+    per-request 头;server 端环境变量同名 key 照旧被剥离,不会泄入租户请求。
+  - 来源标签泛化为 `{provider}_enrichment` / `{provider}_fallback`
+    (如 `exa_enrichment`、`tinyfish_fallback`);tavily/firecrawl 的既有标签、
+    filters 门控(带 domain/recency 过滤的请求跳过 Firecrawl)与 #31 的
+    零结果诊断语义全部保持不变。
+  - `doctor` 新增 `exa`/`tinyfish` 探针节点与 `source_chain` 字段,报告
+    生效的链序。
+
+
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![GrokSearch-rs product banner](assets/groksearch-rs-banner.png)
 
-**A lightweight Rust MCP server for Grok / OpenAI‑compatible web search, plus Tavily fetch/map and Firecrawl fallback.**
+**A lightweight Rust MCP server for Grok / OpenAI‑compatible web search, backed by an ordered source chain — Tavily, Exa, TinyFish, Firecrawl — for supplemental sources, fetch, and map.**
 
 `grok-search-rs` is an **MCP server** — run it locally over **stdio** (your client launches it; you do not run it directly) or as a **remote Streamable HTTP** service for mobile / multi‑device access (see [self-hosting](#self-hosting-remote-http)). It exposes one set of tools (`web_search`, `get_sources`, `web_fetch`, `web_map`, `doctor`) and supports two upstream transports so you can plug into either xAI's official API or any OpenAI‑compatible relay.
 
@@ -12,11 +12,11 @@
 
 - 🔎 **Live web search** with cited sources, cached for follow‑up `get_sources` calls. Opt‑in `include_content` enriches the top sources with full extracted text in one call.
 - 📏 **Response budgeting** — `web_search` keeps responses inside agent context limits: only the top `max_inline_sources` carry inline text, a whole‑response char budget (`response_max_chars`, default 45k — sized to stay under the MCP client token ceiling after JSON serialization) trims tail sources with recovery notes, `response_format: "concise" | "detailed"` picks the payload size, and `get_sources` pages through cached sources with `offset`/`limit`. The session cache always keeps full content.
-- 🧩 **Structured `web_fetch`** — GitHub issues/PRs/releases, StackExchange/MathOverflow, arXiv, and Wikipedia URLs are parsed by specialist extractors into clean Markdown (title, state/labels, release notes, accepted‑answer ordering, abstracts, vote‑sorted answers). Anything else falls back to the generic Tavily → Firecrawl chain. Output carries `source_type` and a `fallback_reason` when a specialist was skipped.
+- 🧩 **Structured `web_fetch`** — GitHub issues/PRs/releases, StackExchange/MathOverflow, arXiv, and Wikipedia URLs are parsed by specialist extractors into clean Markdown (title, state/labels, release notes, accepted‑answer ordering, abstracts, vote‑sorted answers). Anything else falls back to the generic source chain (Tavily → Exa → TinyFish → Firecrawl, as configured). Output carries `source_type` and a `fallback_reason` when a specialist was skipped.
 - 🔀 **Two transports** — native xAI Responses (`/v1/responses`) **or** any OpenAI‑compatible chat‑completions gateway (`/v1/chat/completions`). Pick by env vars; no flag.
 - 🔐 **Optional Grok OAuth mode** — `login/status/logout` commands store a local xAI OAuth token for Responses auth, so the MCP server can run without `GROK_SEARCH_API_KEY`.
 - 🌐 **Optional remote mode** — build with `--features http` to serve the same tools over **Streamable HTTP** (multi‑tenant, bring‑your‑own‑key via request headers) for mobile / multi‑device access. See [self-hosting](#self-hosting-remote-http).
-- 📥 **Tavily fetch / map** for full‑text extraction and link discovery, with **Firecrawl** as automatic fallback. `TAVILY_API_KEY` accepts a comma‑separated key list — keys rotate round‑robin with automatic failover on rate/quota errors.
+- 📥 **Pluggable source chain** — supplemental sources and generic fetch walk an ordered provider chain: **Tavily** (RAG‑tuned search + extract + map), **Exa** (semantic search, native domain/date filters), **TinyFish** (free search + JS‑rendering fetch), **Firecrawl** (robust scrape fallback). First provider with results wins; `GROK_SEARCH_SOURCE_PROVIDERS` reorders. `TAVILY_API_KEY` accepts a comma‑separated key list — keys rotate round‑robin with automatic failover on rate/quota errors.
 - 🐦 **Optional X/Twitter search** via `x_search` (Responses transport only).
 - 🩺 **`doctor`** — connectivity probe + redacted config in one tool call.
 - 🗂 **Single global config file** so multiple MCP clients share one set of keys.
@@ -119,9 +119,11 @@ The MCP **transport** decides how config reaches the server — same values, dif
 | Grok model | `GROK_SEARCH_MODEL` | `X-Grok-Model` |
 | Tavily API key | `TAVILY_API_KEY` | `X-Tavily-Api-Key` |
 | Firecrawl API key | `FIRECRAWL_API_KEY` | `X-Firecrawl-Api-Key` |
+| TinyFish API key | `TINYFISH_API_KEY` | `X-Tinyfish-Api-Key` |
+| Exa API key | `EXA_API_KEY` | `X-Exa-Api-Key` |
 | GitHub token | `GITHUB_TOKEN` | `X-GitHub-Token` |
 
-The tables below use env-key names (they also drive `config.toml` / stdio); on the remote transport send the header from the row above. Full reference and per-transport examples: [docs/CONFIGURATION.md](docs/CONFIGURATION.md#configuration-channels-stdio-env-vs-remote-headers). Both Tavily and Firecrawl keys are shared across transports.
+The tables below use env-key names (they also drive `config.toml` / stdio); on the remote transport send the header from the row above. Full reference and per-transport examples: [docs/CONFIGURATION.md](docs/CONFIGURATION.md#configuration-channels-stdio-env-vs-remote-headers). All source-provider keys (Tavily / Exa / TinyFish / Firecrawl) are shared across transports.
 
 ### A. Native Grok Responses (default)
 
@@ -175,16 +177,19 @@ Notes:
 - `GROK_SEARCH_X_SEARCH=true` is **silently ignored** on this transport (a one‑line stderr warning prints at startup). `x_search` only exists on the Responses API.
 - Source extraction reads four parallel paths and de‑duplicates by URL: OpenAI `annotations[].url_citation`, Perplexity‑style `citations`, top‑level `search_sources[]`, and inline `[[n]](url)` markers.
 
-### Tavily / Firecrawl (shared)
+### Source providers (shared)
 
 | Variable | Default | Purpose |
 |---|---|---|
-| `TAVILY_API_KEY` | — *(required for `web_fetch` / `web_map`)* | Tavily key. Comma‑separated list rotates round‑robin with failover on HTTP 401/403/429/432/433. |
+| `TAVILY_API_KEY` | — *(required for `web_map`)* | Tavily key. Comma‑separated list rotates round‑robin with failover on HTTP 401/403/429/432/433. |
 | `TAVILY_API_URL` | `https://api.tavily.com` | Tavily base. |
-| `GROK_SEARCH_EXTRA_SOURCES` | `3` | Extra Tavily sources after a Grok answer (`0` disables). |
+| `GROK_SEARCH_EXTRA_SOURCES` | `3` | Extra chain‑served sources after a Grok answer (`0` disables). |
 | `GROK_SEARCH_FALLBACK_SOURCES` | `5` | Fallback source count when the AI step can't verify itself. |
 | `FIRECRAWL_API_KEY` | unset | Enables Firecrawl as `web_fetch` / source fallback. |
 | `FIRECRAWL_API_URL` | `https://api.firecrawl.dev` | Firecrawl base. |
+| `TINYFISH_API_KEY` | unset | Enables TinyFish (free search + JS‑rendering fetch) in the chain. |
+| `EXA_API_KEY` | unset | Enables Exa (semantic search, native filters) in the chain. |
+| `GROK_SEARCH_SOURCE_PROVIDERS` | unset | Explicit chain order, e.g. `tinyfish,tavily,firecrawl`. Unset = canonical order `tavily, exa, tinyfish, firecrawl` over configured providers. |
 | `GROK_SEARCH_CACHE_SIZE` | `256` | Max cached `web_search` sessions. |
 | `GROK_SEARCH_TIMEOUT_SECONDS` | `60` | HTTP timeout for all upstreams. |
 | `GROK_SEARCH_FETCH_MAX_CHARS` | unset | Default char cap on `web_fetch`. |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -8,8 +8,11 @@ MCP client
       -> src/service.rs
       -> credential provider: static API key or xAI OAuth token
       -> Grok Responses provider: /v1/responses with web_search and optional x_search
-      -> Tavily provider: search / extract / map
-      -> Firecrawl provider: search / scrape fallback
+      -> source chain (ordered; default tavily -> exa -> tinyfish -> firecrawl)
+           -> Tavily provider: search / extract / map
+           -> Exa provider: semantic search / contents fetch
+           -> TinyFish provider: search / JS-rendering fetch
+           -> Firecrawl provider: search / scrape fallback
       -> source cache
 ```
 
@@ -17,9 +20,9 @@ MCP client
 
 - `web_search` is the AI search path. Grok Responses is primary.
 - `get_sources` retrieves cached sources by `session_id`.
-- `web_fetch` fetches page content through Tavily Extract first, then Firecrawl scrape if configured.
-- `web_map` discovers URLs through Tavily Map.
-- Tavily and Firecrawl are not the default answer generators inside `web_search`; they provide enrichment, fallback sources, fetch, and map capability.
+- `web_fetch` fetches page content through the source chain in order (Tavily Extract, Exa contents, TinyFish fetch, Firecrawl scrape — whichever are configured; first non-empty page wins).
+- `web_map` discovers URLs through Tavily Map (the only provider with a real site-map endpoint).
+- Source providers are not the default answer generators inside `web_search`; they provide enrichment, fallback sources, fetch, and map capability. The chain order is canonical (`tavily, exa, tinyfish, firecrawl`) over configured providers, or exactly `GROK_SEARCH_SOURCE_PROVIDERS` when set.
 - Agents should use `web_search` for concise sourced summaries, call `get_sources` before source-specific claims, citation lists, or follow-up fetches, and call `web_fetch` for exact page evidence, quotes, technical details, or when the summary is insufficient.
 
 ## Provider Layer
@@ -44,11 +47,9 @@ OAuth login is not a service boundary. `grok-search-rs login` temporarily listen
 Sources retain their origin through the `provider` field:
 
 - `grok_responses`: native Responses citation or web search source.
-- `tavily_enrichment`: supplemental Tavily source after Grok succeeds.
-- `tavily_fallback`: Tavily source used because Grok failed or was unverifiable.
-- `firecrawl_enrichment`: supplemental Firecrawl source after Grok succeeds, used when Tavily returns nothing.
-- `firecrawl_fallback`: Firecrawl source used because Grok failed or was unverifiable and Tavily returned nothing.
-- `tavily` / `firecrawl`: direct provider source before orchestration rewrites provenance.
+- `{provider}_enrichment` (`tavily_enrichment`, `exa_enrichment`, `tinyfish_enrichment`, `firecrawl_enrichment`): supplemental source after Grok succeeds, named for the chain provider that served it.
+- `{provider}_fallback` (`tavily_fallback`, `exa_fallback`, `tinyfish_fallback`, `firecrawl_fallback`): source used because Grok failed or was unverifiable, named for the chain provider that served it.
+- `tavily` / `exa` / `tinyfish` / `firecrawl`: direct provider source before orchestration rewrites provenance.
 
 ## Fallback Rules
 
@@ -58,7 +59,7 @@ Sources retain their origin through the `provider` field:
 - the provider response content is empty,
 - the provider response has no verifiable native sources.
 
-Fallback tries Tavily first, then Firecrawl when configured. The output exposes `search_provider`, `fallback_used`, and `fallback_reason` so MCP clients can distinguish a native Grok result from fallback-source handling.
+Fallback walks the source chain in order; the first provider with usable results serves the response. Providers that cannot honor domain/recency filters (Firecrawl) are skipped for filtered requests instead of silently violating the filter contract. The output exposes `search_provider`, `fallback_used`, and `fallback_reason` so MCP clients can distinguish a native Grok result from fallback-source handling.
 
 ## MCP Transport
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -21,7 +21,7 @@ MCP client
 - `web_search` is the AI search path. Grok Responses is primary.
 - `get_sources` retrieves cached sources by `session_id`.
 - `web_fetch` fetches page content through the source chain in order (Tavily Extract, Exa contents, TinyFish fetch, Firecrawl scrape — whichever are configured; first non-empty page wins).
-- `web_map` discovers URLs through Tavily Map (the only provider with a real site-map endpoint).
+- `web_map` discovers URLs through Tavily Map (the only provider with a real site-map endpoint). It is a dedicated capability rather than a chain position: a `GROK_SEARCH_SOURCE_PROVIDERS` list that leaves Tavily out of the supplemental chain still gets map from a configured `TAVILY_API_KEY`.
 - Source providers are not the default answer generators inside `web_search`; they provide enrichment, fallback sources, fetch, and map capability. The chain order is canonical (`tavily, exa, tinyfish, firecrawl`) over configured providers, or exactly `GROK_SEARCH_SOURCE_PROVIDERS` when set.
 - Agents should use `web_search` for concise sourced summaries, call `get_sources` before source-specific claims, citation lists, or follow-up fetches, and call `web_fetch` for exact page evidence, quotes, technical details, or when the summary is insufficient.
 
@@ -59,7 +59,7 @@ Sources retain their origin through the `provider` field:
 - the provider response content is empty,
 - the provider response has no verifiable native sources.
 
-Fallback walks the source chain in order; the first provider with usable results serves the response. Providers that cannot honor domain/recency filters (Firecrawl) are skipped for filtered requests instead of silently violating the filter contract. The output exposes `search_provider`, `fallback_used`, and `fallback_reason` so MCP clients can distinguish a native Grok result from fallback-source handling.
+Fallback walks the source chain in order; the first provider with usable results serves the response. Providers that cannot honor domain/recency filters (Firecrawl) are skipped for filtered requests instead of silently violating the filter contract. The chain walk shares the request's global deadline (D-02), so a hanging provider stops the walk instead of granting every later position a fresh full timeout. The output exposes `search_provider`, `fallback_used`, and `fallback_reason` so MCP clients can distinguish a native Grok result from fallback-source handling.
 
 ## MCP Transport
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -158,7 +158,9 @@ Semantic (embeddings-first) search with native `includeDomains` / `excludeDomain
 
 ## Source chain
 
-Supplemental sources and generic (non-specialist) fetch walk an ordered provider chain; the first provider with usable output wins and later ones are pure fallback. Providers that cannot honor domain/recency filters (Firecrawl) are skipped for filtered requests. `web_map` remains Tavily-only.
+Supplemental sources and generic (non-specialist) fetch walk an ordered provider chain; the first provider with usable output wins and later ones are pure fallback. Providers that cannot honor domain/recency filters (Firecrawl) are skipped for filtered requests. The whole chain shares one request deadline (`GROK_SEARCH_TIMEOUT_SECONDS`) — a slow provider cannot multiply the budget by the chain length.
+
+`web_map` is a separate capability, not part of this chain: it always uses Tavily whenever `TAVILY_API_KEY` is configured, even when the chain excludes Tavily.
 
 | Variable | Default | Description |
 |---|---|---|

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -26,9 +26,11 @@ Both carry the **same configuration values** — only the delivery differs. Ever
 | Grok model | `GROK_SEARCH_MODEL` | `X-Grok-Model` |
 | Tavily API key | `TAVILY_API_KEY` | `X-Tavily-Api-Key` |
 | Firecrawl API key | `FIRECRAWL_API_KEY` | `X-Firecrawl-Api-Key` |
+| TinyFish API key | `TINYFISH_API_KEY` | `X-Tinyfish-Api-Key` |
+| Exa API key | `EXA_API_KEY` | `X-Exa-Api-Key` |
 | GitHub token | `GITHUB_TOKEN` | `X-GitHub-Token` |
 
-Only these six are accepted as headers — the caller's per-request secrets plus the gateway/model that pair with the caller's key. Most other settings here (timeouts, budgets, enrichment knobs, Tavily/Firecrawl base URLs, feature toggles) are **operator-fixed**: set once in the server's own environment, never per request. `GROK_SEARCH_URL` / `GROK_SEARCH_MODEL` have operator defaults too; the `X-Grok-Base-Url` / `X-Grok-Model` headers override them per request. **Two groups are stdio-only — stripped over HTTP, not operator-fixed:** OAuth (`GROK_SEARCH_AUTH_MODE` / `GROK_SEARCH_AUTH_FILE`) and the OpenAI-compatible chat-completions transport (`OPENAI_COMPATIBLE_API_URL` / `_API_KEY` / `_MODEL`). The remote server serves Grok **Responses** only; to run a chat-completions relay, use the stdio transport.
+Only these eight are accepted as headers — the caller's per-request secrets plus the gateway/model that pair with the caller's key. Most other settings here (timeouts, budgets, enrichment knobs, Tavily/Firecrawl base URLs, feature toggles) are **operator-fixed**: set once in the server's own environment, never per request. `GROK_SEARCH_URL` / `GROK_SEARCH_MODEL` have operator defaults too; the `X-Grok-Base-Url` / `X-Grok-Model` headers override them per request. **Two groups are stdio-only — stripped over HTTP, not operator-fixed:** OAuth (`GROK_SEARCH_AUTH_MODE` / `GROK_SEARCH_AUTH_FILE`) and the OpenAI-compatible chat-completions transport (`OPENAI_COMPATIBLE_API_URL` / `_API_KEY` / `_MODEL`). The remote server serves Grok **Responses** only; to run a chat-completions relay, use the stdio transport.
 
 The header is `X-` + the env key in `Kebab-Case`, but a few names are historical (the `GROK_SEARCH_` prefix collapses to `X-Grok-`, and `GROK_SEARCH_URL` → `X-Grok-Base-Url`) — **read names off the table above rather than deriving them by hand.**
 
@@ -120,7 +122,7 @@ GROK_SEARCH_WEB_SEARCH = "true"
 | `TAVILY_API_KEY` | unset | Enables Tavily-backed source enrichment, fallback, fetch, and map. Accepts a single key or a comma-separated list (`tvly-a,tvly-b`); multiple keys rotate round-robin per request, with automatic failover to the next key on key-scoped errors (HTTP 401/403/429/432/433). |
 | `TAVILY_API_URL` | `https://api.tavily.com` | Tavily API base URL. |
 | `TAVILY_ENABLED` | `true` | Optional override. Set to `false` only when you want to disable Tavily even if `TAVILY_API_KEY` is configured. |
-| `GROK_SEARCH_EXTRA_SOURCES` | `3` | Adds Tavily enrichment sources after a verifiable Grok result; Firecrawl can fallback if Tavily returns none. Set `0` to disable enrichment. |
+| `GROK_SEARCH_EXTRA_SOURCES` | `3` | Adds enrichment sources after a verifiable Grok result, served by the first source-chain provider with results. Set `0` to disable enrichment. |
 | `GROK_SEARCH_FALLBACK_SOURCES` | `5` | Number of fallback sources to cache when Grok is unverifiable. |
 
 ## Firecrawl
@@ -130,6 +132,37 @@ GROK_SEARCH_WEB_SEARCH = "true"
 | `FIRECRAWL_API_KEY` | unset | Enables Firecrawl fallback for `web_fetch` and supplemental fallback sources. |
 | `FIRECRAWL_API_URL` | `https://api.firecrawl.dev` | Firecrawl API base URL, normalized to `/v1`. |
 | `FIRECRAWL_ENABLED` | `true` | Optional override. Set to `false` to disable Firecrawl even if a key is configured. |
+
+## TinyFish
+
+Free Search & Fetch APIs built for agents (no credits consumed; rate limits apply — 30 req/min on the free plan, and the account still needs Search API access). Search results are keyword-ranked with structured titles/snippets; fetch renders JS-heavy pages and extracts PDFs.
+
+| Variable | Default | Description |
+|---|---|---|
+| `TINYFISH_API_KEY` | unset | Enables TinyFish in the source chain (supplemental sources + generic fetch). One key serves both endpoints. |
+| `TINYFISH_SEARCH_API_URL` | `https://api.search.tinyfish.ai` | Search endpoint (GET). |
+| `TINYFISH_FETCH_API_URL` | `https://api.fetch.tinyfish.ai` | Fetch endpoint (POST). |
+| `TINYFISH_ENABLED` | `true` | Optional override. Set to `false` to disable TinyFish even if a key is configured. |
+
+Domain filters are honored via `site:` / `-site:` query operators; `recency_days` maps to TinyFish's `recency_minutes`.
+
+## Exa
+
+Semantic (embeddings-first) search with native `includeDomains` / `excludeDomains` / published-date filtering — strong on descriptive queries, papers, and official-domain discovery. Paid per request.
+
+| Variable | Default | Description |
+|---|---|---|
+| `EXA_API_KEY` | unset | Enables Exa in the source chain (supplemental sources + `/contents` fetch). |
+| `EXA_API_URL` | `https://api.exa.ai` | Exa API base URL. |
+| `EXA_ENABLED` | `true` | Optional override. Set to `false` to disable Exa even if a key is configured. |
+
+## Source chain
+
+Supplemental sources and generic (non-specialist) fetch walk an ordered provider chain; the first provider with usable output wins and later ones are pure fallback. Providers that cannot honor domain/recency filters (Firecrawl) are skipped for filtered requests. `web_map` remains Tavily-only.
+
+| Variable | Default | Description |
+|---|---|---|
+| `GROK_SEARCH_SOURCE_PROVIDERS` | unset | Comma-separated explicit chain order, e.g. `tinyfish,tavily,firecrawl` (valid names: `tavily`, `exa`, `tinyfish`, `firecrawl`). Unset = configured providers in canonical order `tavily, exa, tinyfish, firecrawl`. Unknown names fail at startup. |
 
 ## Cache
 
@@ -206,6 +239,14 @@ Unknown keys are rejected by the loader — typos surface as parse errors instea
 | `firecrawl_api_url` | `FIRECRAWL_API_URL` |
 | `firecrawl_api_key` | `FIRECRAWL_API_KEY` |
 | `firecrawl_enabled` | `FIRECRAWL_ENABLED` |
+| `tinyfish_search_api_url` | `TINYFISH_SEARCH_API_URL` |
+| `tinyfish_fetch_api_url` | `TINYFISH_FETCH_API_URL` |
+| `tinyfish_api_key` | `TINYFISH_API_KEY` |
+| `tinyfish_enabled` | `TINYFISH_ENABLED` |
+| `exa_api_url` | `EXA_API_URL` |
+| `exa_api_key` | `EXA_API_KEY` |
+| `exa_enabled` | `EXA_ENABLED` |
+| `source_providers` | `GROK_SEARCH_SOURCE_PROVIDERS` |
 | `default_extra_sources` | `GROK_SEARCH_EXTRA_SOURCES` |
 | `fallback_sources` | `GROK_SEARCH_FALLBACK_SOURCES` |
 | `fetch_max_chars` | `GROK_SEARCH_FETCH_MAX_CHARS` |

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -144,7 +144,7 @@ Free Search & Fetch APIs built for agents (no credits consumed; rate limits appl
 | `TINYFISH_FETCH_API_URL` | `https://api.fetch.tinyfish.ai` | Fetch endpoint (POST). |
 | `TINYFISH_ENABLED` | `true` | Optional override. Set to `false` to disable TinyFish even if a key is configured. |
 
-Domain filters are honored via `site:` / `-site:` query operators; `recency_days` maps to TinyFish's `recency_minutes`.
+Domain filters map to TinyFish's dedicated `include_domains` / `exclude_domains` parameters (the `site:` / `-site:` query operators are deprecated upstream for domain filtering because they collide with other query syntax); `recency_days` maps to `recency_minutes`.
 
 ## Exa
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -31,6 +31,16 @@ pub struct Config {
     pub firecrawl_api_url: String,
     pub firecrawl_api_key: Option<String>,
     pub firecrawl_enabled: bool,
+    pub tinyfish_search_api_url: String,
+    pub tinyfish_fetch_api_url: String,
+    pub tinyfish_api_key: Option<String>,
+    pub tinyfish_enabled: bool,
+    pub exa_api_url: String,
+    pub exa_api_key: Option<String>,
+    pub exa_enabled: bool,
+    /// Explicit source-provider chain order (lowercased names). Empty means
+    /// "use the built-in canonical order over whatever is configured".
+    pub source_providers: Vec<String>,
     pub default_extra_sources: usize,
     pub fallback_sources: usize,
     pub fetch_max_chars: Option<usize>,
@@ -76,6 +86,14 @@ impl std::fmt::Debug for Config {
             .field("firecrawl_api_url", &self.firecrawl_api_url)
             .field("firecrawl_api_key", &mask(&self.firecrawl_api_key))
             .field("firecrawl_enabled", &self.firecrawl_enabled)
+            .field("tinyfish_search_api_url", &self.tinyfish_search_api_url)
+            .field("tinyfish_fetch_api_url", &self.tinyfish_fetch_api_url)
+            .field("tinyfish_api_key", &mask(&self.tinyfish_api_key))
+            .field("tinyfish_enabled", &self.tinyfish_enabled)
+            .field("exa_api_url", &self.exa_api_url)
+            .field("exa_api_key", &mask(&self.exa_api_key))
+            .field("exa_enabled", &self.exa_enabled)
+            .field("source_providers", &self.source_providers)
             .field("default_extra_sources", &self.default_extra_sources)
             .field("fallback_sources", &self.fallback_sources)
             .field("fetch_max_chars", &self.fetch_max_chars)
@@ -117,6 +135,14 @@ struct ConfigFile {
     firecrawl_api_url: Option<String>,
     firecrawl_api_key: Option<String>,
     firecrawl_enabled: Option<bool>,
+    tinyfish_search_api_url: Option<String>,
+    tinyfish_fetch_api_url: Option<String>,
+    tinyfish_api_key: Option<String>,
+    tinyfish_enabled: Option<bool>,
+    exa_api_url: Option<String>,
+    exa_api_key: Option<String>,
+    exa_enabled: Option<bool>,
+    source_providers: Option<Vec<String>>,
     default_extra_sources: Option<usize>,
     fallback_sources: Option<usize>,
     fetch_max_chars: Option<usize>,
@@ -165,6 +191,20 @@ impl ConfigFile {
         insert(
             "FIRECRAWL_ENABLED",
             self.firecrawl_enabled.map(|b| b.to_string()),
+        );
+        insert("TINYFISH_SEARCH_API_URL", self.tinyfish_search_api_url);
+        insert("TINYFISH_FETCH_API_URL", self.tinyfish_fetch_api_url);
+        insert("TINYFISH_API_KEY", self.tinyfish_api_key);
+        insert(
+            "TINYFISH_ENABLED",
+            self.tinyfish_enabled.map(|b| b.to_string()),
+        );
+        insert("EXA_API_URL", self.exa_api_url);
+        insert("EXA_API_KEY", self.exa_api_key);
+        insert("EXA_ENABLED", self.exa_enabled.map(|b| b.to_string()));
+        insert(
+            "GROK_SEARCH_SOURCE_PROVIDERS",
+            self.source_providers.map(|list| list.join(",")),
         );
         insert(
             "GROK_SEARCH_EXTRA_SOURCES",
@@ -300,6 +340,28 @@ impl Config {
                 .cloned()
                 .filter(|value| !value.trim().is_empty()),
             firecrawl_enabled: bool_value(&map, "FIRECRAWL_ENABLED", true),
+            tinyfish_search_api_url: normalize_plain_base(&get(
+                &map,
+                "TINYFISH_SEARCH_API_URL",
+                "https://api.search.tinyfish.ai",
+            )),
+            tinyfish_fetch_api_url: normalize_plain_base(&get(
+                &map,
+                "TINYFISH_FETCH_API_URL",
+                "https://api.fetch.tinyfish.ai",
+            )),
+            tinyfish_api_key: map
+                .get("TINYFISH_API_KEY")
+                .cloned()
+                .filter(|value| !value.trim().is_empty()),
+            tinyfish_enabled: bool_value(&map, "TINYFISH_ENABLED", true),
+            exa_api_url: normalize_plain_base(&get(&map, "EXA_API_URL", "https://api.exa.ai")),
+            exa_api_key: map
+                .get("EXA_API_KEY")
+                .cloned()
+                .filter(|value| !value.trim().is_empty()),
+            exa_enabled: bool_value(&map, "EXA_ENABLED", true),
+            source_providers: csv_list(&map, "GROK_SEARCH_SOURCE_PROVIDERS"),
             default_extra_sources: usize_value(&map, "GROK_SEARCH_EXTRA_SOURCES", 3),
             fallback_sources: usize_value(&map, "GROK_SEARCH_FALLBACK_SOURCES", 5),
             fetch_max_chars: optional_positive_usize(&map, "GROK_SEARCH_FETCH_MAX_CHARS"),
@@ -340,7 +402,7 @@ impl Config {
 
     pub fn redacted_diagnostics(&self) -> String {
         format!(
-            "grok_api_url={} grok_api_key={} grok_auth_mode={:?} grok_auth_file={} grok_model={} web_search_enabled={} x_search_enabled={} tavily_api_key={} firecrawl_api_key={} default_extra_sources={} fallback_sources={} timeout_seconds={} github_token={}",
+            "grok_api_url={} grok_api_key={} grok_auth_mode={:?} grok_auth_file={} grok_model={} web_search_enabled={} x_search_enabled={} tavily_api_key={} firecrawl_api_key={} tinyfish_api_key={} exa_api_key={} default_extra_sources={} fallback_sources={} timeout_seconds={} github_token={}",
             self.grok_api_url,
             redact(self.grok_api_key.as_deref()),
             self.grok_auth_mode,
@@ -353,6 +415,8 @@ impl Config {
             self.x_search_enabled,
             redact(self.tavily_api_key.as_deref()),
             redact(self.firecrawl_api_key.as_deref()),
+            redact(self.tinyfish_api_key.as_deref()),
+            redact(self.exa_api_key.as_deref()),
             self.default_extra_sources,
             self.fallback_sources,
             self.timeout.as_secs(),
@@ -480,11 +544,19 @@ pub const CONFIG_TEMPLATE: &str = r#"# grok-search-rs global configuration
 # grok_model         = "grok-4-1-fast-reasoning"
 # x_search_enabled   = false          # Grok X/Twitter search tool
 # firecrawl_api_key  = "fc-..."       # Optional fetch fallback   https://firecrawl.dev
+# tinyfish_api_key   = "tf-..."       # Optional free search/fetch  https://tinyfish.ai
+# exa_api_key        = "exa-..."      # Optional semantic search    https://exa.ai
+# source_providers   = ["tavily", "exa", "tinyfish", "firecrawl"]
+#                                     # explicit chain order; omit for the
+#                                     # built-in order over configured providers
 
 # ── Endpoints (only set when using a self-hosted gateway) ─────
-# grok_api_url      = "https://api.x.ai"
-# tavily_api_url    = "https://api.tavily.com"
-# firecrawl_api_url = "https://api.firecrawl.dev"
+# grok_api_url            = "https://api.x.ai"
+# tavily_api_url          = "https://api.tavily.com"
+# firecrawl_api_url       = "https://api.firecrawl.dev"
+# tinyfish_search_api_url = "https://api.search.tinyfish.ai"
+# tinyfish_fetch_api_url  = "https://api.fetch.tinyfish.ai"
+# exa_api_url             = "https://api.exa.ai"
 
 # ── OpenAI-compatible transport (alternative to grok_*) ───────
 # Set these three to use a /v1/chat/completions gateway. When grok_api_key
@@ -499,6 +571,8 @@ pub const CONFIG_TEMPLATE: &str = r#"# grok-search-rs global configuration
 # web_search_enabled = true
 # tavily_enabled     = true
 # firecrawl_enabled  = true
+# tinyfish_enabled   = true
+# exa_enabled        = true
 
 # ── Behavior tuning ───────────────────────────────────────────
 # default_extra_sources = 3
@@ -567,6 +641,24 @@ fn normalize_plain_base(url: &str) -> String {
 
 fn bool_value(map: &HashMap<String, String>, key: &str, default: bool) -> bool {
     map.get(key).map(|v| bool_literal(v)).unwrap_or(default)
+}
+
+/// Comma-separated list → trimmed, lowercased entries, de-duplicated with
+/// first occurrence winning. Absent/blank values yield an empty list.
+fn csv_list(map: &HashMap<String, String>, key: &str) -> Vec<String> {
+    let mut names: Vec<String> = Vec::new();
+    for part in map
+        .get(key)
+        .map(String::as_str)
+        .unwrap_or_default()
+        .split(',')
+    {
+        let name = part.trim().to_ascii_lowercase();
+        if !name.is_empty() && !names.contains(&name) {
+            names.push(name);
+        }
+    }
+    names
 }
 
 fn bool_literal(value: &str) -> bool {

--- a/src/http.rs
+++ b/src/http.rs
@@ -4,7 +4,8 @@
 //! `POST /mcp` endpoint, but multi-tenant: the server process holds **no**
 //! credentials. Each request carries the caller's own API keys in headers
 //! (`X-Grok-Api-Key` / `X-Tavily-Api-Key` / `X-Firecrawl-Api-Key` /
-//! `X-GitHub-Token`); a fully-credentialed [`SearchService`] is built per
+//! `X-Tinyfish-Api-Key` / `X-Exa-Api-Key` / `X-GitHub-Token`); a
+//! fully-credentialed [`SearchService`] is built per
 //! request via [`SearchService::for_request`], reusing one shared HTTP client
 //! and one process-wide source cache (so `get_sources` continuation still
 //! works across requests). The whole module is gated behind the `http` feature
@@ -57,6 +58,8 @@ const SECRET_ENV_KEYS: &[&str] = &[
     "GROK_SEARCH_API_KEY",
     "TAVILY_API_KEY",
     "FIRECRAWL_API_KEY",
+    "TINYFISH_API_KEY",
+    "EXA_API_KEY",
     "GITHUB_TOKEN",
     "OPENAI_COMPATIBLE_API_KEY",
     "OPENAI_COMPATIBLE_API_URL",
@@ -71,6 +74,8 @@ const HEADER_TO_ENV: &[(&str, &str)] = &[
     ("x-grok-api-key", "GROK_SEARCH_API_KEY"),
     ("x-tavily-api-key", "TAVILY_API_KEY"),
     ("x-firecrawl-api-key", "FIRECRAWL_API_KEY"),
+    ("x-tinyfish-api-key", "TINYFISH_API_KEY"),
+    ("x-exa-api-key", "EXA_API_KEY"),
     ("x-github-token", "GITHUB_TOKEN"),
     // Non-secret: lets a caller pick the Grok model per request (pairs with
     // X-Grok-Base-Url, since model names are gateway-specific). Absent header

--- a/src/http.rs
+++ b/src/http.rs
@@ -110,6 +110,11 @@ struct AppState {
 pub async fn run_http(base_env: HashMap<String, String>, bind: SocketAddr) -> anyhow::Result<()> {
     // Operator (non-secret) config drives the shared client + cache sizing.
     let operator_cfg = Config::from_env_map(base_env.clone());
+    // Fail before binding on a bad GROK_SEARCH_SOURCE_PROVIDERS: the chain is
+    // operator-fixed (never a request header), and deferring the error to
+    // per-request service construction would leave a listener up that rejects
+    // every call.
+    crate::service::validate_source_providers(&operator_cfg)?;
     // Restricted client: rejects redirects to non-public IP-literal targets.
     let http_client = crate::providers::http::build_restricted_client(operator_cfg.timeout);
     let cache = Arc::new(Mutex::new(SourceCache::new(operator_cfg.cache_size)));

--- a/src/main.rs
+++ b/src/main.rs
@@ -183,6 +183,8 @@ Required keys
   GROK_SEARCH_API_KEY   xAI / Grok-compatible key   (https://x.ai/api)
   TAVILY_API_KEY        Tavily fetch + map          (https://tavily.com)
   FIRECRAWL_API_KEY     optional fetch fallback     (https://firecrawl.dev)
+  TINYFISH_API_KEY      optional free search+fetch  (https://tinyfish.ai)
+  EXA_API_KEY           optional semantic search    (https://exa.ai)
 
 OAuth alternative
   grok-search-rs login

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -250,12 +250,12 @@ fn tools_list() -> Value {
                         "include_domains": {
                             "type": "array",
                             "items": { "type": "string" },
-                            "description": "Only return supplemental results from these domains. Tavily/Exa honor strictly, TinyFish via site: operators; filter-blind providers are skipped. Grok receives as soft preference."
+                            "description": "Only return supplemental results from these domains. Tavily/Exa/TinyFish honor strictly via native domain parameters; filter-blind providers are skipped. Grok receives as soft preference."
                         },
                         "exclude_domains": {
                             "type": "array",
                             "items": { "type": "string" },
-                            "description": "Suppress supplemental results from these domains. Tavily/Exa honor strictly, TinyFish via -site: operators; filter-blind providers are skipped. Grok receives as soft instruction."
+                            "description": "Suppress supplemental results from these domains. Tavily/Exa/TinyFish honor strictly via native domain parameters; filter-blind providers are skipped. Grok receives as soft instruction."
                         },
                         "include_content": {
                             "type": "boolean",

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -240,22 +240,22 @@ fn tools_list() -> Value {
                         "extra_sources": {
                             "type": "integer",
                             "minimum": 0,
-                            "description": "Optional supplemental source count. Tavily is primary; Firecrawl is fallback. If omitted, GROK_SEARCH_EXTRA_SOURCES is used."
+                            "description": "Optional supplemental source count, served by the configured source chain (default order: Tavily, then Exa, TinyFish, Firecrawl — first provider with results wins; GROK_SEARCH_SOURCE_PROVIDERS overrides). If omitted, GROK_SEARCH_EXTRA_SOURCES is used."
                         },
                         "recency_days": {
                             "type": "integer",
                             "minimum": 1,
-                            "description": "Restrict supplemental results to sources published within the last N days. Forwarded to Tavily as days+topic=news; also hinted to Grok prompt."
+                            "description": "Restrict supplemental results to sources published within the last N days. Honored natively by Tavily (days+topic=news), Exa (startPublishedDate), and TinyFish (recency window); providers that cannot honor filters (Firecrawl) are skipped for filtered requests. Also hinted to Grok prompt."
                         },
                         "include_domains": {
                             "type": "array",
                             "items": { "type": "string" },
-                            "description": "Only return supplemental results from these domains. Tavily honors strictly; Grok receives as soft preference."
+                            "description": "Only return supplemental results from these domains. Tavily/Exa honor strictly, TinyFish via site: operators; filter-blind providers are skipped. Grok receives as soft preference."
                         },
                         "exclude_domains": {
                             "type": "array",
                             "items": { "type": "string" },
-                            "description": "Suppress supplemental results from these domains. Tavily honors strictly; Grok receives as soft instruction."
+                            "description": "Suppress supplemental results from these domains. Tavily/Exa honor strictly, TinyFish via -site: operators; filter-blind providers are skipped. Grok receives as soft instruction."
                         },
                         "include_content": {
                             "type": "boolean",
@@ -322,7 +322,7 @@ fn tools_list() -> Value {
             },
             {
                 "name": "doctor",
-                "description": "Diagnostic probe: live connectivity check for Grok, Tavily, and Firecrawl backends, plus masked configuration. Use to verify the server is wired up and reachable.",
+                "description": "Diagnostic probe: live connectivity check for the Grok backend and every configured source provider (Tavily / Exa / TinyFish / Firecrawl), plus the effective source chain and masked configuration. Use to verify the server is wired up and reachable.",
                 "inputSchema": { "type": "object", "properties": {} }
             }
         ]

--- a/src/providers/exa.rs
+++ b/src/providers/exa.rs
@@ -3,8 +3,7 @@
 //! Exa is an embeddings-first engine: strong on descriptive queries, papers,
 //! official domains, and low-noise discovery, with native support for the
 //! whole `SearchFilters` contract (domain include/exclude lists and a
-//! published-date lower bound). Fetch goes through `/contents`. Auth accepts
-//! `Authorization: Bearer`, so the shared bearer helpers apply as-is.
+//! published-date lower bound). Fetch goes through `/contents`.
 
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
@@ -15,7 +14,12 @@ use crate::error::{GrokSearchError, Result};
 use crate::model::search::SearchFilters;
 use crate::model::source::{FetchedPage, Source};
 
-use super::http::{build_client, post_json};
+use super::http::{build_client, post_json_with_header_auth};
+
+/// Exa's canonical auth channel. The docs also describe `Authorization:
+/// Bearer` as accepted, but every reference example uses this header — stick
+/// to the primary documented path rather than the alternate one.
+const AUTH_HEADER: &str = "x-api-key";
 
 /// Exa's public `numResults` ceiling.
 const MAX_NUM_RESULTS: usize = 100;
@@ -57,10 +61,10 @@ impl ExaProvider {
         filters: &SearchFilters,
     ) -> Result<Vec<Source>> {
         let body = exa_search_request_body(query, max_results, filters, now_unix_seconds());
-        let raw = post_json(
+        let raw = post_json_with_header_auth(
             &self.client,
             &self.endpoint("search"),
-            &self.api_key,
+            (AUTH_HEADER, &self.api_key),
             &body,
             "Exa",
         )
@@ -69,10 +73,10 @@ impl ExaProvider {
     }
 
     pub async fn fetch(&self, url: &str) -> Result<FetchedPage> {
-        let raw = post_json(
+        let raw = post_json_with_header_auth(
             &self.client,
             &self.endpoint("contents"),
-            &self.api_key,
+            (AUTH_HEADER, &self.api_key),
             &json!({ "urls": [url], "text": true }),
             "Exa",
         )

--- a/src/providers/exa.rs
+++ b/src/providers/exa.rs
@@ -1,0 +1,218 @@
+//! Exa semantic search provider.
+//!
+//! Exa is an embeddings-first engine: strong on descriptive queries, papers,
+//! official domains, and low-noise discovery, with native support for the
+//! whole `SearchFilters` contract (domain include/exclude lists and a
+//! published-date lower bound). Fetch goes through `/contents`. Auth accepts
+//! `Authorization: Bearer`, so the shared bearer helpers apply as-is.
+
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use reqwest::Client;
+use serde_json::{json, Value};
+
+use crate::error::{GrokSearchError, Result};
+use crate::model::search::SearchFilters;
+use crate::model::source::{FetchedPage, Source};
+
+use super::http::{build_client, post_json};
+
+/// Exa's public `numResults` ceiling.
+const MAX_NUM_RESULTS: usize = 100;
+
+#[derive(Clone)]
+pub struct ExaProvider {
+    client: Client,
+    api_url: String,
+    api_key: String,
+}
+
+impl ExaProvider {
+    pub fn new(api_url: impl Into<String>, api_key: impl Into<String>, timeout: Duration) -> Self {
+        Self::with_client(build_client(timeout), api_url, api_key)
+    }
+
+    /// Construct with an externally provided `reqwest::Client`. Used by
+    /// `SearchService` to share one tuned client across providers.
+    pub fn with_client(
+        client: Client,
+        api_url: impl Into<String>,
+        api_key: impl Into<String>,
+    ) -> Self {
+        Self {
+            client,
+            api_url: api_url.into().trim_end_matches('/').to_string(),
+            api_key: api_key.into(),
+        }
+    }
+
+    fn endpoint(&self, path: &str) -> String {
+        format!("{}/{}", self.api_url, path.trim_start_matches('/'))
+    }
+
+    pub async fn search(
+        &self,
+        query: &str,
+        max_results: usize,
+        filters: &SearchFilters,
+    ) -> Result<Vec<Source>> {
+        let body = exa_search_request_body(query, max_results, filters, now_unix_seconds());
+        let raw = post_json(
+            &self.client,
+            &self.endpoint("search"),
+            &self.api_key,
+            &body,
+            "Exa",
+        )
+        .await?;
+        Ok(normalize_exa_results(&raw))
+    }
+
+    pub async fn fetch(&self, url: &str) -> Result<FetchedPage> {
+        let raw = post_json(
+            &self.client,
+            &self.endpoint("contents"),
+            &self.api_key,
+            &json!({ "urls": [url], "text": true }),
+            "Exa",
+        )
+        .await?;
+        parse_exa_contents(&raw, url)
+    }
+}
+
+fn now_unix_seconds() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|elapsed| elapsed.as_secs())
+        .unwrap_or(0)
+}
+
+/// Search body without contents options: results carry metadata only
+/// (title/url/publishedDate), keeping per-call cost at the base search rate —
+/// inline page text comes from the shared enrichment pipeline, not from Exa.
+pub fn exa_search_request_body(
+    query: &str,
+    max_results: usize,
+    filters: &SearchFilters,
+    now_unix: u64,
+) -> Value {
+    let mut body = json!({
+        "query": query,
+        "numResults": max_results.clamp(1, MAX_NUM_RESULTS),
+    });
+    let object = body.as_object_mut().expect("literal object");
+    if !filters.include_domains.is_empty() {
+        object.insert("includeDomains".into(), json!(filters.include_domains));
+    }
+    if !filters.exclude_domains.is_empty() {
+        object.insert("excludeDomains".into(), json!(filters.exclude_domains));
+    }
+    if let Some(days) = filters.recency_days {
+        object.insert(
+            "startPublishedDate".into(),
+            json!(start_published_date(days, now_unix)),
+        );
+    }
+    body
+}
+
+/// `recency_days` → ISO-8601 lower bound for Exa's `startPublishedDate`:
+/// midnight UTC `days` ago.
+pub fn start_published_date(days: u32, now_unix: u64) -> String {
+    let day_index = (now_unix / 86_400) as i64 - i64::from(days);
+    let (year, month, day) = civil_from_days(day_index);
+    format!("{year:04}-{month:02}-{day:02}T00:00:00.000Z")
+}
+
+/// Days-since-epoch → proleptic-Gregorian (year, month, day), after Howard
+/// Hinnant's `civil_from_days`. One date subtraction does not justify a
+/// calendar dependency.
+fn civil_from_days(days: i64) -> (i64, u32, u32) {
+    let shifted = days + 719_468;
+    let era = if shifted >= 0 {
+        shifted
+    } else {
+        shifted - 146_096
+    } / 146_097;
+    let day_of_era = shifted - era * 146_097;
+    let year_of_era =
+        (day_of_era - day_of_era / 1_460 + day_of_era / 36_524 - day_of_era / 146_096) / 365;
+    let year = year_of_era + era * 400;
+    let day_of_year = day_of_era - (365 * year_of_era + year_of_era / 4 - year_of_era / 100);
+    let month_index = (5 * day_of_year + 2) / 153;
+    let day = (day_of_year - (153 * month_index + 2) / 5 + 1) as u32;
+    let month = if month_index < 10 {
+        month_index + 3
+    } else {
+        month_index - 9
+    } as u32;
+    (if month <= 2 { year + 1 } else { year }, month, day)
+}
+
+pub fn normalize_exa_results(raw: &Value) -> Vec<Source> {
+    raw.get("results")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(|item| {
+            let url = item.get("url").and_then(Value::as_str)?;
+            let mut source = Source::new(url, "exa");
+            if let Some(title) = item.get("title").and_then(Value::as_str) {
+                source = source.with_title(title);
+            }
+            if let Some(summary) = item.get("summary").and_then(Value::as_str) {
+                source = source.with_description(summary);
+            }
+            if let Some(date) = item.get("publishedDate").and_then(Value::as_str) {
+                source = source.with_published_date(date);
+            }
+            Some(source)
+        })
+        .collect()
+}
+
+/// `/contents` reports per-URL failures in `statuses[]` beside a 200
+/// response; an empty result set is inspected for that reason before the
+/// generic "no content" verdict.
+pub fn parse_exa_contents(raw: &Value, url: &str) -> Result<FetchedPage> {
+    if let Some(result) = raw
+        .get("results")
+        .and_then(Value::as_array)
+        .and_then(|results| results.first())
+    {
+        let content = result
+            .get("text")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .to_string();
+        if !content.trim().is_empty() {
+            return Ok(FetchedPage {
+                content,
+                title: result
+                    .get("title")
+                    .and_then(Value::as_str)
+                    .map(str::to_string),
+                published_date: result
+                    .get("publishedDate")
+                    .and_then(Value::as_str)
+                    .map(str::to_string),
+            });
+        }
+    }
+    let detail = raw
+        .get("statuses")
+        .and_then(Value::as_array)
+        .and_then(|statuses| statuses.first())
+        .and_then(|status| {
+            status
+                .get("error")
+                .and_then(|error| error.get("tag"))
+                .or_else(|| status.get("status"))
+        })
+        .and_then(Value::as_str)
+        .unwrap_or("no content returned");
+    Err(GrokSearchError::Provider(format!(
+        "Exa contents failed for {url}: {detail}"
+    )))
+}

--- a/src/providers/http.rs
+++ b/src/providers/http.rs
@@ -172,19 +172,58 @@ pub async fn post_json_with_status(
     body: &Value,
     label: &str,
 ) -> std::result::Result<Value, HttpFailure> {
-    let mut response = client
-        .post(endpoint)
-        .bearer_auth(api_key)
-        .json(body)
-        .send()
-        .await
-        .map_err(|err| {
-            HttpFailure::transport(if err.is_timeout() {
-                GrokSearchError::Timeout(format!("{label} request timed out: {err}"))
-            } else {
-                GrokSearchError::Provider(format!("{label} request failed: {err}"))
-            })
-        })?;
+    send_json(client.post(endpoint).bearer_auth(api_key).json(body), label).await
+}
+
+/// Like [`post_json`], but authenticated with a provider-specific header
+/// (e.g. TinyFish's `X-API-Key`) instead of a bearer `Authorization`.
+pub async fn post_json_with_header_auth(
+    client: &Client,
+    endpoint: &str,
+    header: (&str, &str),
+    body: &Value,
+    label: &str,
+) -> Result<Value> {
+    send_json(
+        client.post(endpoint).header(header.0, header.1).json(body),
+        label,
+    )
+    .await
+    .map_err(|failure| failure.error)
+}
+
+/// Authenticated JSON GET with query parameters and a provider-specific auth
+/// header, for GET-style search APIs (e.g. TinyFish). Same error
+/// normalization as [`post_json`].
+pub async fn get_json_with_header_auth(
+    client: &Client,
+    endpoint: &str,
+    query: &[(&str, String)],
+    header: (&str, &str),
+    label: &str,
+) -> Result<Value> {
+    send_json(
+        client.get(endpoint).query(query).header(header.0, header.1),
+        label,
+    )
+    .await
+    .map_err(|failure| failure.error)
+}
+
+/// Send a prepared JSON request and normalize transport / status / parse
+/// failures into `HttpFailure`. Shared by the bearer- and header-auth helpers
+/// so every provider gets identical error handling (including the SSE path).
+async fn send_json(
+    request: reqwest::RequestBuilder,
+    label: &str,
+) -> std::result::Result<Value, HttpFailure> {
+    let mut response = request.send().await.map_err(|err| {
+        HttpFailure::transport(if err.is_timeout() {
+            GrokSearchError::Timeout(format!("{label} request timed out: {err}"))
+        } else {
+            GrokSearchError::Provider(format!("{label} request failed: {err}"))
+        })
+    })?;
 
     let status = response.status();
     let content_type = response

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -1,5 +1,7 @@
+pub mod exa;
 pub mod firecrawl;
 pub mod grok;
 pub mod http;
 pub mod openai_compatible;
 pub mod tavily;
+pub mod tinyfish;

--- a/src/providers/tinyfish.rs
+++ b/src/providers/tinyfish.rs
@@ -68,7 +68,7 @@ impl TinyfishProvider {
         let raw = get_json_with_header_auth(
             &self.client,
             &self.search_api_url,
-            &tinyfish_search_query(query, filters),
+            &tinyfish_search_params(query, filters),
             (AUTH_HEADER, &self.api_key),
             "TinyFish",
         )
@@ -93,32 +93,20 @@ impl TinyfishProvider {
     }
 }
 
-/// Build the GET query parameters. TinyFish has no structured domain
-/// parameters — domain scoping rides inside the query string as `site:` /
-/// `-site:` search operators (the documented mechanism) — while recency maps
-/// onto `recency_minutes`.
-pub fn tinyfish_search_query(query: &str, filters: &SearchFilters) -> Vec<(&'static str, String)> {
-    let mut composed = query.to_string();
-    match filters.include_domains.as_slice() {
-        [] => {}
-        [single] => {
-            composed.push_str(" site:");
-            composed.push_str(single);
-        }
-        many => {
-            let group = many
-                .iter()
-                .map(|domain| format!("site:{domain}"))
-                .collect::<Vec<_>>()
-                .join(" OR ");
-            composed.push_str(&format!(" ({group})"));
-        }
+/// Build the GET query parameters. Domain scoping uses TinyFish's dedicated
+/// comma-separated `include_domains` / `exclude_domains` parameters: the
+/// `site:` / `-site:` query operators still work but are documented as
+/// deprecated for domain filtering precisely because they collide with other
+/// query syntax — and the caller's query is arbitrary user text, so it can
+/// carry that syntax. Recency maps onto `recency_minutes`.
+pub fn tinyfish_search_params(query: &str, filters: &SearchFilters) -> Vec<(&'static str, String)> {
+    let mut params = vec![("query", query.to_string())];
+    if !filters.include_domains.is_empty() {
+        params.push(("include_domains", filters.include_domains.join(",")));
     }
-    for domain in &filters.exclude_domains {
-        composed.push_str(" -site:");
-        composed.push_str(domain);
+    if !filters.exclude_domains.is_empty() {
+        params.push(("exclude_domains", filters.exclude_domains.join(",")));
     }
-    let mut params = vec![("query", composed)];
     if let Some(days) = filters.recency_days {
         let minutes = u64::from(days)
             .saturating_mul(24 * 60)

--- a/src/providers/tinyfish.rs
+++ b/src/providers/tinyfish.rs
@@ -1,0 +1,187 @@
+//! TinyFish Search & Fetch provider (issue #12).
+//!
+//! Two independent endpoints share one API key: search is a GET service at
+//! `api.search.tinyfish.ai`, fetch a POST service at `api.fetch.tinyfish.ai`.
+//! Both authenticate with an `X-API-Key` header rather than a bearer token,
+//! and neither consumes account credits (rate limits still apply).
+
+use std::time::Duration;
+
+use reqwest::Client;
+use serde_json::{json, Value};
+
+use crate::error::{GrokSearchError, Result};
+use crate::model::search::SearchFilters;
+use crate::model::source::{FetchedPage, Source};
+
+use super::http::{build_client, get_json_with_header_auth, post_json_with_header_auth};
+
+const AUTH_HEADER: &str = "X-API-Key";
+/// TinyFish caps `recency_minutes` at ten years.
+const MAX_RECENCY_MINUTES: u64 = 5_256_000;
+
+#[derive(Clone)]
+pub struct TinyfishProvider {
+    client: Client,
+    search_api_url: String,
+    fetch_api_url: String,
+    api_key: String,
+}
+
+impl TinyfishProvider {
+    pub fn new(
+        search_api_url: impl Into<String>,
+        fetch_api_url: impl Into<String>,
+        api_key: impl Into<String>,
+        timeout: Duration,
+    ) -> Self {
+        Self::with_client(
+            build_client(timeout),
+            search_api_url,
+            fetch_api_url,
+            api_key,
+        )
+    }
+
+    /// Construct with an externally provided `reqwest::Client`. Used by
+    /// `SearchService` to share one tuned client across providers.
+    pub fn with_client(
+        client: Client,
+        search_api_url: impl Into<String>,
+        fetch_api_url: impl Into<String>,
+        api_key: impl Into<String>,
+    ) -> Self {
+        Self {
+            client,
+            search_api_url: search_api_url.into().trim_end_matches('/').to_string(),
+            fetch_api_url: fetch_api_url.into().trim_end_matches('/').to_string(),
+            api_key: api_key.into(),
+        }
+    }
+
+    pub async fn search(
+        &self,
+        query: &str,
+        max_results: usize,
+        filters: &SearchFilters,
+    ) -> Result<Vec<Source>> {
+        let raw = get_json_with_header_auth(
+            &self.client,
+            &self.search_api_url,
+            &tinyfish_search_query(query, filters),
+            (AUTH_HEADER, &self.api_key),
+            "TinyFish",
+        )
+        .await?;
+        // The API has no result-count parameter (only pagination), so the
+        // caller's budget is applied client-side.
+        let mut sources = normalize_tinyfish_results(&raw);
+        sources.truncate(max_results);
+        Ok(sources)
+    }
+
+    pub async fn fetch(&self, url: &str) -> Result<FetchedPage> {
+        let raw = post_json_with_header_auth(
+            &self.client,
+            &self.fetch_api_url,
+            (AUTH_HEADER, &self.api_key),
+            &json!({ "urls": [url], "format": "markdown" }),
+            "TinyFish",
+        )
+        .await?;
+        parse_tinyfish_fetch(&raw, url)
+    }
+}
+
+/// Build the GET query parameters. TinyFish has no structured domain
+/// parameters — domain scoping rides inside the query string as `site:` /
+/// `-site:` search operators (the documented mechanism) — while recency maps
+/// onto `recency_minutes`.
+pub fn tinyfish_search_query(query: &str, filters: &SearchFilters) -> Vec<(&'static str, String)> {
+    let mut composed = query.to_string();
+    match filters.include_domains.as_slice() {
+        [] => {}
+        [single] => {
+            composed.push_str(" site:");
+            composed.push_str(single);
+        }
+        many => {
+            let group = many
+                .iter()
+                .map(|domain| format!("site:{domain}"))
+                .collect::<Vec<_>>()
+                .join(" OR ");
+            composed.push_str(&format!(" ({group})"));
+        }
+    }
+    for domain in &filters.exclude_domains {
+        composed.push_str(" -site:");
+        composed.push_str(domain);
+    }
+    let mut params = vec![("query", composed)];
+    if let Some(days) = filters.recency_days {
+        let minutes = u64::from(days)
+            .saturating_mul(24 * 60)
+            .clamp(1, MAX_RECENCY_MINUTES);
+        params.push(("recency_minutes", minutes.to_string()));
+    }
+    params
+}
+
+pub fn normalize_tinyfish_results(raw: &Value) -> Vec<Source> {
+    raw.get("results")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(|item| {
+            let url = item.get("url").and_then(Value::as_str)?;
+            let mut source = Source::new(url, "tinyfish");
+            if let Some(title) = item.get("title").and_then(Value::as_str) {
+                source = source.with_title(title);
+            }
+            if let Some(snippet) = item.get("snippet").and_then(Value::as_str) {
+                source = source.with_description(snippet);
+            }
+            if let Some(date) = item.get("date").and_then(Value::as_str) {
+                source = source.with_published_date(date);
+            }
+            Some(source)
+        })
+        .collect()
+}
+
+/// Per-URL failures (timeouts, anti-bot blocks) arrive in `errors[]` beside a
+/// 200 response, so an empty `results` is inspected for a reason before the
+/// generic "no content" verdict.
+pub fn parse_tinyfish_fetch(raw: &Value, url: &str) -> Result<FetchedPage> {
+    if let Some(result) = raw
+        .get("results")
+        .and_then(Value::as_array)
+        .and_then(|results| results.first())
+    {
+        let content = result
+            .get("text")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .to_string();
+        if !content.trim().is_empty() {
+            return Ok(FetchedPage {
+                content,
+                title: result
+                    .get("title")
+                    .and_then(Value::as_str)
+                    .map(str::to_string),
+                published_date: None,
+            });
+        }
+    }
+    let detail = raw
+        .get("errors")
+        .and_then(Value::as_array)
+        .and_then(|errors| errors.first())
+        .and_then(|error| error.get("error").and_then(Value::as_str))
+        .unwrap_or("no content returned");
+    Err(GrokSearchError::Provider(format!(
+        "TinyFish fetch failed for {url}: {detail}"
+    )))
+}

--- a/src/service.rs
+++ b/src/service.rs
@@ -13,9 +13,11 @@ use crate::model::search::{
 };
 use crate::model::source::{is_junk_title, merge_sources, FetchedPage, Source};
 use crate::model::tool::{GetSourcesOutput, WebFetchOutput, WebSearchInput, WebSearchOutput};
+use crate::providers::exa::ExaProvider;
 use crate::providers::firecrawl::FirecrawlProvider;
 use crate::providers::grok::GrokResponsesProvider;
 use crate::providers::tavily::TavilyProvider;
+use crate::providers::tinyfish::TinyfishProvider;
 
 #[async_trait]
 pub trait AiProvider: Send + Sync {
@@ -89,6 +91,254 @@ impl SourceProvider for FirecrawlProvider {
     }
 }
 
+#[async_trait]
+impl SourceProvider for TinyfishProvider {
+    async fn search_sources(
+        &self,
+        query: &str,
+        max_results: usize,
+        filters: &SearchFilters,
+    ) -> Result<Vec<Source>> {
+        self.search(query, max_results, filters).await
+    }
+
+    async fn fetch(&self, url: &str) -> Result<FetchedPage> {
+        TinyfishProvider::fetch(self, url).await
+    }
+
+    async fn map(&self, url: &str, max_results: usize) -> Result<Vec<Source>> {
+        // No native site-map endpoint; a search on the URL is the closest
+        // discovery primitive (mirrors the Firecrawl impl above).
+        self.search(url, max_results, &SearchFilters::default())
+            .await
+    }
+}
+
+#[async_trait]
+impl SourceProvider for ExaProvider {
+    async fn search_sources(
+        &self,
+        query: &str,
+        max_results: usize,
+        filters: &SearchFilters,
+    ) -> Result<Vec<Source>> {
+        self.search(query, max_results, filters).await
+    }
+
+    async fn fetch(&self, url: &str) -> Result<FetchedPage> {
+        ExaProvider::fetch(self, url).await
+    }
+
+    async fn map(&self, url: &str, max_results: usize) -> Result<Vec<Source>> {
+        // No native site-map endpoint; a search on the URL is the closest
+        // discovery primitive (mirrors the Firecrawl impl above).
+        self.search(url, max_results, &SearchFilters::default())
+            .await
+    }
+}
+
+/// Static description of one known source provider: how it is configured, how
+/// its absence is reported, and which request shapes it can honor. The
+/// service's source chain (`SourceSlot` list) is built from these at
+/// construction time.
+pub(crate) struct ProviderSpec {
+    pub(crate) name: &'static str,
+    display: &'static str,
+    enable_var: &'static str,
+    key_var: &'static str,
+    header: &'static str,
+    /// Whether the provider honors `SearchFilters` (recency + domain
+    /// include/exclude). Providers that cannot are *skipped* for filtered
+    /// requests instead of silently violating the filter contract.
+    supports_filters: bool,
+    /// Whether the provider exposes a real site-map endpoint (`web_map`).
+    supports_map: bool,
+    /// Core providers appear in zero-source diagnostics even when
+    /// unconfigured; optional ones are mentioned only when the operator names
+    /// them in `GROK_SEARCH_SOURCE_PROVIDERS`. Keeps "I never set up Exa"
+    /// from reading as a broken credential in every failure message.
+    core: bool,
+}
+
+const TAVILY_SPEC: ProviderSpec = ProviderSpec {
+    name: "tavily",
+    display: "Tavily",
+    enable_var: "TAVILY_ENABLED",
+    key_var: "TAVILY_API_KEY",
+    header: "x-tavily-api-key",
+    supports_filters: true,
+    supports_map: true,
+    core: true,
+};
+
+const EXA_SPEC: ProviderSpec = ProviderSpec {
+    name: "exa",
+    display: "Exa",
+    enable_var: "EXA_ENABLED",
+    key_var: "EXA_API_KEY",
+    header: "x-exa-api-key",
+    supports_filters: true,
+    supports_map: false,
+    core: false,
+};
+
+const TINYFISH_SPEC: ProviderSpec = ProviderSpec {
+    name: "tinyfish",
+    display: "TinyFish",
+    enable_var: "TINYFISH_ENABLED",
+    key_var: "TINYFISH_API_KEY",
+    header: "x-tinyfish-api-key",
+    supports_filters: true,
+    supports_map: false,
+    core: false,
+};
+
+const FIRECRAWL_SPEC: ProviderSpec = ProviderSpec {
+    name: "firecrawl",
+    display: "Firecrawl",
+    enable_var: "FIRECRAWL_ENABLED",
+    key_var: "FIRECRAWL_API_KEY",
+    header: "x-firecrawl-api-key",
+    supports_filters: false,
+    supports_map: false,
+    core: true,
+};
+
+/// Canonical chain order. Tavily's RAG-tuned results keep the primary slot;
+/// Exa (semantic search, native filter support) outranks the keyword engines
+/// among the newcomers; TinyFish is the free keyword/fetch tier; Firecrawl
+/// keeps its historical last-resort slot because its search cannot honor
+/// filters. `GROK_SEARCH_SOURCE_PROVIDERS` overrides this order entirely.
+const CANONICAL_SOURCE_ORDER: [&ProviderSpec; 4] =
+    [&TAVILY_SPEC, &EXA_SPEC, &TINYFISH_SPEC, &FIRECRAWL_SPEC];
+
+/// One instantiated provider in the source chain.
+#[derive(Clone)]
+struct SourceEntry {
+    spec: &'static ProviderSpec,
+    provider: Arc<dyn SourceProvider>,
+}
+
+/// One position in the configured source chain: an instantiated provider, or
+/// a known-but-absent provider remembered so zero-source failures can name
+/// what was missing and how to supply it (`enabled` decides whether the note
+/// reads as "switched off" or "no key").
+enum SourceSlot {
+    Active(SourceEntry),
+    Missing {
+        spec: &'static ProviderSpec,
+        enabled: bool,
+    },
+}
+
+fn instantiate_source(
+    spec: &'static ProviderSpec,
+    config: &Config,
+    http: &reqwest::Client,
+) -> Option<Arc<dyn SourceProvider>> {
+    match spec.name {
+        "tavily" => config
+            .tavily_enabled
+            .then(|| config.tavily_api_key.clone())
+            .flatten()
+            .map(|key| {
+                Arc::new(TavilyProvider::with_client(
+                    http.clone(),
+                    config.tavily_api_url.clone(),
+                    key,
+                )) as Arc<dyn SourceProvider>
+            }),
+        "exa" => config
+            .exa_enabled
+            .then(|| config.exa_api_key.clone())
+            .flatten()
+            .map(|key| {
+                Arc::new(ExaProvider::with_client(
+                    http.clone(),
+                    config.exa_api_url.clone(),
+                    key,
+                )) as Arc<dyn SourceProvider>
+            }),
+        "tinyfish" => config
+            .tinyfish_enabled
+            .then(|| config.tinyfish_api_key.clone())
+            .flatten()
+            .map(|key| {
+                Arc::new(TinyfishProvider::with_client(
+                    http.clone(),
+                    config.tinyfish_search_api_url.clone(),
+                    config.tinyfish_fetch_api_url.clone(),
+                    key,
+                )) as Arc<dyn SourceProvider>
+            }),
+        "firecrawl" => config
+            .firecrawl_enabled
+            .then(|| config.firecrawl_api_key.clone())
+            .flatten()
+            .map(|key| {
+                Arc::new(FirecrawlProvider::with_client(
+                    http.clone(),
+                    config.firecrawl_api_url.clone(),
+                    key,
+                )) as Arc<dyn SourceProvider>
+            }),
+        _ => None,
+    }
+}
+
+fn provider_enabled(spec: &ProviderSpec, config: &Config) -> bool {
+    match spec.name {
+        "tavily" => config.tavily_enabled,
+        "exa" => config.exa_enabled,
+        "tinyfish" => config.tinyfish_enabled,
+        "firecrawl" => config.firecrawl_enabled,
+        _ => false,
+    }
+}
+
+/// Resolve the effective source chain. Default: the canonical order over
+/// whatever is configured, with core providers (Tavily/Firecrawl) holding
+/// `Missing` slots when absent — preserving their long-standing place in
+/// zero-source diagnostics. With an explicit `GROK_SEARCH_SOURCE_PROVIDERS`
+/// list, exactly the named providers are slotted, and every named-but-absent
+/// one gets a `Missing` slot: the operator asked for it, so its absence is
+/// worth reporting.
+fn build_source_slots(config: &Config, http: &reqwest::Client) -> Result<Vec<SourceSlot>> {
+    let explicit = !config.source_providers.is_empty();
+    let specs: Vec<&'static ProviderSpec> = if explicit {
+        config
+            .source_providers
+            .iter()
+            .map(|name| {
+                CANONICAL_SOURCE_ORDER
+                    .iter()
+                    .copied()
+                    .find(|spec| spec.name == name)
+                    .ok_or_else(|| {
+                        GrokSearchError::InvalidParams(format!(
+                            "unknown source provider \"{name}\" in GROK_SEARCH_SOURCE_PROVIDERS (valid: tavily, exa, tinyfish, firecrawl)"
+                        ))
+                    })
+            })
+            .collect::<Result<_>>()?
+    } else {
+        CANONICAL_SOURCE_ORDER.to_vec()
+    };
+
+    let mut slots = Vec::new();
+    for spec in specs {
+        match instantiate_source(spec, config, http) {
+            Some(provider) => slots.push(SourceSlot::Active(SourceEntry { spec, provider })),
+            None if spec.core || explicit => slots.push(SourceSlot::Missing {
+                spec,
+                enabled: provider_enabled(spec, config),
+            }),
+            None => {}
+        }
+    }
+    Ok(slots)
+}
+
 #[derive(Clone)]
 pub struct SearchService {
     config: Config,
@@ -100,8 +350,10 @@ pub struct SearchService {
     /// chat-completions transport. Per-call overrides via `WebSearchInput.model`
     /// still win.
     default_model: String,
-    sources: Option<Arc<dyn SourceProvider>>,
-    fallback_sources: Option<Arc<dyn SourceProvider>>,
+    /// Ordered source-provider chain (first usable answer wins), with
+    /// `Missing` placeholders so diagnostics can name absent providers.
+    /// Behind `Arc` so `SearchService: Clone` stays cheap.
+    source_slots: Arc<Vec<SourceSlot>>,
     cache: Arc<Mutex<SourceCache>>,
     /// Shared reqwest client for the sources pipeline (same instance handed to
     /// providers). Stored here because resolve_content needs direct GET access.
@@ -119,8 +371,7 @@ pub struct SearchService {
 struct ProviderSet {
     ai: Arc<dyn AiProvider>,
     default_model: String,
-    sources: Option<Arc<dyn SourceProvider>>,
-    fallback_sources: Option<Arc<dyn SourceProvider>>,
+    source_slots: Vec<SourceSlot>,
     source_router: Arc<crate::sources::SourceRouter>,
 }
 
@@ -207,37 +458,14 @@ fn build_providers_with_grok(
         }
     };
 
-    let sources = if config.tavily_enabled {
-        config.tavily_api_key.clone().map(|key| {
-            Arc::new(TavilyProvider::with_client(
-                http.clone(),
-                config.tavily_api_url.clone(),
-                key,
-            )) as Arc<dyn SourceProvider>
-        })
-    } else {
-        None
-    };
-
-    let fallback_sources = if config.firecrawl_enabled {
-        config.firecrawl_api_key.clone().map(|key| {
-            Arc::new(FirecrawlProvider::with_client(
-                http.clone(),
-                config.firecrawl_api_url.clone(),
-                key,
-            )) as Arc<dyn SourceProvider>
-        })
-    } else {
-        None
-    };
+    let source_slots = build_source_slots(config, http)?;
 
     let source_router = Arc::new(crate::sources::SourceRouter::from_config(config));
 
     Ok(ProviderSet {
         ai,
         default_model: resolve_default_model(config),
-        sources,
-        fallback_sources,
+        source_slots,
         source_router,
     })
 }
@@ -343,11 +571,21 @@ impl SearchService {
             default_model: providers.default_model,
             config,
             ai: providers.ai,
-            sources: providers.sources,
-            fallback_sources: providers.fallback_sources,
+            source_slots: Arc::new(providers.source_slots),
             http_client: http,
             source_router: providers.source_router,
         }
+    }
+
+    /// Instantiated providers from the chain, in chain order.
+    fn active_sources(&self) -> Vec<SourceEntry> {
+        self.source_slots
+            .iter()
+            .filter_map(|slot| match slot {
+                SourceSlot::Active(entry) => Some(entry.clone()),
+                SourceSlot::Missing { .. } => None,
+            })
+            .collect()
     }
 
     /// Namespace a session id with the caller's tenant tag so cached
@@ -363,16 +601,52 @@ impl SearchService {
             ("GROK_SEARCH_API_KEY", "fake-grok"),
             ("TAVILY_API_KEY", "fake-tavily"),
         ]);
+        let firecrawl_enabled = config.firecrawl_enabled;
         Self {
             cache: Arc::new(Mutex::new(SourceCache::new(256))),
             default_model: resolve_default_model(&config),
             config,
             ai: Arc::new(FakeAiProvider),
-            sources: Some(Arc::new(FakeSourceProvider)),
-            fallback_sources: None,
+            source_slots: Arc::new(vec![
+                SourceSlot::Active(SourceEntry {
+                    spec: &TAVILY_SPEC,
+                    provider: Arc::new(FakeSourceProvider),
+                }),
+                SourceSlot::Missing {
+                    spec: &FIRECRAWL_SPEC,
+                    enabled: firecrawl_enabled,
+                },
+            ]),
             http_client: crate::providers::http::build_client(std::time::Duration::from_secs(30)),
             source_router: Arc::new(crate::sources::SourceRouter::default()),
         }
+    }
+
+    /// Legacy two-slot wiring for test factories: `primary` occupies the
+    /// Tavily slot and `fallback` the Firecrawl slot, exactly as the
+    /// pre-chain service was shaped.
+    fn fake_slots(
+        primary: Arc<dyn SourceProvider>,
+        fallback: Option<Arc<dyn SourceProvider>>,
+        firecrawl_enabled: bool,
+    ) -> Arc<Vec<SourceSlot>> {
+        let firecrawl_slot = match fallback {
+            Some(provider) => SourceSlot::Active(SourceEntry {
+                spec: &FIRECRAWL_SPEC,
+                provider,
+            }),
+            None => SourceSlot::Missing {
+                spec: &FIRECRAWL_SPEC,
+                enabled: firecrawl_enabled,
+            },
+        };
+        Arc::new(vec![
+            SourceSlot::Active(SourceEntry {
+                spec: &TAVILY_SPEC,
+                provider: primary,
+            }),
+            firecrawl_slot,
+        ])
     }
 
     /// Unified test factory: override AI / primary / fallback providers and
@@ -405,13 +679,13 @@ impl SearchService {
         );
         let config = Config::from_env_map(vars);
 
+        let source_slots = Self::fake_slots(primary, fallback, config.firecrawl_enabled);
         Self {
             cache: Arc::new(Mutex::new(SourceCache::new(256))),
             default_model: resolve_default_model(&config),
             config,
             ai: ai.unwrap_or_else(|| Arc::new(FakeAiProvider)),
-            sources: Some(primary),
-            fallback_sources: fallback,
+            source_slots,
             http_client: crate::providers::http::build_client(std::time::Duration::from_secs(30)),
             source_router: Arc::new(crate::sources::SourceRouter::default()),
         }
@@ -436,13 +710,13 @@ impl SearchService {
             ));
         }
         let config = Config::from_env_map(vars);
+        let source_slots = Self::fake_slots(primary, fallback, config.firecrawl_enabled);
         Self {
             cache: Arc::new(Mutex::new(SourceCache::new(256))),
             default_model: resolve_default_model(&config),
             config,
             ai: Arc::new(FakeAiProvider),
-            sources: Some(primary),
-            fallback_sources: fallback,
+            source_slots,
             http_client: crate::providers::http::build_client(std::time::Duration::from_secs(30)),
             source_router: Arc::new(router),
         }
@@ -542,8 +816,7 @@ impl SearchService {
                 self.config.enrich_concurrency,
                 self.config.enrich_max_chars,
                 self.config.max_inline_sources,
-                self.sources.clone(),
-                self.fallback_sources.clone(),
+                self.active_sources(),
             )
             .await
         } else {
@@ -577,11 +850,11 @@ impl SearchService {
         })
     }
 
-    /// Fetch sources from the primary source provider (or fall through to
-    /// firecrawl) without applying a path-specific provider label. The
-    /// returned Vec carries each provider's native label ("tavily"/"firecrawl");
-    /// the caller re-labels via `with_provider` once the path (enrichment vs
-    /// fallback) is known.
+    /// Fetch sources by walking the configured provider chain in order; the
+    /// first provider with usable results wins. No path-specific provider
+    /// label is applied here — the returned Vec carries each provider's
+    /// native label ("tavily"/"exa"/…); the caller re-labels via
+    /// `with_provider` once the path (enrichment vs fallback) is known.
     ///
     /// Every path that yields nothing records *why* in [`RawSources::notes`].
     /// Provider errors used to be swallowed outright, which left a request that
@@ -600,71 +873,64 @@ impl SearchService {
             )]);
         }
         let mut notes = Vec::new();
-        match &self.sources {
-            Some(provider) => match provider.search_sources(query, count, filters).await {
-                Ok(sources) => match usable_or_note("tavily", sources) {
-                    Ok(usable) => return RawSources::found(usable, RawSourceOrigin::Primary),
-                    Err(note) => notes.push(note),
-                },
-                Err(err) => notes.push(SourceNote::broken(format!("tavily: {err}"))),
-            },
-            None => notes.push(unavailable_note(
-                "tavily",
-                self.config.tavily_enabled,
-                "TAVILY_ENABLED",
-                "TAVILY_API_KEY",
-                "x-tavily-api-key",
-            )),
-        }
-        // The fallback source provider (Firecrawl) ignores `SearchFilters`
-        // outright — it has no structured recency/domain support — so a
-        // filter-constrained request must never fall through: swapping
-        // constrained Tavily results for unconstrained Firecrawl ones would
-        // silently violate the include/exclude/recency contract. Constrained
-        // requests are Tavily-or-nothing.
-        if !filters.is_empty() {
-            const SKIPPED: &str =
-                "skipped (request carries domain/recency filters, which firecrawl cannot honor)";
-            // Whether the gate is the *only* thing in the way decides what to
-            // advise. A configured Firecrawl really would have answered, so
-            // dropping the filters is a genuine remedy and this is an honest
-            // empty outcome. An absent one changes nothing when the filters go,
-            // so recording that as a healthy no-match would promise a remedy
-            // that cannot work — while hiding the configuration problem behind
-            // it.
-            notes.push(match &self.fallback_sources {
-                Some(_) => SourceNote::no_results(format!("firecrawl: {SKIPPED}")),
-                None => {
-                    let unavailable = unavailable_note(
-                        "firecrawl",
-                        self.config.firecrawl_enabled,
-                        "FIRECRAWL_ENABLED",
-                        "FIRECRAWL_API_KEY",
-                        "x-firecrawl-api-key",
-                    );
-                    SourceNote::new(
-                        unavailable.kind,
-                        format!("{} — also {SKIPPED}", unavailable.detail),
-                    )
+        for slot in self.source_slots.iter() {
+            match slot {
+                SourceSlot::Active(entry) => {
+                    let name = entry.spec.name;
+                    // A provider that ignores `SearchFilters` (Firecrawl) must
+                    // never serve a filter-constrained request: swapping
+                    // constrained results for unconstrained ones would
+                    // silently violate the include/exclude/recency contract.
+                    // Filtered requests are filter-capable-providers-or-nothing.
+                    if !filters.is_empty() && !entry.spec.supports_filters {
+                        notes.push(SourceNote::no_results(format!(
+                            "{name}: skipped (request carries domain/recency filters, which {name} cannot honor)"
+                        )));
+                        continue;
+                    }
+                    match entry.provider.search_sources(query, count, filters).await {
+                        Ok(sources) => match usable_or_note(name, sources) {
+                            Ok(usable) => {
+                                if !notes.is_empty() {
+                                    eprintln!(
+                                        "grok-search-rs: source chain fell through to {name} ({})",
+                                        source_diagnosis(&notes)
+                                    );
+                                }
+                                return RawSources::found(usable, Some(name));
+                            }
+                            Err(note) => notes.push(note),
+                        },
+                        Err(err) => notes.push(SourceNote::broken(format!("{name}: {err}"))),
+                    }
                 }
-            });
-            return RawSources::empty(notes);
-        }
-        match &self.fallback_sources {
-            Some(provider) => match provider.search_sources(query, count, filters).await {
-                Ok(sources) => match usable_or_note("firecrawl", sources) {
-                    Ok(usable) => return RawSources::found(usable, RawSourceOrigin::Fallback),
-                    Err(note) => notes.push(note),
-                },
-                Err(err) => notes.push(SourceNote::broken(format!("firecrawl: {err}"))),
-            },
-            None => notes.push(unavailable_note(
-                "firecrawl",
-                self.config.firecrawl_enabled,
-                "FIRECRAWL_ENABLED",
-                "FIRECRAWL_API_KEY",
-                "x-firecrawl-api-key",
-            )),
+                SourceSlot::Missing { spec, enabled } => {
+                    let unavailable = unavailable_note(
+                        spec.name,
+                        *enabled,
+                        spec.enable_var,
+                        spec.key_var,
+                        spec.header,
+                    );
+                    // For a filter-blind provider, whether the gate is the
+                    // *only* thing in the way decides what to advise. A
+                    // configured Firecrawl really would have answered, so
+                    // dropping the filters is a genuine remedy; an absent one
+                    // changes nothing when the filters go, so the note names
+                    // both problems instead of hiding the config one.
+                    notes.push(if !filters.is_empty() && !spec.supports_filters {
+                        SourceNote::new(
+                            unavailable.kind,
+                            format!(
+                                "{} — also skipped (request carries domain/recency filters, which {} cannot honor)",
+                                unavailable.detail, spec.name
+                            ),
+                        )
+                    } else {
+                        unavailable
+                    });
+                }
+            }
         }
         RawSources::empty(notes)
     }
@@ -749,8 +1015,7 @@ impl SearchService {
                 self.config.enrich_concurrency,
                 self.config.enrich_max_chars,
                 self.config.max_inline_sources,
-                self.sources.clone(),
-                self.fallback_sources.clone(),
+                self.active_sources(),
             )
             .await
         } else {
@@ -878,17 +1143,24 @@ impl SearchService {
     }
 
     async fn web_fetch_raw(&self, url: &str) -> Result<String> {
-        generic_source_fetch(&self.sources, &self.fallback_sources, url)
+        generic_source_fetch(&self.active_sources(), url)
             .await
             .map(|page| page.content)
     }
 
     pub async fn web_map(&self, url: &str, max_results: usize) -> Result<Vec<Source>> {
-        self.sources
-            .as_ref()
-            .ok_or(GrokSearchError::MissingConfig("TAVILY_API_KEY"))?
-            .map(url, max_results)
-            .await
+        // Only providers with a real site-map endpoint qualify (Tavily today);
+        // the search-shaped `map` impls on the other providers are not a
+        // substitute for actual URL discovery.
+        let entry = self
+            .source_slots
+            .iter()
+            .find_map(|slot| match slot {
+                SourceSlot::Active(entry) if entry.spec.supports_map => Some(entry.clone()),
+                _ => None,
+            })
+            .ok_or(GrokSearchError::MissingConfig("TAVILY_API_KEY"))?;
+        entry.provider.map(url, max_results).await
     }
 
     /// Runtime diagnostics with live connectivity probes against each configured backend.
@@ -896,14 +1168,18 @@ impl SearchService {
     pub async fn doctor(&self) -> serde_json::Value {
         use crate::config::Transport;
         let grok_probe = self.probe_grok().await;
-        let tavily_probe = match &self.sources {
-            Some(provider) => probe_source(provider.as_ref(), "https://example.com").await,
-            None => Probe::skipped("TAVILY_API_KEY not configured"),
-        };
-        let firecrawl_probe = match &self.fallback_sources {
-            Some(provider) => probe_source(provider.as_ref(), "https://example.com").await,
-            None => Probe::skipped("FIRECRAWL_API_KEY not configured"),
-        };
+        let tavily_probe = self.probe_chain_source("tavily").await;
+        let exa_probe = self.probe_chain_source("exa").await;
+        let tinyfish_probe = self.probe_chain_source("tinyfish").await;
+        let firecrawl_probe = self.probe_chain_source("firecrawl").await;
+        let source_chain: Vec<&str> = self
+            .source_slots
+            .iter()
+            .filter_map(|slot| match slot {
+                SourceSlot::Active(entry) => Some(entry.spec.name),
+                SourceSlot::Missing { .. } => None,
+            })
+            .collect();
 
         // Surface the AI transport that the service actually dispatches to so
         // doctor() stays truthful when callers point us at an OpenAI-compatible
@@ -957,12 +1233,26 @@ impl SearchService {
                 "reachable": tavily_probe.ok,
                 "detail": tavily_probe.detail,
             },
+            "exa": {
+                "api_url": self.config.exa_api_url,
+                "enabled": self.config.exa_enabled,
+                "reachable": exa_probe.ok,
+                "detail": exa_probe.detail,
+            },
+            "tinyfish": {
+                "search_api_url": self.config.tinyfish_search_api_url,
+                "fetch_api_url": self.config.tinyfish_fetch_api_url,
+                "enabled": self.config.tinyfish_enabled,
+                "reachable": tinyfish_probe.ok,
+                "detail": tinyfish_probe.detail,
+            },
             "firecrawl": {
                 "api_url": self.config.firecrawl_api_url,
                 "enabled": self.config.firecrawl_enabled,
                 "reachable": firecrawl_probe.ok,
                 "detail": firecrawl_probe.detail,
             },
+            "source_chain": source_chain,
             "default_extra_sources": self.config.default_extra_sources,
             "fallback_sources": self.config.fallback_sources,
             "cache_size": self.config.cache_size,
@@ -970,6 +1260,26 @@ impl SearchService {
             "github_token": self.config.github_token_status(),
             "redacted": self.config.redacted_diagnostics()
         })
+    }
+
+    /// Probe one chain provider by name: live search for an active slot, a
+    /// skip marker naming the missing key otherwise.
+    async fn probe_chain_source(&self, name: &str) -> Probe {
+        let active = self.source_slots.iter().find_map(|slot| match slot {
+            SourceSlot::Active(entry) if entry.spec.name == name => Some(entry.clone()),
+            _ => None,
+        });
+        match active {
+            Some(entry) => probe_source(entry.provider.as_ref(), "https://example.com").await,
+            None => {
+                let key_var = CANONICAL_SOURCE_ORDER
+                    .iter()
+                    .find(|spec| spec.name == name)
+                    .map(|spec| spec.key_var)
+                    .unwrap_or("API key");
+                Probe::skipped(format!("{key_var} not configured"))
+            }
+        }
     }
 
     async fn probe_grok(&self) -> Probe {
@@ -1045,26 +1355,19 @@ impl SearchService {
     }
 }
 
-#[derive(Debug, Clone, Copy)]
-enum RawSourceOrigin {
-    None,
-    Primary,
-    Fallback,
-}
-
-/// Outcome of the speculative source fan-out: the sources plus a per-provider
-/// account of what happened. `notes` stays empty on the happy path (a provider
-/// that returns results short-circuits before anything is recorded); it is
-/// populated only when a provider yields nothing, so a request that ends with
-/// zero sources can say why.
+/// Outcome of the speculative source fan-out: the sources, the name of the
+/// chain provider that served them (`None` when nothing answered), plus a
+/// per-provider account of what happened. `notes` stays empty on the
+/// first-provider happy path; earlier dead ends are recorded so a request
+/// that ends with zero sources can say why.
 struct RawSources {
     sources: Vec<Source>,
-    origin: RawSourceOrigin,
+    origin: Option<&'static str>,
     notes: Vec<SourceNote>,
 }
 
 impl RawSources {
-    fn found(sources: Vec<Source>, origin: RawSourceOrigin) -> Self {
+    fn found(sources: Vec<Source>, origin: Option<&'static str>) -> Self {
         Self {
             sources,
             origin,
@@ -1075,7 +1378,7 @@ impl RawSources {
     fn empty(notes: Vec<SourceNote>) -> Self {
         Self {
             sources: Vec::new(),
-            origin: RawSourceOrigin::None,
+            origin: None,
             notes,
         }
     }
@@ -1218,7 +1521,7 @@ fn fallback_remediation(notes: &[SourceNote]) -> String {
         // before asking for a remediation. Raising the budget would not
         // instantiate a switched-off provider, so it is not offered here.
         parts.push(
-            "A source provider is switched off; enable it (TAVILY_ENABLED / FIRECRAWL_ENABLED).",
+            "A source provider is switched off; enable it (TAVILY_ENABLED / EXA_ENABLED / TINYFISH_ENABLED / FIRECRAWL_ENABLED).",
         );
     }
     if has(NoteKind::Broken) {
@@ -1315,6 +1618,257 @@ mod remediation_tests {
     }
 }
 
+#[cfg(test)]
+mod chain_tests {
+    use super::*;
+
+    fn http() -> reqwest::Client {
+        crate::providers::http::build_client(std::time::Duration::from_secs(5))
+    }
+
+    fn slot_names(slots: &[SourceSlot]) -> Vec<String> {
+        slots
+            .iter()
+            .map(|slot| match slot {
+                SourceSlot::Active(entry) => format!("active:{}", entry.spec.name),
+                SourceSlot::Missing { spec, .. } => format!("missing:{}", spec.name),
+            })
+            .collect()
+    }
+
+    #[test]
+    fn default_chain_orders_all_configured_providers_canonically() {
+        let config = Config::from_env_map([
+            ("TAVILY_API_KEY", "t"),
+            ("EXA_API_KEY", "e"),
+            ("TINYFISH_API_KEY", "f"),
+            ("FIRECRAWL_API_KEY", "c"),
+        ]);
+        let slots = build_source_slots(&config, &http()).expect("slots");
+        assert_eq!(
+            slot_names(&slots),
+            [
+                "active:tavily",
+                "active:exa",
+                "active:tinyfish",
+                "active:firecrawl"
+            ]
+        );
+    }
+
+    // Core providers keep their historical place in zero-source diagnostics
+    // even when unconfigured; optional ones stay out unless named explicitly,
+    // so "I never set up Exa" cannot read as a broken credential.
+    #[test]
+    fn default_chain_slots_missing_core_but_omits_missing_optional() {
+        let config = Config::from_env_map([("TINYFISH_API_KEY", "f")]);
+        let slots = build_source_slots(&config, &http()).expect("slots");
+        assert_eq!(
+            slot_names(&slots),
+            ["missing:tavily", "active:tinyfish", "missing:firecrawl"]
+        );
+    }
+
+    #[test]
+    fn explicit_order_overrides_and_slots_every_named_provider() {
+        let config = Config::from_env_map([
+            ("TINYFISH_API_KEY", "f"),
+            ("GROK_SEARCH_SOURCE_PROVIDERS", "tinyfish, Exa"),
+        ]);
+        let slots = build_source_slots(&config, &http()).expect("slots");
+        assert_eq!(slot_names(&slots), ["active:tinyfish", "missing:exa"]);
+    }
+
+    #[test]
+    fn unknown_provider_name_fails_construction() {
+        let config = Config::from_env_map([("GROK_SEARCH_SOURCE_PROVIDERS", "tavily,serpapi")]);
+        let err = match build_source_slots(&config, &http()) {
+            Err(err) => err,
+            Ok(_) => panic!("must reject unknown provider name"),
+        };
+        assert!(err.to_string().contains("serpapi"), "{err}");
+    }
+
+    #[test]
+    fn labels_follow_the_serving_provider() {
+        assert_eq!(enrichment_label(Some("exa")), "exa_enrichment");
+        assert_eq!(fallback_label(Some("tinyfish")), "tinyfish_fallback");
+        assert_eq!(fallback_label(None), "tavily_fallback");
+    }
+
+    /// Search always answers with no results.
+    struct EmptySearchProvider;
+    #[async_trait]
+    impl SourceProvider for EmptySearchProvider {
+        async fn search_sources(
+            &self,
+            _query: &str,
+            _max_results: usize,
+            _filters: &SearchFilters,
+        ) -> Result<Vec<Source>> {
+            Ok(Vec::new())
+        }
+        async fn fetch(&self, url: &str) -> Result<FetchedPage> {
+            Ok(FetchedPage::text(format!("empty provider fetch {url}")))
+        }
+        async fn map(&self, _url: &str, _max_results: usize) -> Result<Vec<Source>> {
+            Ok(Vec::new())
+        }
+    }
+
+    /// Serves sources whose provider label is the provider's own name.
+    struct NamedSourceProvider(&'static str);
+    #[async_trait]
+    impl SourceProvider for NamedSourceProvider {
+        async fn search_sources(
+            &self,
+            _query: &str,
+            max_results: usize,
+            _filters: &SearchFilters,
+        ) -> Result<Vec<Source>> {
+            Ok((0..max_results)
+                .map(|idx| Source::new(format!("https://{}.example/{idx}", self.0), self.0))
+                .collect())
+        }
+        async fn fetch(&self, _url: &str) -> Result<FetchedPage> {
+            Ok(FetchedPage::text(format!("content from {}", self.0)))
+        }
+        async fn map(&self, _url: &str, _max_results: usize) -> Result<Vec<Source>> {
+            Ok(Vec::new())
+        }
+    }
+
+    struct ErrAiProvider;
+    #[async_trait]
+    impl AiProvider for ErrAiProvider {
+        async fn search(&self, _request: &SearchRequest) -> Result<SearchResponse> {
+            Err(GrokSearchError::Provider("ai down".to_string()))
+        }
+    }
+
+    fn chain_service(slots: Vec<SourceSlot>, ai: Arc<dyn AiProvider>) -> SearchService {
+        let config = Config::from_env_map([("GROK_SEARCH_API_KEY", "fake")]);
+        SearchService {
+            default_model: resolve_default_model(&config),
+            config,
+            ai,
+            source_slots: Arc::new(slots),
+            cache: Arc::new(Mutex::new(SourceCache::new(16))),
+            http_client: crate::providers::http::build_client(std::time::Duration::from_secs(5)),
+            source_router: Arc::new(crate::sources::SourceRouter::default()),
+        }
+    }
+
+    fn concise_input() -> WebSearchInput {
+        WebSearchInput {
+            query: "chain test".to_string(),
+            // Opt out of inline content so no real HTTP enrichment runs.
+            include_content: Some(false),
+            ..Default::default()
+        }
+    }
+
+    #[tokio::test]
+    async fn chain_falls_through_to_next_provider_and_labels_fallback_by_name() {
+        let svc = chain_service(
+            vec![
+                SourceSlot::Active(SourceEntry {
+                    spec: &TAVILY_SPEC,
+                    provider: Arc::new(EmptySearchProvider),
+                }),
+                SourceSlot::Active(SourceEntry {
+                    spec: &TINYFISH_SPEC,
+                    provider: Arc::new(NamedSourceProvider("tinyfish")),
+                }),
+            ],
+            Arc::new(ErrAiProvider),
+        );
+        let out = svc
+            .web_search(concise_input())
+            .await
+            .expect("fallback output");
+        assert!(out.fallback_used);
+        assert!(!out.sources.is_empty());
+        assert!(
+            out.sources
+                .iter()
+                .all(|source| source.provider == "tinyfish_fallback"),
+            "expected tinyfish_fallback labels, got: {:?}",
+            out.sources
+                .iter()
+                .map(|source| source.provider.clone())
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[tokio::test]
+    async fn filtered_requests_skip_filter_blind_providers_but_use_capable_ones() {
+        // Firecrawl sits FIRST here yet must be skipped for a filtered
+        // request; TinyFish (filter-capable) serves instead.
+        let svc = chain_service(
+            vec![
+                SourceSlot::Active(SourceEntry {
+                    spec: &FIRECRAWL_SPEC,
+                    provider: Arc::new(NamedSourceProvider("firecrawl")),
+                }),
+                SourceSlot::Active(SourceEntry {
+                    spec: &TINYFISH_SPEC,
+                    provider: Arc::new(NamedSourceProvider("tinyfish")),
+                }),
+            ],
+            Arc::new(ErrAiProvider),
+        );
+        let mut input = concise_input();
+        input.include_domains = vec!["example.com".to_string()];
+        let out = svc.web_search(input).await.expect("fallback output");
+        assert!(
+            out.sources
+                .iter()
+                .all(|source| source.provider == "tinyfish_fallback"),
+            "filter-blind firecrawl must not serve a filtered request: {:?}",
+            out.sources
+                .iter()
+                .map(|source| source.provider.clone())
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[tokio::test]
+    async fn enrichment_sources_carry_the_serving_providers_label() {
+        // Grok succeeds (FakeAiProvider is verifiable); the supplemental
+        // sources come from the second chain slot after the first is empty,
+        // and must be labeled {provider}_enrichment.
+        let svc = chain_service(
+            vec![
+                SourceSlot::Active(SourceEntry {
+                    spec: &TAVILY_SPEC,
+                    provider: Arc::new(EmptySearchProvider),
+                }),
+                SourceSlot::Active(SourceEntry {
+                    spec: &EXA_SPEC,
+                    provider: Arc::new(NamedSourceProvider("exa")),
+                }),
+            ],
+            Arc::new(FakeAiProvider),
+        );
+        let out = svc
+            .web_search(concise_input())
+            .await
+            .expect("search output");
+        assert!(!out.fallback_used);
+        assert!(
+            out.sources
+                .iter()
+                .any(|source| source.provider == "exa_enrichment"),
+            "expected exa_enrichment labels, got: {:?}",
+            out.sources
+                .iter()
+                .map(|source| source.provider.clone())
+                .collect::<Vec<_>>()
+        );
+    }
+}
+
 /// Pick the model the active transport actually understands. Responses speaks
 /// Grok-native model names (`grok_model`); the chat-completions gateway speaks
 /// whatever `OPENAI_COMPATIBLE_MODEL` declares, falling back to `grok_model`
@@ -1332,20 +1886,17 @@ fn resolve_default_model(config: &Config) -> String {
     }
 }
 
-fn enrichment_label(origin: RawSourceOrigin) -> &'static str {
-    match origin {
-        RawSourceOrigin::Primary => "tavily_enrichment",
-        RawSourceOrigin::Fallback => "firecrawl_enrichment",
-        RawSourceOrigin::None => "tavily_enrichment",
-    }
+/// Per-source label for the enrichment path: the serving chain provider's
+/// name plus an `_enrichment` suffix ("tavily_enrichment", "exa_enrichment",
+/// …). `None` (nothing served) keeps the historical "tavily" default, though
+/// it only ever labels an empty list.
+fn enrichment_label(origin: Option<&'static str>) -> String {
+    format!("{}_enrichment", origin.unwrap_or("tavily"))
 }
 
-fn fallback_label(origin: RawSourceOrigin) -> &'static str {
-    match origin {
-        RawSourceOrigin::Primary => "tavily_fallback",
-        RawSourceOrigin::Fallback => "firecrawl_fallback",
-        RawSourceOrigin::None => "tavily_fallback",
-    }
+/// Per-source label for the degraded path, `{provider}_fallback` (#30).
+fn fallback_label(origin: Option<&'static str>) -> String {
+    format!("{}_fallback", origin.unwrap_or("tavily"))
 }
 
 /// Maps a failed Grok call to a stable `fallback_reason` identifier. Kept at
@@ -1425,30 +1976,29 @@ fn apply_fetch_limit(
     }
 }
 
-/// Generic (non-specialist) content fetch via the configured source providers:
-/// primary (Tavily) first, then fallback (Firecrawl). Shared by `web_fetch` and
-/// inline enrichment so both agree on how an ordinary URL is retrieved once no
-/// specialist extractor matches. Returns `MissingConfig` only when neither
-/// provider is configured; a configured primary that fails or yields empty
-/// content with no fallback surfaces its real error instead, so users are not
-/// sent to debug config that is actually set.
-async fn generic_source_fetch(
-    primary: &Option<Arc<dyn SourceProvider>>,
-    fallback: &Option<Arc<dyn SourceProvider>>,
-    url: &str,
-) -> Result<FetchedPage> {
-    let primary_err = match primary {
-        Some(provider) => match provider.fetch(url).await {
+/// Generic (non-specialist) content fetch via the configured source-provider
+/// chain, first non-empty page wins. Shared by `web_fetch` and inline
+/// enrichment so both agree on how an ordinary URL is retrieved once no
+/// specialist extractor matches. Returns `MissingConfig` only when no
+/// provider is configured at all; otherwise the last attempt's real error
+/// surfaces, so users are not sent to debug config that is actually set.
+async fn generic_source_fetch(chain: &[SourceEntry], url: &str) -> Result<FetchedPage> {
+    let mut last_error: Option<GrokSearchError> = None;
+    for entry in chain {
+        match entry.provider.fetch(url).await {
             Ok(page) if !page.content.trim().is_empty() => return Ok(page),
-            Ok(_) => GrokSearchError::Provider(format!("Tavily returned empty content for {url}")),
-            Err(err) => err,
-        },
-        None => GrokSearchError::MissingConfig("TAVILY_API_KEY or FIRECRAWL_API_KEY"),
-    };
-    match fallback {
-        Some(provider) => provider.fetch(url).await,
-        None => Err(primary_err),
+            Ok(_) => {
+                last_error = Some(GrokSearchError::Provider(format!(
+                    "{} returned empty content for {url}",
+                    entry.spec.display
+                )))
+            }
+            Err(err) => last_error = Some(err),
+        }
     }
+    Err(last_error.unwrap_or(GrokSearchError::MissingConfig(
+        "TAVILY_API_KEY, EXA_API_KEY, TINYFISH_API_KEY or FIRECRAWL_API_KEY",
+    )))
 }
 
 /// One enrichment outcome: the content to store plus any metadata backfill
@@ -1543,8 +2093,7 @@ async fn enrich_sources(
     concurrency: usize,
     max_chars: usize,
     max_sources: usize,
-    primary: Option<Arc<dyn SourceProvider>>,
-    fallback: Option<Arc<dyn SourceProvider>>,
+    chain: Vec<SourceEntry>,
 ) -> Vec<Source> {
     let sem = Arc::new(tokio::sync::Semaphore::new(concurrency));
     let mut set: tokio::task::JoinSet<(usize, EnrichedFetch)> = tokio::task::JoinSet::new();
@@ -1555,8 +2104,7 @@ async fn enrich_sources(
         let client = client.clone();
         let router = Arc::clone(router);
         let caps = caps.clone();
-        let primary = primary.clone();
-        let fallback = fallback.clone();
+        let chain = chain.clone();
 
         set.spawn(async move {
             // acquire is micro-second scale for concurrency<=5; deadline
@@ -1579,7 +2127,7 @@ async fn enrich_sources(
                         // specialist-failure fallback). The original `reason` is
                         // surfaced only if the generic fetch also fails.
                         Ok(Err(reason)) => {
-                            let generic = generic_source_fetch(&primary, &fallback, &url_str);
+                            let generic = generic_source_fetch(&chain, &url_str);
                             match tokio::time::timeout_at(deadline, generic).await {
                                 Ok(Ok(page)) => EnrichedFetch::from_page(page, max_chars),
                                 Ok(Err(_)) => EnrichedFetch::note(format!(
@@ -1901,8 +2449,7 @@ mod transport_dispatch_tests {
             default_model: resolve_default_model(&config),
             config,
             ai: Arc::new(FakeAiProvider),
-            sources: None,
-            fallback_sources: None,
+            source_slots: Arc::new(Vec::new()),
             cache: Arc::new(Mutex::new(SourceCache::new(16))),
             http_client: crate::providers::http::build_client(std::time::Duration::from_secs(30)),
             source_router: Arc::new(crate::sources::SourceRouter::default()),
@@ -1928,8 +2475,7 @@ mod transport_dispatch_tests {
             default_model: resolve_default_model(&config),
             config,
             ai: Arc::new(FakeAiProvider),
-            sources: None,
-            fallback_sources: None,
+            source_slots: Arc::new(Vec::new()),
             cache: Arc::new(Mutex::new(SourceCache::new(16))),
             http_client: crate::providers::http::build_client(std::time::Duration::from_secs(30)),
             source_router: Arc::new(crate::sources::SourceRouter::default()),
@@ -1951,8 +2497,7 @@ mod transport_dispatch_tests {
             default_model: resolve_default_model(&config),
             config,
             ai: Arc::new(FakeAiProvider),
-            sources: None,
-            fallback_sources: None,
+            source_slots: Arc::new(Vec::new()),
             cache: Arc::new(Mutex::new(SourceCache::new(16))),
             http_client: crate::providers::http::build_client(std::time::Duration::from_secs(30)),
             source_router: Arc::new(crate::sources::SourceRouter::default()),
@@ -1971,8 +2516,7 @@ mod transport_dispatch_tests {
             default_model: resolve_default_model(&config_unset),
             config: config_unset,
             ai: Arc::new(FakeAiProvider),
-            sources: None,
-            fallback_sources: None,
+            source_slots: Arc::new(Vec::new()),
             cache: Arc::new(Mutex::new(SourceCache::new(16))),
             http_client: crate::providers::http::build_client(std::time::Duration::from_secs(30)),
             source_router: Arc::new(crate::sources::SourceRouter::default()),
@@ -2153,12 +2697,19 @@ mod enrich_tests {
         router: SourceRouter,
         sources: Option<Arc<dyn SourceProvider>>,
     ) -> SearchService {
+        let source_slots = sources
+            .map(|provider| {
+                vec![SourceSlot::Active(SourceEntry {
+                    spec: &TAVILY_SPEC,
+                    provider,
+                })]
+            })
+            .unwrap_or_default();
         SearchService {
             default_model: resolve_default_model(&config),
             config,
             ai: Arc::new(FakeAiProvider),
-            sources,
-            fallback_sources: None,
+            source_slots: Arc::new(source_slots),
             cache: Arc::new(Mutex::new(SourceCache::new(64))),
             http_client: crate::providers::http::build_client(std::time::Duration::from_secs(30)),
             source_router: Arc::new(router),
@@ -2358,13 +2909,15 @@ mod enrich_tests {
 
     #[tokio::test]
     async fn generic_fetch_missing_config_only_when_no_provider_configured() {
-        let err = generic_source_fetch(&None, &None, "https://example.com")
+        let err = generic_source_fetch(&[], "https://example.com")
             .await
             .expect_err("no providers must error");
         assert!(
             matches!(
                 err,
-                GrokSearchError::MissingConfig("TAVILY_API_KEY or FIRECRAWL_API_KEY")
+                GrokSearchError::MissingConfig(
+                    "TAVILY_API_KEY, EXA_API_KEY, TINYFISH_API_KEY or FIRECRAWL_API_KEY"
+                )
             ),
             "expected MissingConfig, got: {err:?}"
         );
@@ -2376,8 +2929,11 @@ mod enrich_tests {
         // through to MissingConfig("TAVILY_API_KEY or FIRECRAWL_API_KEY") even
         // though TAVILY_API_KEY was set, sending users to debug config instead
         // of the actual provider failure.
-        let primary: Option<Arc<dyn SourceProvider>> = Some(Arc::new(SearchOkFetchErrProvider));
-        let err = generic_source_fetch(&primary, &None, "https://example.com")
+        let chain = vec![SourceEntry {
+            spec: &TAVILY_SPEC,
+            provider: Arc::new(SearchOkFetchErrProvider),
+        }];
+        let err = generic_source_fetch(&chain, "https://example.com")
             .await
             .expect_err("primary failure must error");
         match err {
@@ -2389,8 +2945,11 @@ mod enrich_tests {
     #[tokio::test]
     async fn generic_fetch_primary_empty_content_reports_empty_without_fallback() {
         let url = "https://npmjs.com/package/grok-search-rs";
-        let primary: Option<Arc<dyn SourceProvider>> = Some(Arc::new(EmptyFetchProvider));
-        let err = generic_source_fetch(&primary, &None, url)
+        let chain = vec![SourceEntry {
+            spec: &TAVILY_SPEC,
+            provider: Arc::new(EmptyFetchProvider),
+        }];
+        let err = generic_source_fetch(&chain, url)
             .await
             .expect_err("empty content must error");
         match err {
@@ -2404,9 +2963,17 @@ mod enrich_tests {
 
     #[tokio::test]
     async fn generic_fetch_primary_failure_still_rescued_by_fallback() {
-        let primary: Option<Arc<dyn SourceProvider>> = Some(Arc::new(SearchOkFetchErrProvider));
-        let fallback: Option<Arc<dyn SourceProvider>> = Some(Arc::new(FakeSourceProvider));
-        let page = generic_source_fetch(&primary, &fallback, "https://example.com")
+        let chain = vec![
+            SourceEntry {
+                spec: &TAVILY_SPEC,
+                provider: Arc::new(SearchOkFetchErrProvider),
+            },
+            SourceEntry {
+                spec: &FIRECRAWL_SPEC,
+                provider: Arc::new(FakeSourceProvider),
+            },
+        ];
+        let page = generic_source_fetch(&chain, "https://example.com")
             .await
             .expect("fallback must rescue primary failure");
         assert!(
@@ -2565,6 +3132,14 @@ mod enrich_tests {
         primary: Option<Arc<dyn SourceProvider>>,
         max_sources: usize,
     ) -> Vec<Source> {
+        let chain = primary
+            .map(|provider| {
+                vec![SourceEntry {
+                    spec: &TAVILY_SPEC,
+                    provider,
+                }]
+            })
+            .unwrap_or_default();
         enrich_sources(
             sources,
             tokio::time::Instant::now() + Duration::from_secs(30),
@@ -2577,8 +3152,7 @@ mod enrich_tests {
             4,
             15_000,
             max_sources,
-            primary,
-            None,
+            chain,
         )
         .await
     }

--- a/src/service.rs
+++ b/src/service.rs
@@ -1131,37 +1131,50 @@ impl SearchService {
 
     pub async fn web_fetch(&self, url: &str, max_chars: Option<usize>) -> Result<WebFetchOutput> {
         let effective_limit = max_chars.or(self.config.fetch_max_chars);
+        // D-02, as on the web_search path: one deadline for the whole call.
+        // The specialist attempt and every generic-chain provider draw from
+        // the same budget, so a slow specialist followed by a slow chain
+        // cannot spend a full GROK_SEARCH_TIMEOUT_SECONDS apiece.
+        let deadline = tokio::time::Instant::now() + self.config.timeout;
 
         let (content, source_type, fallback_reason) = match url::Url::parse(url) {
             Ok(parsed) => {
-                match crate::sources::resolve_content(
+                let caps = crate::sources::SourceCaps {
+                    max_answers: self.config.source_max_answers,
+                    max_comments: self.config.source_max_comments,
+                };
+                let specialist = crate::sources::resolve_content(
                     &self.http_client,
                     &parsed,
                     self.source_router.as_ref(),
-                    &crate::sources::SourceCaps {
-                        max_answers: self.config.source_max_answers,
-                        max_comments: self.config.source_max_comments,
-                    },
-                )
-                .await
-                {
+                    &caps,
+                );
+                match tokio::time::timeout_at(deadline, specialist).await {
                     // Specialist succeeded — keep its content and source type.
-                    Ok((content, kind)) => (content, kind, None),
+                    Ok(Ok((content, kind))) => (content, kind, None),
                     // No specialist matched: go generic silently (D-01).
-                    Err(reason) if reason == crate::sources::NO_SPECIALIST_MATCH => {
-                        let generic = self.web_fetch_raw(url).await?;
+                    Ok(Err(reason)) if reason == crate::sources::NO_SPECIALIST_MATCH => {
+                        let generic = self.web_fetch_raw(url, deadline).await?;
                         (generic, crate::sources::SourceType::Generic, None)
                     }
                     // Specialist matched but failed/empty: surface the reason (D-01).
-                    Err(reason) => {
-                        let generic = self.web_fetch_raw(url).await?;
+                    Ok(Err(reason)) => {
+                        let generic = self.web_fetch_raw(url, deadline).await?;
                         (generic, crate::sources::SourceType::Generic, Some(reason))
+                    }
+                    // The budget is gone, so the generic chain cannot run
+                    // either — report the timeout instead of pretending there
+                    // is another path left to try.
+                    Err(_elapsed) => {
+                        return Err(GrokSearchError::Timeout(format!(
+                            "web_fetch timed out extracting {url} (GROK_SEARCH_TIMEOUT_SECONDS)"
+                        )))
                     }
                 }
             }
             // Malformed URL is not a specialist failure — go generic, no reason.
             Err(_) => {
-                let generic = self.web_fetch_raw(url).await?;
+                let generic = self.web_fetch_raw(url, deadline).await?;
                 (generic, crate::sources::SourceType::Generic, None)
             }
         };
@@ -1175,10 +1188,18 @@ impl SearchService {
         ))
     }
 
-    async fn web_fetch_raw(&self, url: &str) -> Result<String> {
-        generic_source_fetch(&self.active_sources(), url)
-            .await
-            .map(|page| page.content)
+    /// Generic fetch through the source chain, bounded by the call's shared
+    /// `deadline`. Mirrors how inline enrichment already wraps the same
+    /// helper: without this, each chain position would get its own full
+    /// client timeout and the chain would multiply the configured budget.
+    async fn web_fetch_raw(&self, url: &str, deadline: tokio::time::Instant) -> Result<String> {
+        let chain = self.active_sources();
+        match tokio::time::timeout_at(deadline, generic_source_fetch(&chain, url)).await {
+            Ok(result) => result.map(|page| page.content),
+            Err(_elapsed) => Err(GrokSearchError::Timeout(format!(
+                "web_fetch timed out fetching {url} through the source chain (GROK_SEARCH_TIMEOUT_SECONDS)"
+            ))),
+        }
     }
 
     pub async fn web_map(&self, url: &str, max_results: usize) -> Result<Vec<Source>> {
@@ -1933,6 +1954,69 @@ mod chain_tests {
         assert!(
             err.to_string().contains("request deadline reached"),
             "error must name the deadline: {err}"
+        );
+    }
+
+    /// Generic fetch hangs; search is instant and empty.
+    struct HangingFetchProvider;
+    #[async_trait]
+    impl SourceProvider for HangingFetchProvider {
+        async fn search_sources(
+            &self,
+            _query: &str,
+            _max_results: usize,
+            _filters: &SearchFilters,
+        ) -> Result<Vec<Source>> {
+            Ok(Vec::new())
+        }
+        async fn fetch(&self, _url: &str) -> Result<FetchedPage> {
+            tokio::time::sleep(std::time::Duration::from_secs(60)).await;
+            Ok(FetchedPage::text("never reached"))
+        }
+        async fn map(&self, _url: &str, _max_results: usize) -> Result<Vec<Source>> {
+            Ok(Vec::new())
+        }
+    }
+
+    // D-02 on the direct web_fetch path: two hanging chain providers must
+    // share one request budget, not take a full client timeout each.
+    #[tokio::test]
+    async fn web_fetch_chain_is_bounded_by_one_deadline() {
+        let config = Config::from_env_map([
+            ("GROK_SEARCH_API_KEY", "fake"),
+            ("GROK_SEARCH_TIMEOUT_SECONDS", "1"),
+        ]);
+        let svc = SearchService {
+            default_model: resolve_default_model(&config),
+            config,
+            ai: Arc::new(FakeAiProvider),
+            source_slots: Arc::new(vec![
+                SourceSlot::Active(SourceEntry {
+                    spec: &TAVILY_SPEC,
+                    provider: Arc::new(HangingFetchProvider),
+                }),
+                SourceSlot::Active(SourceEntry {
+                    spec: &FIRECRAWL_SPEC,
+                    provider: Arc::new(HangingFetchProvider),
+                }),
+            ]),
+            cache: Arc::new(Mutex::new(SourceCache::new(16))),
+            http_client: crate::providers::http::build_client(std::time::Duration::from_secs(5)),
+            source_router: Arc::new(crate::sources::SourceRouter::default()),
+        };
+        let started = std::time::Instant::now();
+        let err = svc
+            .web_fetch("https://example.com/page", None)
+            .await
+            .expect_err("hanging chain must time out");
+        assert!(
+            started.elapsed() < std::time::Duration::from_secs(10),
+            "web_fetch must be cut at the ~1s deadline, took {:?}",
+            started.elapsed()
+        );
+        assert!(
+            matches!(err, GrokSearchError::Timeout(_)),
+            "expected a Timeout error, got: {err:?}"
         );
     }
 

--- a/src/service.rs
+++ b/src/service.rs
@@ -303,24 +303,36 @@ fn provider_enabled(spec: &ProviderSpec, config: &Config) -> bool {
 /// list, exactly the named providers are slotted, and every named-but-absent
 /// one gets a `Missing` slot: the operator asked for it, so its absence is
 /// worth reporting.
+/// Check every name in `GROK_SEARCH_SOURCE_PROVIDERS` against the known
+/// provider registry. Exposed separately from [`build_source_slots`] so the
+/// HTTP transport can fail at startup (before binding the listener) instead
+/// of failing every request later — the operator's chain is operator-fixed
+/// config, never a per-request header, so a startup check covers it fully.
+pub fn validate_source_providers(config: &Config) -> Result<()> {
+    for name in &config.source_providers {
+        if !CANONICAL_SOURCE_ORDER.iter().any(|spec| spec.name == name) {
+            return Err(GrokSearchError::InvalidParams(format!(
+                "unknown source provider \"{name}\" in GROK_SEARCH_SOURCE_PROVIDERS (valid: tavily, exa, tinyfish, firecrawl)"
+            )));
+        }
+    }
+    Ok(())
+}
+
 fn build_source_slots(config: &Config, http: &reqwest::Client) -> Result<Vec<SourceSlot>> {
+    validate_source_providers(config)?;
     let explicit = !config.source_providers.is_empty();
     let specs: Vec<&'static ProviderSpec> = if explicit {
         config
             .source_providers
             .iter()
-            .map(|name| {
+            .filter_map(|name| {
                 CANONICAL_SOURCE_ORDER
                     .iter()
                     .copied()
                     .find(|spec| spec.name == name)
-                    .ok_or_else(|| {
-                        GrokSearchError::InvalidParams(format!(
-                            "unknown source provider \"{name}\" in GROK_SEARCH_SOURCE_PROVIDERS (valid: tavily, exa, tinyfish, firecrawl)"
-                        ))
-                    })
             })
-            .collect::<Result<_>>()?
+            .collect()
     } else {
         CANONICAL_SOURCE_ORDER.to_vec()
     };
@@ -767,7 +779,7 @@ impl SearchService {
 
         let grok_future = self.ai.search(&request);
         let speculative_future =
-            self.fetch_raw_extra_sources(&input.query, speculative_count, &filters);
+            self.fetch_raw_extra_sources(&input.query, speculative_count, &filters, deadline);
         let (grok_result, raw) = tokio::join!(grok_future, speculative_future);
 
         let response = match grok_result {
@@ -866,6 +878,7 @@ impl SearchService {
         query: &str,
         count: usize,
         filters: &SearchFilters,
+        deadline: tokio::time::Instant,
     ) -> RawSources {
         if count == 0 {
             return RawSources::empty(vec![SourceNote::config(
@@ -888,7 +901,27 @@ impl SearchService {
                         )));
                         continue;
                     }
-                    match entry.provider.search_sources(query, count, filters).await {
+                    // D-02: the whole chain shares the request's global
+                    // deadline. Without this, every chain position gets a
+                    // fresh full client timeout and a slow chain multiplies
+                    // the configured budget by its length.
+                    let attempt = tokio::time::timeout_at(
+                        deadline,
+                        entry.provider.search_sources(query, count, filters),
+                    )
+                    .await;
+                    let outcome = match attempt {
+                        Ok(outcome) => outcome,
+                        Err(_elapsed) => {
+                            // Later providers would hit the same expired
+                            // deadline immediately; one note explains the stop.
+                            notes.push(SourceNote::broken(format!(
+                                "{name}: timed out (request deadline reached; providers after it were not tried)"
+                            )));
+                            break;
+                        }
+                    };
+                    match outcome {
                         Ok(sources) => match usable_or_note(name, sources) {
                             Ok(usable) => {
                                 if !notes.is_empty() {
@@ -1151,16 +1184,23 @@ impl SearchService {
     pub async fn web_map(&self, url: &str, max_results: usize) -> Result<Vec<Source>> {
         // Only providers with a real site-map endpoint qualify (Tavily today);
         // the search-shaped `map` impls on the other providers are not a
-        // substitute for actual URL discovery.
-        let entry = self
+        // substitute for actual URL discovery. web_map is a dedicated
+        // capability, not part of the supplemental-source chain — an operator
+        // whose GROK_SEARCH_SOURCE_PROVIDERS excludes Tavily from the chain
+        // keeps map as long as TAVILY_API_KEY is configured, so a map-capable
+        // provider absent from the chain is instantiated directly.
+        let provider = self
             .source_slots
             .iter()
             .find_map(|slot| match slot {
-                SourceSlot::Active(entry) if entry.spec.supports_map => Some(entry.clone()),
+                SourceSlot::Active(entry) if entry.spec.supports_map => {
+                    Some(entry.provider.clone())
+                }
                 _ => None,
             })
+            .or_else(|| instantiate_source(&TAVILY_SPEC, &self.config, &self.http_client))
             .ok_or(GrokSearchError::MissingConfig("TAVILY_API_KEY"))?;
-        entry.provider.map(url, max_results).await
+        provider.map(url, max_results).await
     }
 
     /// Runtime diagnostics with live connectivity probes against each configured backend.
@@ -1830,6 +1870,103 @@ mod chain_tests {
                 .iter()
                 .map(|source| source.provider.clone())
                 .collect::<Vec<_>>()
+        );
+    }
+
+    /// Search hangs far past any test deadline; fetch/map are instant.
+    struct HangingSearchProvider;
+    #[async_trait]
+    impl SourceProvider for HangingSearchProvider {
+        async fn search_sources(
+            &self,
+            _query: &str,
+            _max_results: usize,
+            _filters: &SearchFilters,
+        ) -> Result<Vec<Source>> {
+            tokio::time::sleep(std::time::Duration::from_secs(60)).await;
+            Ok(Vec::new())
+        }
+        async fn fetch(&self, url: &str) -> Result<FetchedPage> {
+            Ok(FetchedPage::text(format!("hanging provider fetch {url}")))
+        }
+        async fn map(&self, _url: &str, _max_results: usize) -> Result<Vec<Source>> {
+            Ok(Vec::new())
+        }
+    }
+
+    // D-02: a hanging chain provider must be cut at the request's global
+    // deadline, not granted a fresh full client timeout per chain position.
+    #[tokio::test]
+    async fn chain_is_bounded_by_the_global_deadline() {
+        let config = Config::from_env_map([
+            ("GROK_SEARCH_API_KEY", "fake"),
+            ("GROK_SEARCH_TIMEOUT_SECONDS", "1"),
+        ]);
+        let svc = SearchService {
+            default_model: resolve_default_model(&config),
+            config,
+            ai: Arc::new(ErrAiProvider),
+            source_slots: Arc::new(vec![
+                SourceSlot::Active(SourceEntry {
+                    spec: &TAVILY_SPEC,
+                    provider: Arc::new(HangingSearchProvider),
+                }),
+                SourceSlot::Active(SourceEntry {
+                    spec: &TINYFISH_SPEC,
+                    provider: Arc::new(NamedSourceProvider("tinyfish")),
+                }),
+            ]),
+            cache: Arc::new(Mutex::new(SourceCache::new(16))),
+            http_client: crate::providers::http::build_client(std::time::Duration::from_secs(5)),
+            source_router: Arc::new(crate::sources::SourceRouter::default()),
+        };
+        let started = std::time::Instant::now();
+        let err = svc
+            .web_search(concise_input())
+            .await
+            .expect_err("deadline-cut chain with a failed AI yields zero sources");
+        assert!(
+            started.elapsed() < std::time::Duration::from_secs(10),
+            "chain must be cut at the ~1s deadline, took {:?}",
+            started.elapsed()
+        );
+        assert!(
+            err.to_string().contains("request deadline reached"),
+            "error must name the deadline: {err}"
+        );
+    }
+
+    // web_map is a dedicated Tavily capability: excluding Tavily from the
+    // supplemental chain must not break map while TAVILY_API_KEY is set.
+    #[tokio::test]
+    async fn web_map_survives_a_chain_that_excludes_tavily() {
+        let config = Config::from_env_map([
+            ("GROK_SEARCH_API_KEY", "fake"),
+            ("TAVILY_API_KEY", "fake-tavily"),
+            ("GROK_SEARCH_SOURCE_PROVIDERS", "tinyfish"),
+        ]);
+        let svc = SearchService {
+            default_model: resolve_default_model(&config),
+            config,
+            ai: Arc::new(FakeAiProvider),
+            source_slots: Arc::new(vec![SourceSlot::Active(SourceEntry {
+                spec: &TINYFISH_SPEC,
+                provider: Arc::new(NamedSourceProvider("tinyfish")),
+            })]),
+            cache: Arc::new(Mutex::new(SourceCache::new(16))),
+            http_client: crate::providers::http::build_client(std::time::Duration::from_secs(5)),
+            source_router: Arc::new(crate::sources::SourceRouter::default()),
+        };
+        // The chain has no map-capable slot, so web_map instantiates Tavily
+        // from config; the fake key means the call itself fails upstream, but
+        // it must NOT fail as MissingConfig("TAVILY_API_KEY").
+        let err = svc
+            .web_map("https://example.com", 3)
+            .await
+            .expect_err("fake key cannot reach real Tavily");
+        assert!(
+            !matches!(err, GrokSearchError::MissingConfig(_)),
+            "web_map must not report missing config when TAVILY_API_KEY is set: {err:?}"
         );
     }
 

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -451,3 +451,90 @@ fn response_budget_defaults_and_env_overrides() {
     assert_eq!(overridden.max_inline_sources, 2);
     assert_eq!(overridden.response_max_chars, 30_000);
 }
+
+#[test]
+fn tinyfish_and_exa_defaults_are_enabled_with_official_endpoints() {
+    let cfg = Config::from_env_map([("GROK_SEARCH_API_KEY", "k")]);
+    assert_eq!(
+        cfg.tinyfish_search_api_url,
+        "https://api.search.tinyfish.ai"
+    );
+    assert_eq!(cfg.tinyfish_fetch_api_url, "https://api.fetch.tinyfish.ai");
+    assert_eq!(cfg.tinyfish_api_key, None);
+    assert!(cfg.tinyfish_enabled);
+    assert_eq!(cfg.exa_api_url, "https://api.exa.ai");
+    assert_eq!(cfg.exa_api_key, None);
+    assert!(cfg.exa_enabled);
+    assert!(cfg.source_providers.is_empty());
+}
+
+#[test]
+fn blank_tinyfish_and_exa_keys_mean_absent() {
+    let cfg = Config::from_env_map([("TINYFISH_API_KEY", "   "), ("EXA_API_KEY", "")]);
+    assert_eq!(cfg.tinyfish_api_key, None);
+    assert_eq!(cfg.exa_api_key, None);
+}
+
+#[test]
+fn tinyfish_and_exa_read_keys_urls_and_toggles() {
+    let cfg = Config::from_env_map([
+        ("TINYFISH_API_KEY", "tf-key"),
+        ("TINYFISH_SEARCH_API_URL", "https://search.proxy.example/"),
+        ("TINYFISH_FETCH_API_URL", "https://fetch.proxy.example/"),
+        ("TINYFISH_ENABLED", "false"),
+        ("EXA_API_KEY", "exa-key"),
+        ("EXA_API_URL", "https://exa.proxy.example/"),
+        ("EXA_ENABLED", "false"),
+    ]);
+    assert_eq!(cfg.tinyfish_api_key.as_deref(), Some("tf-key"));
+    assert_eq!(cfg.tinyfish_search_api_url, "https://search.proxy.example");
+    assert_eq!(cfg.tinyfish_fetch_api_url, "https://fetch.proxy.example");
+    assert!(!cfg.tinyfish_enabled);
+    assert_eq!(cfg.exa_api_key.as_deref(), Some("exa-key"));
+    assert_eq!(cfg.exa_api_url, "https://exa.proxy.example");
+    assert!(!cfg.exa_enabled);
+}
+
+#[test]
+fn source_providers_csv_is_trimmed_lowercased_and_deduped() {
+    let cfg = Config::from_env_map([(
+        "GROK_SEARCH_SOURCE_PROVIDERS",
+        " Tavily, exa ,tavily,, TINYFISH ",
+    )]);
+    assert_eq!(cfg.source_providers, ["tavily", "exa", "tinyfish"]);
+}
+
+#[test]
+fn config_file_accepts_tinyfish_exa_and_source_providers() {
+    let dir = tempdir().expect("tempdir");
+    let path = dir.path().join("config.toml");
+    fs::write(
+        &path,
+        r#"
+tinyfish_api_key = "tf-file"
+exa_api_key = "exa-file"
+source_providers = ["tinyfish", "exa"]
+"#,
+    )
+    .expect("write config");
+
+    let cfg = Config::load_from([("GROK_SEARCH_CONFIG", path.to_string_lossy().to_string())]);
+    assert_eq!(cfg.tinyfish_api_key.as_deref(), Some("tf-file"));
+    assert_eq!(cfg.exa_api_key.as_deref(), Some("exa-file"));
+    assert_eq!(cfg.source_providers, ["tinyfish", "exa"]);
+}
+
+#[test]
+fn redacted_diagnostics_masks_tinyfish_and_exa_keys() {
+    let cfg = Config::from_env_map([
+        ("TINYFISH_API_KEY", "tf-secret-value"),
+        ("EXA_API_KEY", "exa-secret-value"),
+    ]);
+    let diagnostics = cfg.redacted_diagnostics();
+    assert!(
+        !diagnostics.contains("tf-secret-value") && !diagnostics.contains("exa-secret-value"),
+        "keys must never appear in diagnostics: {diagnostics}"
+    );
+    assert!(diagnostics.contains("tinyfish_api_key="));
+    assert!(diagnostics.contains("exa_api_key="));
+}

--- a/tests/exa_parse.rs
+++ b/tests/exa_parse.rs
@@ -1,0 +1,115 @@
+use grok_search_rs::model::search::SearchFilters;
+use grok_search_rs::providers::exa::{
+    exa_search_request_body, normalize_exa_results, parse_exa_contents, start_published_date,
+};
+use serde_json::json;
+
+#[test]
+fn search_body_carries_native_domain_and_date_filters() {
+    let filters = SearchFilters {
+        recency_days: Some(30),
+        include_domains: vec!["arxiv.org".to_string()],
+        exclude_domains: vec!["reddit.com".to_string()],
+    };
+    // 2026-08-02T00:00:00Z = 1785628800; 30 days earlier is 2026-07-03.
+    let body = exa_search_request_body("LLM eval papers", 5, &filters, 1_785_628_800);
+    assert_eq!(body["query"], "LLM eval papers");
+    assert_eq!(body["numResults"], 5);
+    assert_eq!(body["includeDomains"], json!(["arxiv.org"]));
+    assert_eq!(body["excludeDomains"], json!(["reddit.com"]));
+    assert_eq!(body["startPublishedDate"], "2026-07-03T00:00:00.000Z");
+}
+
+#[test]
+fn search_body_omits_absent_filters_and_clamps_num_results() {
+    let body = exa_search_request_body("q", 0, &SearchFilters::default(), 1_785_628_800);
+    assert_eq!(body["numResults"], 1);
+    assert!(body.get("includeDomains").is_none());
+    assert!(body.get("excludeDomains").is_none());
+    assert!(body.get("startPublishedDate").is_none());
+
+    let body = exa_search_request_body("q", 500, &SearchFilters::default(), 1_785_628_800);
+    assert_eq!(body["numResults"], 100);
+}
+
+#[test]
+fn start_published_date_handles_month_and_year_boundaries() {
+    // 2026-01-10 minus 15 days = 2025-12-26 (year boundary).
+    // 1768003200 = 2026-01-10T00:00:00Z.
+    assert_eq!(
+        start_published_date(15, 1_768_003_200),
+        "2025-12-26T00:00:00.000Z"
+    );
+    // 2026-03-01 minus 1 day = 2026-02-28 (2026 is not a leap year).
+    // 1772323200 = 2026-03-01T00:00:00Z.
+    assert_eq!(
+        start_published_date(1, 1_772_323_200),
+        "2026-02-28T00:00:00.000Z"
+    );
+    // 2024-03-01 minus 1 day = 2024-02-29 (leap year).
+    // 1709251200 = 2024-03-01T00:00:00Z.
+    assert_eq!(
+        start_published_date(1, 1_709_251_200),
+        "2024-02-29T00:00:00.000Z"
+    );
+}
+
+#[test]
+fn search_results_parse_metadata() {
+    let raw = json!({
+        "results": [
+            {
+                "title": "A Comprehensive Overview of Large Language Models",
+                "url": "https://arxiv.org/pdf/2307.06435.pdf",
+                "publishedDate": "2023-11-16T01:36:32.547Z",
+                "author": "Humza Naveed",
+                "id": "https://arxiv.org/abs/2307.06435"
+            },
+            { "id": "no-url-dropped" }
+        ],
+        "requestId": "abc"
+    });
+    let sources = normalize_exa_results(&raw);
+    assert_eq!(sources.len(), 1);
+    assert_eq!(sources[0].url, "https://arxiv.org/pdf/2307.06435.pdf");
+    assert_eq!(sources[0].provider, "exa");
+    assert_eq!(
+        sources[0].published_date.as_deref(),
+        Some("2023-11-16T01:36:32.547Z")
+    );
+}
+
+#[test]
+fn contents_parse_text_title_and_date() {
+    let raw = json!({
+        "results": [
+            {
+                "url": "https://example.com/post",
+                "title": "Post Title",
+                "publishedDate": "2026-05-01T00:00:00.000Z",
+                "text": "Full page text."
+            }
+        ]
+    });
+    let page = parse_exa_contents(&raw, "https://example.com/post").expect("page");
+    assert_eq!(page.content, "Full page text.");
+    assert_eq!(page.title.as_deref(), Some("Post Title"));
+    assert_eq!(
+        page.published_date.as_deref(),
+        Some("2026-05-01T00:00:00.000Z")
+    );
+}
+
+#[test]
+fn contents_failure_surfaces_status_reason() {
+    let raw = json!({
+        "results": [],
+        "statuses": [ { "id": "https://gone.example", "status": "error", "error": { "tag": "CRAWL_NOT_FOUND" } } ]
+    });
+    let err = parse_exa_contents(&raw, "https://gone.example").expect_err("must fail");
+    let message = err.to_string();
+    assert!(
+        message.contains("CRAWL_NOT_FOUND") && message.contains("https://gone.example"),
+        "error must carry the upstream reason and url: {message}"
+    );
+}

--- a/tests/tinyfish_parse.rs
+++ b/tests/tinyfish_parse.rs
@@ -1,0 +1,140 @@
+use grok_search_rs::model::search::SearchFilters;
+use grok_search_rs::providers::tinyfish::{
+    normalize_tinyfish_results, parse_tinyfish_fetch, tinyfish_search_query,
+};
+use serde_json::json;
+
+#[test]
+fn search_results_parse_title_snippet_url_and_date() {
+    let raw = json!({
+        "query": "web automation tools",
+        "results": [
+            {
+                "position": 1,
+                "site_name": "tinyfish.ai",
+                "title": "TinyFish — AI Web Automation Platform",
+                "snippet": "Automate any website...",
+                "url": "https://tinyfish.ai"
+            },
+            {
+                "position": 2,
+                "title": "News item",
+                "url": "https://example.com/news",
+                "date": "2026-07-30"
+            },
+            { "position": 3, "title": "no url, dropped" }
+        ],
+        "total_results": 3,
+        "page": 0
+    });
+    let sources = normalize_tinyfish_results(&raw);
+    assert_eq!(sources.len(), 2);
+    assert_eq!(sources[0].url, "https://tinyfish.ai");
+    assert_eq!(sources[0].provider, "tinyfish");
+    assert_eq!(
+        sources[0].title.as_deref(),
+        Some("TinyFish — AI Web Automation Platform")
+    );
+    assert_eq!(
+        sources[0].description.as_deref(),
+        Some("Automate any website...")
+    );
+    assert_eq!(sources[1].published_date.as_deref(), Some("2026-07-30"));
+}
+
+#[test]
+fn query_carries_domain_filters_as_site_operators() {
+    let filters = SearchFilters {
+        recency_days: None,
+        include_domains: vec!["docs.rs".to_string(), "crates.io".to_string()],
+        exclude_domains: vec!["pinterest.com".to_string()],
+    };
+    let params = tinyfish_search_query("rust http client", &filters);
+    assert_eq!(params.len(), 1);
+    assert_eq!(params[0].0, "query");
+    assert_eq!(
+        params[0].1,
+        "rust http client (site:docs.rs OR site:crates.io) -site:pinterest.com"
+    );
+}
+
+#[test]
+fn single_include_domain_needs_no_group() {
+    let filters = SearchFilters {
+        recency_days: None,
+        include_domains: vec!["github.com".to_string()],
+        exclude_domains: Vec::new(),
+    };
+    let params = tinyfish_search_query("grok-search-rs", &filters);
+    assert_eq!(params[0].1, "grok-search-rs site:github.com");
+}
+
+#[test]
+fn recency_days_map_to_minutes_with_ten_year_cap() {
+    let week = SearchFilters {
+        recency_days: Some(7),
+        include_domains: Vec::new(),
+        exclude_domains: Vec::new(),
+    };
+    let params = tinyfish_search_query("q", &week);
+    assert_eq!(params[1], ("recency_minutes", (7 * 24 * 60).to_string()));
+
+    let huge = SearchFilters {
+        recency_days: Some(4_000_000),
+        include_domains: Vec::new(),
+        exclude_domains: Vec::new(),
+    };
+    let params = tinyfish_search_query("q", &huge);
+    assert_eq!(params[1], ("recency_minutes", "5256000".to_string()));
+}
+
+#[test]
+fn unfiltered_query_sends_only_the_query_param() {
+    let params = tinyfish_search_query("plain", &SearchFilters::default());
+    assert_eq!(params, vec![("query", "plain".to_string())]);
+}
+
+#[test]
+fn fetch_parses_markdown_text_and_title() {
+    let raw = json!({
+        "results": [
+            {
+                "url": "https://www.tinyfish.ai/",
+                "final_url": "https://www.tinyfish.ai/",
+                "title": "TinyFish | Enterprise Web Agent Infrastructure",
+                "description": "TinyFish provides...",
+                "language": "en",
+                "format": "markdown",
+                "text": "# TinyFish\n\nEnterprise infrastructure..."
+            }
+        ],
+        "errors": []
+    });
+    let page = parse_tinyfish_fetch(&raw, "https://www.tinyfish.ai/").expect("page");
+    assert_eq!(page.content, "# TinyFish\n\nEnterprise infrastructure...");
+    assert_eq!(
+        page.title.as_deref(),
+        Some("TinyFish | Enterprise Web Agent Infrastructure")
+    );
+    assert_eq!(page.published_date, None);
+}
+
+#[test]
+fn fetch_surfaces_per_url_error_from_errors_array() {
+    let raw = json!({
+        "results": [],
+        "errors": [ { "url": "https://blocked.example", "error": "anti_bot_challenge" } ]
+    });
+    let err = parse_tinyfish_fetch(&raw, "https://blocked.example").expect_err("must fail");
+    let message = err.to_string();
+    assert!(
+        message.contains("anti_bot_challenge") && message.contains("https://blocked.example"),
+        "error must carry the upstream reason and url: {message}"
+    );
+}
+
+#[test]
+fn fetch_with_empty_text_is_an_error_not_a_blank_page() {
+    let raw = json!({ "results": [ { "url": "https://x.example", "text": "   " } ], "errors": [] });
+    assert!(parse_tinyfish_fetch(&raw, "https://x.example").is_err());
+}

--- a/tests/tinyfish_parse.rs
+++ b/tests/tinyfish_parse.rs
@@ -1,6 +1,6 @@
 use grok_search_rs::model::search::SearchFilters;
 use grok_search_rs::providers::tinyfish::{
-    normalize_tinyfish_results, parse_tinyfish_fetch, tinyfish_search_query,
+    normalize_tinyfish_results, parse_tinyfish_fetch, tinyfish_search_params,
 };
 use serde_json::json;
 
@@ -42,31 +42,43 @@ fn search_results_parse_title_snippet_url_and_date() {
     assert_eq!(sources[1].published_date.as_deref(), Some("2026-07-30"));
 }
 
+// Domain filters ride the dedicated comma-separated params, never the query
+// string: `site:`/`-site:` operators are deprecated for domain filtering
+// upstream because they collide with other query syntax, and the caller's
+// query is arbitrary user text.
 #[test]
-fn query_carries_domain_filters_as_site_operators() {
+fn domain_filters_use_dedicated_params_and_leave_the_query_untouched() {
     let filters = SearchFilters {
         recency_days: None,
         include_domains: vec!["docs.rs".to_string(), "crates.io".to_string()],
         exclude_domains: vec!["pinterest.com".to_string()],
     };
-    let params = tinyfish_search_query("rust http client", &filters);
-    assert_eq!(params.len(), 1);
-    assert_eq!(params[0].0, "query");
+    let params = tinyfish_search_params("rust http client", &filters);
     assert_eq!(
-        params[0].1,
-        "rust http client (site:docs.rs OR site:crates.io) -site:pinterest.com"
+        params,
+        vec![
+            ("query", "rust http client".to_string()),
+            ("include_domains", "docs.rs,crates.io".to_string()),
+            ("exclude_domains", "pinterest.com".to_string()),
+        ]
     );
 }
 
+// A query carrying operator-like syntax of its own must survive verbatim —
+// the old string-splicing path could turn it into a different query.
 #[test]
-fn single_include_domain_needs_no_group() {
+fn operator_like_query_text_is_not_rewritten() {
     let filters = SearchFilters {
         recency_days: None,
         include_domains: vec!["github.com".to_string()],
         exclude_domains: Vec::new(),
     };
-    let params = tinyfish_search_query("grok-search-rs", &filters);
-    assert_eq!(params[0].1, "grok-search-rs site:github.com");
+    let params = tinyfish_search_params("rust OR go site:example.com", &filters);
+    assert_eq!(
+        params[0],
+        ("query", "rust OR go site:example.com".to_string())
+    );
+    assert_eq!(params[1], ("include_domains", "github.com".to_string()));
 }
 
 #[test]
@@ -76,7 +88,7 @@ fn recency_days_map_to_minutes_with_ten_year_cap() {
         include_domains: Vec::new(),
         exclude_domains: Vec::new(),
     };
-    let params = tinyfish_search_query("q", &week);
+    let params = tinyfish_search_params("q", &week);
     assert_eq!(params[1], ("recency_minutes", (7 * 24 * 60).to_string()));
 
     let huge = SearchFilters {
@@ -84,13 +96,13 @@ fn recency_days_map_to_minutes_with_ten_year_cap() {
         include_domains: Vec::new(),
         exclude_domains: Vec::new(),
     };
-    let params = tinyfish_search_query("q", &huge);
+    let params = tinyfish_search_params("q", &huge);
     assert_eq!(params[1], ("recency_minutes", "5256000".to_string()));
 }
 
 #[test]
 fn unfiltered_query_sends_only_the_query_param() {
-    let params = tinyfish_search_query("plain", &SearchFilters::default());
+    let params = tinyfish_search_params("plain", &SearchFilters::default());
     assert_eq!(params, vec![("query", "plain".to_string())]);
 }
 


### PR DESCRIPTION
## 动机

- Closes #12(TinyFish 免费 Search/Fetch 接入请求)。
- 借鉴 [smart-search](https://github.com/konbakuyomu/smartsearch) 的 capability-chain 编排:同能力内多 provider 有序 fallback,而不是硬编码 primary/fallback 两槽位。第三个 provider 进来后旧结构已经撑不住,这次一并泛化。

## 设计

**源链(source chain)**:`SearchService` 的 `sources`/`fallback_sources` 两字段替换为 `Vec<SourceSlot>`(`Active(provider)` / `Missing{spec}`)。补充源扇出与 generic fetch 按链序尝试,第一个返回可用结果的 provider 胜出;后位纯兜底,happy path 仍是"每次 web_search 恰好一次源调用"。

- 默认链序:`tavily → exa → tinyfish → firecrawl`(只遍历已配置的 provider)。
- `GROK_SEARCH_SOURCE_PROVIDERS=tinyfish,tavily` 可显式重排/裁剪;未知名启动即报错。
- 静态 `ProviderSpec` 注册表承载各 provider 的能力属性:`supports_filters`(filters 门控从"Firecrawl 特判"泛化为按属性跳过)、`supports_map`(web_map 仍 Tavily-only)、`core`(未配置的可选 provider 不进默认零结果诊断,不会被误读成坏凭证)。

**TinyFish**:一把 `TINYFISH_API_KEY` 驱动两个端点——`GET api.search.tinyfish.ai`(免费搜索,结构化 title/snippet/url/date)与 `POST api.fetch.tinyfish.ai`(JS 渲染 + PDF 抽取,markdown 输出)。domain 过滤按官方文档经 `site:`/`-site:` 操作符注入 query;`recency_days → recency_minutes`(上限十年)。`X-API-Key` 认证走 `providers/http.rs` 新增的 header-auth 辅助函数(与 bearer 路径共享同一响应处理)。注意:免费但免费档限速 30 req/min,且账户需开通 Search API 访问(402 语义已在文档标注)。

**Exa**:语义检索,原生 `includeDomains`/`excludeDomains`/`startPublishedDate`(SearchFilters 三个字段全部原生落地);fetch 走 `/contents`。Bearer 认证直接复用 `post_json`。`recency_days → startPublishedDate` 的日期换算手写 civil-from-days(约 20 行,不引日历依赖,含闰年/跨年测试)。

## 兼容性(零行为回归)

- 既有测试(288 个)一行未改全绿;来源标签泛化为 `{provider}_enrichment`/`{provider}_fallback`,tavily/firecrawl 取值不变(含 #30 的 `firecrawl_fallback`)。
- filters 门控与 #31 零结果诊断(SourceNote/remediation)语义逐字保留。
- 仅配 Tavily+Firecrawl 的用户行为与主干完全一致。
- 远端 HTTP 传输新增 `X-Tinyfish-Api-Key`/`X-Exa-Api-Key`;server 端同名 env key 照旧剥离。
- `doctor` 新增 `exa`/`tinyfish` 节点与 `source_chain` 字段(纯增量)。

## 验证

- `cargo test --all-features`:**316 passed, 0 failed**(新增 28 个:链序/override 校验/fall-through/filters 门控/标签 8 个,TinyFish 解析与请求构造 8 个,Exa 请求体与日期边界 6 个,config 新键 6 个)。
- `cargo clippy --all-features --all-targets`:0 告警;`cargo fmt --check` 干净。

## 后续(不在本 PR)

- `provider_attempts` 观测字段(输出契约变更,单独 PR 讨论)。
- Firecrawl v2 原生 `/map` 端点接入后可给它 `supports_map`。