### PR TITLE
feat: configurable Grok reasoning_effort (low..xhigh)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to GrokSearch-rs are documented here.
 ### Added
 
 - **Reasoning intensity (`reasoning_effort`).** Clients can pass
-  `low` / `medium` / `high` / `xhigh` / `max` three ways:
+  `low` / `medium` / `high` / `xhigh` three ways:
   1. **Tool arg** (stdio + remote HTTP): `web_search.reasoning_effort`
   2. **Server default**: env `GROK_SEARCH_REASONING_EFFORT`, TOML
      `reasoning_effort`, or remote header `X-Grok-Reasoning-Effort`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to GrokSearch-rs are documented here.
 
+## Unreleased
+
+### Added
+
+- **Reasoning intensity (`reasoning_effort`).** Clients can pass
+  `low` / `medium` / `high` / `xhigh` / `max` three ways:
+  1. **Tool arg** (stdio + remote HTTP): `web_search.reasoning_effort`
+  2. **Server default**: env `GROK_SEARCH_REASONING_EFFORT`, TOML
+     `reasoning_effort`, or remote header `X-Grok-Reasoning-Effort`
+  3. Precedence: tool arg > header/env/config > omit (provider default)
+
+  Upstream mapping:
+  - Responses API → nested `reasoning.effort`
+  - OpenAI-compatible chat-completions → top-level `reasoning_effort`
+
+  Invalid values are ignored (fall through to the next layer). `doctor`
+  reports the effective server default under `grok.reasoning_effort`.
+
 ## 0.1.24 - 2026-08-05
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ The MCP **transport** decides how config reaches the server — same values, dif
 | Grok API key | `GROK_SEARCH_API_KEY` | `X-Grok-Api-Key` |
 | Grok gateway URL | `GROK_SEARCH_URL` | `X-Grok-Base-Url` |
 | Grok model | `GROK_SEARCH_MODEL` | `X-Grok-Model` |
+| Grok reasoning effort | `GROK_SEARCH_REASONING_EFFORT` | `X-Grok-Reasoning-Effort` |
 | Tavily API key | `TAVILY_API_KEY` | `X-Tavily-Api-Key` |
 | Firecrawl API key | `FIRECRAWL_API_KEY` | `X-Firecrawl-Api-Key` |
 | TinyFish API key | `TINYFISH_API_KEY` | `X-Tinyfish-Api-Key` |
@@ -134,6 +135,7 @@ The tables below use env-key names (they also drive `config.toml` / stdio); on t
 | `GROK_SEARCH_AUTH_FILE` | `<home>/.config/grok-search-rs/auth.json` | Optional OAuth token file override. |
 | `GROK_SEARCH_URL` | `https://api.x.ai` | Root, `/v1`, or full‑endpoint URL. |
 | `GROK_SEARCH_MODEL` | `grok-4-1-fast-reasoning` | Model name. |
+| `GROK_SEARCH_REASONING_EFFORT` | — *(provider default)* | `low`/`medium`/`high`/`xhigh`/`max`. Also overridable via `web_search.reasoning_effort` or `X-Grok-Reasoning-Effort`. |
 | `GROK_SEARCH_WEB_SEARCH` | `true` | Offer `web_search` tool to Grok. |
 | `GROK_SEARCH_X_SEARCH` | `false` | Offer `x_search` tool (X/Twitter) to Grok. |
 
@@ -255,7 +257,7 @@ request carries the caller's own keys as headers, so many users can share one en
 each pays with their own keys:
 
 - `X-Grok-Api-Key`, `X-Tavily-Api-Key`, `X-Firecrawl-Api-Key` (optional `X-GitHub-Token`)
-- Optional non‑secret overrides: `X-Grok-Base-Url` (gateway), `X-Grok-Model` (model name, since model ids are gateway‑specific)
+- Optional non‑secret overrides: `X-Grok-Base-Url` (gateway), `X-Grok-Model` (model name, since model ids are gateway‑specific), `X-Grok-Reasoning-Effort` (`low`/`medium`/`high`/`xhigh`/`max`)
 
 This cuts both ways: setting `TAVILY_API_KEY` / `FIRECRAWL_API_KEY` in the **server's** own
 environment (compose file, `.env`, systemd unit) has no effect — those are stripped from every

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ The tables below use env-key names (they also drive `config.toml` / stdio); on t
 | `GROK_SEARCH_AUTH_FILE` | `<home>/.config/grok-search-rs/auth.json` | Optional OAuth token file override. |
 | `GROK_SEARCH_URL` | `https://api.x.ai` | Root, `/v1`, or full‑endpoint URL. |
 | `GROK_SEARCH_MODEL` | `grok-4-1-fast-reasoning` | Model name. |
-| `GROK_SEARCH_REASONING_EFFORT` | — *(provider default)* | `low`/`medium`/`high`/`xhigh`/`max`. Also overridable via `web_search.reasoning_effort` or `X-Grok-Reasoning-Effort`. |
+| `GROK_SEARCH_REASONING_EFFORT` | — *(provider default)* | `low`/`medium`/`high`/`xhigh`. Also overridable via `web_search.reasoning_effort` or `X-Grok-Reasoning-Effort`. |
 | `GROK_SEARCH_WEB_SEARCH` | `true` | Offer `web_search` tool to Grok. |
 | `GROK_SEARCH_X_SEARCH` | `false` | Offer `x_search` tool (X/Twitter) to Grok. |
 
@@ -257,7 +257,7 @@ request carries the caller's own keys as headers, so many users can share one en
 each pays with their own keys:
 
 - `X-Grok-Api-Key`, `X-Tavily-Api-Key`, `X-Firecrawl-Api-Key` (optional `X-GitHub-Token`)
-- Optional non‑secret overrides: `X-Grok-Base-Url` (gateway), `X-Grok-Model` (model name, since model ids are gateway‑specific), `X-Grok-Reasoning-Effort` (`low`/`medium`/`high`/`xhigh`/`max`)
+- Optional non‑secret overrides: `X-Grok-Base-Url` (gateway), `X-Grok-Model` (model name, since model ids are gateway‑specific), `X-Grok-Reasoning-Effort` (`low`/`medium`/`high`/`xhigh`)
 
 This cuts both ways: setting `TAVILY_API_KEY` / `FIRECRAWL_API_KEY` in the **server's** own
 environment (compose file, `.env`, systemd unit) has no effect — those are stripped from every

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -74,7 +74,7 @@ Local (stdio) — the same values as `env`:
 | `GROK_SEARCH_AUTH_FILE` | `<home>/.config/grok-search-rs/auth.json` | Optional OAuth token file override. |
 | `GROK_SEARCH_URL` | `https://api.x.ai` | Root URL, `/v1` base URL, or endpoint-like URL. The service normalizes it to a `/v1` base. |
 | `GROK_SEARCH_MODEL` | `grok-4-1-fast-reasoning` | Model sent in the Responses payload. |
-| `GROK_SEARCH_REASONING_EFFORT` | unset (provider default) | Optional reasoning intensity: `low` \| `medium` \| `high` \| `xhigh` \| `max`. Responses payload uses nested `reasoning.effort`; chat-completions uses top-level `reasoning_effort`. Overridable per request via `X-Grok-Reasoning-Effort` (HTTP) or the `web_search.reasoning_effort` tool arg (stdio + HTTP). |
+| `GROK_SEARCH_REASONING_EFFORT` | unset (provider default) | Optional reasoning intensity: `low` | `medium` | `high` | `xhigh`. Responses payload uses nested `reasoning.effort`; chat-completions uses top-level `reasoning_effort`. Overridable per request via `X-Grok-Reasoning-Effort` (HTTP) or the `web_search.reasoning_effort` tool arg (stdio + HTTP). |
 | `GROK_SEARCH_WEB_SEARCH` | `true` | Sends Responses `{"type":"web_search"}`. |
 | `GROK_SEARCH_X_SEARCH` | `false` | Sends Responses `{"type":"x_search"}` only when enabled. |
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -24,13 +24,14 @@ Both carry the **same configuration values** — only the delivery differs. Ever
 | Grok API key | `GROK_SEARCH_API_KEY` | `X-Grok-Api-Key` |
 | Grok gateway URL | `GROK_SEARCH_URL` | `X-Grok-Base-Url` |
 | Grok model | `GROK_SEARCH_MODEL` | `X-Grok-Model` |
+| Grok reasoning effort | `GROK_SEARCH_REASONING_EFFORT` | `X-Grok-Reasoning-Effort` |
 | Tavily API key | `TAVILY_API_KEY` | `X-Tavily-Api-Key` |
 | Firecrawl API key | `FIRECRAWL_API_KEY` | `X-Firecrawl-Api-Key` |
 | TinyFish API key | `TINYFISH_API_KEY` | `X-Tinyfish-Api-Key` |
 | Exa API key | `EXA_API_KEY` | `X-Exa-Api-Key` |
 | GitHub token | `GITHUB_TOKEN` | `X-GitHub-Token` |
 
-Only these eight are accepted as headers — the caller's per-request secrets plus the gateway/model that pair with the caller's key. Most other settings here (timeouts, budgets, enrichment knobs, Tavily/Firecrawl base URLs, feature toggles) are **operator-fixed**: set once in the server's own environment, never per request. `GROK_SEARCH_URL` / `GROK_SEARCH_MODEL` have operator defaults too; the `X-Grok-Base-Url` / `X-Grok-Model` headers override them per request. **Two groups are stdio-only — stripped over HTTP, not operator-fixed:** OAuth (`GROK_SEARCH_AUTH_MODE` / `GROK_SEARCH_AUTH_FILE`) and the OpenAI-compatible chat-completions transport (`OPENAI_COMPATIBLE_API_URL` / `_API_KEY` / `_MODEL`). The remote server serves Grok **Responses** only; to run a chat-completions relay, use the stdio transport.
+Only these nine are accepted as headers — the caller's per-request secrets plus the gateway/model/reasoning that pair with the caller's key. Most other settings here (timeouts, budgets, enrichment knobs, Tavily/Firecrawl base URLs, feature toggles) are **operator-fixed**: set once in the server's own environment, never per request. `GROK_SEARCH_URL` / `GROK_SEARCH_MODEL` / `GROK_SEARCH_REASONING_EFFORT` have operator defaults too; the `X-Grok-Base-Url` / `X-Grok-Model` / `X-Grok-Reasoning-Effort` headers override them per request. **Two groups are stdio-only — stripped over HTTP, not operator-fixed:** OAuth (`GROK_SEARCH_AUTH_MODE` / `GROK_SEARCH_AUTH_FILE`) and the OpenAI-compatible chat-completions transport (`OPENAI_COMPATIBLE_API_URL` / `_API_KEY` / `_MODEL`). The remote server serves Grok **Responses** only; to run a chat-completions relay, use the stdio transport.
 
 The header is `X-` + the env key in `Kebab-Case`, but a few names are historical (the `GROK_SEARCH_` prefix collapses to `X-Grok-`, and `GROK_SEARCH_URL` → `X-Grok-Base-Url`) — **read names off the table above rather than deriving them by hand.**
 
@@ -73,6 +74,7 @@ Local (stdio) — the same values as `env`:
 | `GROK_SEARCH_AUTH_FILE` | `<home>/.config/grok-search-rs/auth.json` | Optional OAuth token file override. |
 | `GROK_SEARCH_URL` | `https://api.x.ai` | Root URL, `/v1` base URL, or endpoint-like URL. The service normalizes it to a `/v1` base. |
 | `GROK_SEARCH_MODEL` | `grok-4-1-fast-reasoning` | Model sent in the Responses payload. |
+| `GROK_SEARCH_REASONING_EFFORT` | unset (provider default) | Optional reasoning intensity: `low` \| `medium` \| `high` \| `xhigh` \| `max`. Responses payload uses nested `reasoning.effort`; chat-completions uses top-level `reasoning_effort`. Overridable per request via `X-Grok-Reasoning-Effort` (HTTP) or the `web_search.reasoning_effort` tool arg (stdio + HTTP). |
 | `GROK_SEARCH_WEB_SEARCH` | `true` | Sends Responses `{"type":"web_search"}`. |
 | `GROK_SEARCH_X_SEARCH` | `false` | Sends Responses `{"type":"x_search"}` only when enabled. |
 
@@ -233,6 +235,7 @@ Unknown keys are rejected by the loader — typos surface as parse errors instea
 | `grok_auth_mode` | `GROK_SEARCH_AUTH_MODE` |
 | `grok_auth_file` | `GROK_SEARCH_AUTH_FILE` |
 | `grok_model` | `GROK_SEARCH_MODEL` |
+| `reasoning_effort` | `GROK_SEARCH_REASONING_EFFORT` |
 | `web_search_enabled` | `GROK_SEARCH_WEB_SEARCH` |
 | `x_search_enabled` | `GROK_SEARCH_X_SEARCH` |
 | `tavily_api_url` | `TAVILY_API_URL` |

--- a/src/adapters/chat_completions_request.rs
+++ b/src/adapters/chat_completions_request.rs
@@ -44,5 +44,14 @@ pub fn to_chat_completions_payload(
     if include_web_search_tool {
         payload["tools"] = json!([{ "type": "web_search" }]);
     }
+    if let Some(effort) = req
+        .reasoning_effort
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        // OpenAI-compatible / xAI chat completions: top-level string.
+        payload["reasoning_effort"] = json!(effort);
+    }
     payload
 }

--- a/src/adapters/grok_responses_request.rs
+++ b/src/adapters/grok_responses_request.rs
@@ -42,10 +42,21 @@ pub fn to_grok_responses_payload(
         tools.push(json!({ "type": "x_search" }));
     }
 
-    Ok(json!({
+    let mut payload = json!({
         "model": req.model,
         "input": input,
         "tools": tools,
         "stream": false
-    }))
+    });
+    if let Some(effort) = req
+        .reasoning_effort
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        // xAI Responses API: nested `reasoning.effort` (chat uses top-level
+        // `reasoning_effort` — see chat_completions_request).
+        payload["reasoning"] = json!({ "effort": effort });
+    }
+    Ok(payload)
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -59,7 +59,7 @@ pub struct Config {
     pub response_max_chars: usize,
     /// Default reasoning intensity for Grok/OpenAI-compatible upstreams.
     /// `None` = omit the field (provider default). Values:
-    /// `low` | `medium` | `high` | `xhigh` | `max`.
+    /// `low` | `medium` | `high` | `xhigh`.
     pub reasoning_effort: Option<String>,
 }
 
@@ -551,7 +551,7 @@ pub const CONFIG_TEMPLATE: &str = r#"# grok-search-rs global configuration
 
 # ── Common knobs ──────────────────────────────────────────────
 # grok_model         = "grok-4-1-fast-reasoning"
-# reasoning_effort   = "high"         # low|medium|high|xhigh|max (omit = provider default)
+# reasoning_effort   = "high"         # low|medium|high|xhigh (omit = provider default)
 # x_search_enabled   = false          # Grok X/Twitter search tool
 # firecrawl_api_key  = "fc-..."       # Optional fetch fallback   https://firecrawl.dev
 # tinyfish_api_key   = "tf-..."       # Optional free search/fetch  https://tinyfish.ai
@@ -694,7 +694,7 @@ fn auth_mode_value(map: &HashMap<String, String>) -> AuthMode {
 }
 
 /// Parse and normalize a reasoning-effort setting.
-/// Accepted: `low` | `medium` | `high` | `xhigh` | `max` (case-insensitive).
+/// Accepted: `low` | `medium` | `high` | `xhigh` (case-insensitive).
 /// Blank/absent → `None` (omit the field; provider default applies).
 /// Unknown values warn and fall back to `None`.
 fn reasoning_effort_value(map: &HashMap<String, String>, key: &str) -> Option<String> {
@@ -703,9 +703,7 @@ fn reasoning_effort_value(map: &HashMap<String, String>, key: &str) -> Option<St
         return None;
     }
     parse_reasoning_effort(raw).or_else(|| {
-        eprintln!(
-            "unknown {key}=\"{raw}\"; ignoring. Valid values: low, medium, high, xhigh, max."
-        );
+        eprintln!("unknown {key}=\"{raw}\"; ignoring. Valid values: low, medium, high, xhigh.");
         None
     })
 }
@@ -715,7 +713,7 @@ fn reasoning_effort_value(map: &HashMap<String, String>, key: &str) -> Option<St
 pub fn parse_reasoning_effort(raw: &str) -> Option<String> {
     let value = raw.trim().to_ascii_lowercase();
     match value.as_str() {
-        "low" | "medium" | "high" | "xhigh" | "max" => Some(value),
+        "low" | "medium" | "high" | "xhigh" => Some(value),
         _ => None,
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -57,6 +57,10 @@ pub struct Config {
     pub enrich_max_chars: usize,
     pub max_inline_sources: usize,
     pub response_max_chars: usize,
+    /// Default reasoning intensity for Grok/OpenAI-compatible upstreams.
+    /// `None` = omit the field (provider default). Values:
+    /// `low` | `medium` | `high` | `xhigh` | `max`.
+    pub reasoning_effort: Option<String>,
 }
 
 /// Hand-written `Debug` that masks secret-bearing fields so a stray
@@ -113,6 +117,7 @@ impl std::fmt::Debug for Config {
             .field("enrich_max_chars", &self.enrich_max_chars)
             .field("max_inline_sources", &self.max_inline_sources)
             .field("response_max_chars", &self.response_max_chars)
+            .field("reasoning_effort", &self.reasoning_effort)
             .finish()
     }
 }
@@ -158,6 +163,7 @@ struct ConfigFile {
     enrich_max_chars: Option<usize>,
     max_inline_sources: Option<usize>,
     response_max_chars: Option<usize>,
+    reasoning_effort: Option<String>,
 }
 
 impl ConfigFile {
@@ -254,6 +260,7 @@ impl ConfigFile {
             "GROK_SEARCH_RESPONSE_MAX_CHARS",
             self.response_max_chars.map(|n| n.to_string()),
         );
+        insert("GROK_SEARCH_REASONING_EFFORT", self.reasoning_effort);
         out
     }
 }
@@ -387,6 +394,7 @@ impl Config {
             enrich_max_chars: usize_value(&map, "GROK_SEARCH_ENRICH_MAX_CHARS", 15000),
             max_inline_sources: usize_value(&map, "GROK_SEARCH_MAX_INLINE_SOURCES", 5),
             response_max_chars: usize_value(&map, "GROK_SEARCH_RESPONSE_MAX_CHARS", 45_000),
+            reasoning_effort: reasoning_effort_value(&map, "GROK_SEARCH_REASONING_EFFORT"),
         }
     }
 
@@ -402,7 +410,7 @@ impl Config {
 
     pub fn redacted_diagnostics(&self) -> String {
         format!(
-            "grok_api_url={} grok_api_key={} grok_auth_mode={:?} grok_auth_file={} grok_model={} web_search_enabled={} x_search_enabled={} tavily_api_key={} firecrawl_api_key={} tinyfish_api_key={} exa_api_key={} default_extra_sources={} fallback_sources={} timeout_seconds={} github_token={}",
+            "grok_api_url={} grok_api_key={} grok_auth_mode={:?} grok_auth_file={} grok_model={} reasoning_effort={} web_search_enabled={} x_search_enabled={} tavily_api_key={} firecrawl_api_key={} tinyfish_api_key={} exa_api_key={} default_extra_sources={} fallback_sources={} timeout_seconds={} github_token={}",
             self.grok_api_url,
             redact(self.grok_api_key.as_deref()),
             self.grok_auth_mode,
@@ -411,6 +419,7 @@ impl Config {
                 .map(|p| p.display().to_string())
                 .unwrap_or_else(|| "default".to_string()),
             self.grok_model,
+            self.reasoning_effort.as_deref().unwrap_or("unset"),
             self.web_search_enabled,
             self.x_search_enabled,
             redact(self.tavily_api_key.as_deref()),
@@ -542,6 +551,7 @@ pub const CONFIG_TEMPLATE: &str = r#"# grok-search-rs global configuration
 
 # ── Common knobs ──────────────────────────────────────────────
 # grok_model         = "grok-4-1-fast-reasoning"
+# reasoning_effort   = "high"         # low|medium|high|xhigh|max (omit = provider default)
 # x_search_enabled   = false          # Grok X/Twitter search tool
 # firecrawl_api_key  = "fc-..."       # Optional fetch fallback   https://firecrawl.dev
 # tinyfish_api_key   = "tf-..."       # Optional free search/fetch  https://tinyfish.ai
@@ -680,6 +690,33 @@ fn auth_mode_value(map: &HashMap<String, String>) -> AuthMode {
             AuthMode::ApiKey
         }
         _ => AuthMode::ApiKey,
+    }
+}
+
+/// Parse and normalize a reasoning-effort setting.
+/// Accepted: `low` | `medium` | `high` | `xhigh` | `max` (case-insensitive).
+/// Blank/absent → `None` (omit the field; provider default applies).
+/// Unknown values warn and fall back to `None`.
+fn reasoning_effort_value(map: &HashMap<String, String>, key: &str) -> Option<String> {
+    let raw = map.get(key)?.trim();
+    if raw.is_empty() {
+        return None;
+    }
+    parse_reasoning_effort(raw).or_else(|| {
+        eprintln!(
+            "unknown {key}=\"{raw}\"; ignoring. Valid values: low, medium, high, xhigh, max."
+        );
+        None
+    })
+}
+
+/// Normalize a free-form reasoning-effort string. Returns `None` for blank or
+/// unrecognized values (caller decides whether to warn).
+pub fn parse_reasoning_effort(raw: &str) -> Option<String> {
+    let value = raw.trim().to_ascii_lowercase();
+    match value.as_str() {
+        "low" | "medium" | "high" | "xhigh" | "max" => Some(value),
+        _ => None,
     }
 }
 

--- a/src/http.rs
+++ b/src/http.rs
@@ -81,6 +81,9 @@ const HEADER_TO_ENV: &[(&str, &str)] = &[
     // X-Grok-Base-Url, since model names are gateway-specific). Absent header
     // -> the operator default model.
     ("x-grok-model", "GROK_SEARCH_MODEL"),
+    // Non-secret: per-request reasoning intensity override. Absent header ->
+    // the operator default (`GROK_SEARCH_REASONING_EFFORT`) or provider default.
+    ("x-grok-reasoning-effort", "GROK_SEARCH_REASONING_EFFORT"),
 ];
 
 #[derive(Clone)]
@@ -703,15 +706,18 @@ mod tests {
                 ("X-Grok-Api-Key", "xai-caller"),
                 ("X-Tavily-Api-Key", "tvly-caller"),
                 ("X-Grok-Model", "grok-caller-model"),
+                ("X-Grok-Reasoning-Effort", "xhigh"),
             ]),
             None,
         );
         assert_eq!(cfg.grok_api_key.as_deref(), Some("xai-caller"));
         assert_eq!(cfg.tavily_api_key.as_deref(), Some("tvly-caller"));
         assert_eq!(cfg.grok_model, "grok-caller-model");
+        assert_eq!(cfg.reasoning_effort.as_deref(), Some("xhigh"));
         // Absent model header -> operator default survives.
         let default_cfg = request_config(&base(), &headers(&[]), None);
         assert_eq!(default_cfg.grok_model, "grok-4-1-fast-reasoning");
+        assert_eq!(default_cfg.reasoning_effort, None);
     }
 
     #[test]

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -276,8 +276,8 @@ fn tools_list() -> Value {
                         },
                         "reasoning_effort": {
                             "type": "string",
-                            "enum": ["low", "medium", "high", "xhigh", "max"],
-                            "description": "Optional per-call reasoning intensity for the Grok / OpenAI-compatible upstream. Responses sends reasoning.effort; chat-completions sends top-level reasoning_effort. low/medium/high are depth knobs; xhigh is multi-agent scale (e.g. grok-4.20-multi-agent); max is accepted for client compatibility. When omitted, uses GROK_SEARCH_REASONING_EFFORT / X-Grok-Reasoning-Effort, else the provider default."
+                            "enum": ["low", "medium", "high", "xhigh"],
+                            "description": "Optional per-call reasoning intensity for the Grok / OpenAI-compatible upstream. Responses sends reasoning.effort; chat-completions sends top-level reasoning_effort. low/medium/high are depth knobs; xhigh is multi-agent scale (e.g. grok-4.20-multi-agent). When omitted, uses GROK_SEARCH_REASONING_EFFORT / X-Grok-Reasoning-Effort, else the provider default."
                         }
                     }
                 }
@@ -596,7 +596,7 @@ mod tests {
         let effort_enum = props["reasoning_effort"]["enum"]
             .as_array()
             .expect("reasoning_effort enum");
-        for level in ["low", "medium", "high", "xhigh", "max"] {
+        for level in ["low", "medium", "high", "xhigh"] {
             assert!(
                 effort_enum.iter().any(|v| v == level),
                 "missing {level} in {effort_enum:?}"

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -165,6 +165,13 @@ async fn call_tool(service: &SearchService, name: &str, args: Value) -> Result<V
                     .get("response_format")
                     .and_then(Value::as_str)
                     .map(str::to_string),
+                // Per-call reasoning intensity. Validated/normalized here so a
+                // hallucinated value does not poison the upstream payload; bad
+                // values fall through to the server default.
+                reasoning_effort: args
+                    .get("reasoning_effort")
+                    .and_then(Value::as_str)
+                    .and_then(crate::config::parse_reasoning_effort),
             };
             let output = service.web_search(input).await?;
             Ok(serde_json::to_value(output)
@@ -266,6 +273,11 @@ fn tools_list() -> Value {
                             "type": "string",
                             "enum": ["concise", "detailed"],
                             "description": "concise = synthesized answer + source metadata only (smallest payload); detailed = inline source content, subject to the response budget. Takes precedence over include_content."
+                        },
+                        "reasoning_effort": {
+                            "type": "string",
+                            "enum": ["low", "medium", "high", "xhigh", "max"],
+                            "description": "Optional per-call reasoning intensity for the Grok / OpenAI-compatible upstream. Responses sends reasoning.effort; chat-completions sends top-level reasoning_effort. low/medium/high are depth knobs; xhigh is multi-agent scale (e.g. grok-4.20-multi-agent); max is accepted for client compatibility. When omitted, uses GROK_SEARCH_REASONING_EFFORT / X-Grok-Reasoning-Effort, else the provider default."
                         }
                     }
                 }
@@ -577,5 +589,18 @@ mod tests {
             props.contains_key("response_format"),
             "response_format must remain: {props:?}"
         );
+        assert!(
+            props.contains_key("reasoning_effort"),
+            "reasoning_effort must be exposed: {props:?}"
+        );
+        let effort_enum = props["reasoning_effort"]["enum"]
+            .as_array()
+            .expect("reasoning_effort enum");
+        for level in ["low", "medium", "high", "xhigh", "max"] {
+            assert!(
+                effort_enum.iter().any(|v| v == level),
+                "missing {level} in {effort_enum:?}"
+            );
+        }
     }
 }

--- a/src/model/search.rs
+++ b/src/model/search.rs
@@ -9,7 +9,7 @@ pub struct SearchRequest {
     pub tools: Vec<SearchTool>,
     /// Optional reasoning effort for Grok / OpenAI-compatible gateways.
     /// Responses: `reasoning.effort`. Chat Completions: top-level `reasoning_effort`.
-    /// Values: `low` | `medium` | `high` | `xhigh` | `max`.
+    /// Values: `low` | `medium` | `high` | `xhigh`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub reasoning_effort: Option<String>,
 }

--- a/src/model/search.rs
+++ b/src/model/search.rs
@@ -7,6 +7,11 @@ pub struct SearchRequest {
     pub system: Option<String>,
     pub messages: Vec<SearchMessage>,
     pub tools: Vec<SearchTool>,
+    /// Optional reasoning effort for Grok / OpenAI-compatible gateways.
+    /// Responses: `reasoning.effort`. Chat Completions: top-level `reasoning_effort`.
+    /// Values: `low` | `medium` | `high` | `xhigh` | `max`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reasoning_effort: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/src/model/tool.rs
+++ b/src/model/tool.rs
@@ -19,6 +19,10 @@ pub struct WebSearchInput {
     /// content, subject to the response budget). When set, takes precedence
     /// over the legacy `include_content` flag.
     pub response_format: Option<String>,
+    /// Per-call reasoning intensity override: `low` | `medium` | `high` |
+    /// `xhigh` | `max`. When set, beats the server default
+    /// (`GROK_SEARCH_REASONING_EFFORT` / `X-Grok-Reasoning-Effort`).
+    pub reasoning_effort: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/src/model/tool.rs
+++ b/src/model/tool.rs
@@ -20,7 +20,7 @@ pub struct WebSearchInput {
     /// over the legacy `include_content` flag.
     pub response_format: Option<String>,
     /// Per-call reasoning intensity override: `low` | `medium` | `high` |
-    /// `xhigh` | `max`. When set, beats the server default
+    /// `xhigh`. When set, beats the server default
     /// (`GROK_SEARCH_REASONING_EFFORT` / `X-Grok-Reasoning-Effort`).
     pub reasoning_effort: Option<String>,
 }

--- a/src/service.rs
+++ b/src/service.rs
@@ -1285,6 +1285,7 @@ impl SearchService {
                     .unwrap_or_else(|| "unavailable".to_string()),
                 "web_search_enabled": self.config.web_search_enabled,
                 "x_search_enabled": ai_x_search_enabled,
+                "reasoning_effort": self.config.reasoning_effort,
                 "reachable": grok_probe.ok,
                 "detail": grok_probe.detail,
             },
@@ -1358,6 +1359,7 @@ impl SearchService {
                 content: vec![ContentBlock::text("ping")],
             }],
             tools,
+            reasoning_effort: self.config.reasoning_effort.clone(),
         };
         match self.ai.search(&request).await {
             Ok(_) => Probe::ok("grok responded"),
@@ -1412,6 +1414,11 @@ impl SearchService {
                 content: vec![ContentBlock::text(content)],
             }],
             tools: vec![SearchTool::web_search()],
+            // Per-call tool arg wins; else operator/server default (env/header/config).
+            reasoning_effort: input
+                .reasoning_effort
+                .clone()
+                .or_else(|| self.config.reasoning_effort.clone()),
         }
     }
 }

--- a/tests/adapter_grok_responses.rs
+++ b/tests/adapter_grok_responses.rs
@@ -11,6 +11,7 @@ fn sample_request() -> SearchRequest {
             content: vec![ContentBlock::text("latest OpenAI announcement")],
         }],
         tools: vec![SearchTool::web_search()],
+        reasoning_effort: None,
     }
 }
 
@@ -24,6 +25,18 @@ fn grok_responses_payload_includes_web_search_by_default() {
     assert_eq!(payload["input"][1]["role"], "user");
     assert_eq!(payload["tools"][0]["type"], "web_search");
     assert_eq!(payload["tools"].as_array().unwrap().len(), 1);
+    assert!(
+        payload.get("reasoning").is_none(),
+        "reasoning must be omitted when effort is unset"
+    );
+}
+
+#[test]
+fn grok_responses_payload_includes_reasoning_effort_when_set() {
+    let mut req = sample_request();
+    req.reasoning_effort = Some("xhigh".into());
+    let payload = to_grok_responses_payload(&req, true, false).expect("payload");
+    assert_eq!(payload["reasoning"]["effort"], "xhigh");
 }
 
 #[test]

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -20,6 +20,19 @@ fn config_reads_grok_search_responses_defaults() {
     assert_eq!(cfg.fallback_sources, 5);
     assert_eq!(cfg.timeout.as_secs(), 60);
     assert_eq!(cfg.grok_auth_mode, AuthMode::ApiKey);
+    assert_eq!(cfg.reasoning_effort, None);
+}
+
+#[test]
+fn config_reads_reasoning_effort() {
+    let cfg = Config::from_env_map([
+        ("GROK_SEARCH_API_KEY", "grok-test-key"),
+        ("GROK_SEARCH_REASONING_EFFORT", "XHigh"),
+    ]);
+    assert_eq!(cfg.reasoning_effort.as_deref(), Some("xhigh"));
+
+    let bad = Config::from_env_map([("GROK_SEARCH_REASONING_EFFORT", "ultra")]);
+    assert_eq!(bad.reasoning_effort, None);
 }
 
 #[test]

--- a/tests/integration_compat.rs
+++ b/tests/integration_compat.rs
@@ -34,6 +34,7 @@ async fn chat_completions_e2e_returns_text_and_sources() {
             )],
         }],
         tools: vec![SearchTool::web_search()],
+        reasoning_effort: None,
     };
 
     let resp = provider.search(&req).await.expect("e2e search");

--- a/tests/integration_service.rs
+++ b/tests/integration_service.rs
@@ -39,6 +39,7 @@ async fn full_service_web_search_via_chat_completions() {
             model: None,
             include_content: None,
             response_format: None,
+            reasoning_effort: None,
         })
         .await
         .expect("web_search");

--- a/tests/openai_compatible_adapter.rs
+++ b/tests/openai_compatible_adapter.rs
@@ -11,6 +11,7 @@ fn sample_request() -> SearchRequest {
             content: vec![ContentBlock::text("hello")],
         }],
         tools: vec![SearchTool::web_search()],
+        reasoning_effort: None,
     }
 }
 
@@ -23,6 +24,18 @@ fn payload_includes_tools_when_web_search_enabled() {
     assert_eq!(payload["messages"][0]["role"], "system");
     assert_eq!(payload["messages"][1]["role"], "user");
     assert_eq!(payload["messages"][1]["content"], "hello");
+    assert!(
+        payload.get("reasoning_effort").is_none(),
+        "reasoning_effort must be omitted when unset"
+    );
+}
+
+#[test]
+fn payload_includes_reasoning_effort_when_set() {
+    let mut req = sample_request();
+    req.reasoning_effort = Some("high".into());
+    let payload = to_chat_completions_payload(&req, "grok-4.3-fast", true);
+    assert_eq!(payload["reasoning_effort"], "high");
 }
 
 #[test]


### PR DESCRIPTION
## Summary / 摘要

Add optional **reasoning intensity** for Grok / OpenAI-compatible upstreams.

为 Grok / OpenAI 兼容上游增加可选的 **推理强度**。

- Values / 取值: `low` | `medium` | `high` | `xhigh` (**no `max`**)
- Responses API → nested `reasoning.effort`
- Chat Completions → top-level `reasoning_effort`

## Motivation / 动机

xAI models honor `reasoning.effort` / `reasoning_effort` (depth on Grok 4.5; agent scale on multi-agent). Operators need a server default; remote BYOK clients need a header; MCP callers also benefit from an optional per-call tool argument that can override the server default.

xAI 模型支持 `reasoning.effort` / `reasoning_effort`（4.5 控深度；multi-agent 控 agent 规模）。运营方需要服务端默认；远程 BYOK 需要请求头；MCP 调用方也可通过可选工具参数按次覆盖默认值。

## Changes / 改动

### Config / 配置
- Env: `GROK_SEARCH_REASONING_EFFORT`
- TOML: `reasoning_effort`
- Invalid values ignored (provider default)

### Remote HTTP
- Header: `X-Grok-Reasoning-Effort`

### MCP tool arg
- `web_search.reasoning_effort` enum: `low`/`medium`/`high`/`xhigh`
- **Precedence**: tool arg > header/env/config > omit (provider default)

### Upstream payload
- Responses: `{"reasoning":{"effort":"..."}}` when set
- Chat Completions: `"reasoning_effort":"..."` when set
- Unset → field omitted

### Docs
- README / CONFIGURATION / CHANGELOG

## Test Plan / 测试计划

- [x] Unit/integration tests green locally
- [x] HTTP feature tests for header overlay
- [x] release-http build
- [x] Live tools/list includes `reasoning_effort` without `max`
- [ ] Upstream CI

## Notes for Reviewers / 给 Reviewer

- Tool-arg is intentional and can override server default.
- `max` was considered for client compatibility and **removed** — only low..xhigh.
- Remote HTTP remains BYOK.