### PR TITLE
feat(doctor): report what became of the config file

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -57,6 +57,47 @@ pub struct Config {
     pub enrich_max_chars: usize,
     pub max_inline_sources: usize,
     pub response_max_chars: usize,
+    /// Where the config file was looked for, whether or not one was there.
+    /// Worth reporting even when absent — it tells the operator where to put
+    /// one.
+    pub config_file_path: Option<PathBuf>,
+    /// What became of that file. Rejection is deliberate — one unknown key
+    /// voids the whole file rather than half-applying it — but the only sign
+    /// of it used to be a line on stderr, which an MCP client swallows,
+    /// leaving the operator staring at defaults with no way to learn why.
+    pub config_file_state: ConfigFileState,
+}
+
+/// The outcome of loading the config file.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub enum ConfigFileState {
+    /// Nothing at the resolved path, or no path could be resolved. Not a
+    /// failure: running purely on environment variables is normal.
+    #[default]
+    Absent,
+    Loaded,
+    /// Present but unusable, with the reason attached verbatim so the operator
+    /// sees which key or line is at fault.
+    Rejected(String),
+}
+
+impl ConfigFileState {
+    /// Stable label for diagnostics output.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            ConfigFileState::Absent => "absent",
+            ConfigFileState::Loaded => "loaded",
+            ConfigFileState::Rejected(_) => "rejected",
+        }
+    }
+
+    /// The rejection reason, if this is a rejection.
+    pub fn detail(&self) -> Option<&str> {
+        match self {
+            ConfigFileState::Rejected(detail) => Some(detail),
+            _ => None,
+        }
+    }
 }
 
 /// Hand-written `Debug` that masks secret-bearing fields so a stray
@@ -113,6 +154,8 @@ impl std::fmt::Debug for Config {
             .field("enrich_max_chars", &self.enrich_max_chars)
             .field("max_inline_sources", &self.max_inline_sources)
             .field("response_max_chars", &self.response_max_chars)
+            .field("config_file_path", &self.config_file_path)
+            .field("config_file_state", &self.config_file_state)
             .finish()
     }
 }
@@ -280,10 +323,15 @@ impl Config {
             .into_iter()
             .map(|(k, v)| (k.into(), v.into()))
             .collect();
-        let file_map = resolve_config_path(&env_map)
-            .and_then(|path| load_file_map(&path))
-            .unwrap_or_default();
-        Self::from_env_map(merge_env_over_file(file_map, env_map))
+        let path = resolve_config_path(&env_map);
+        let (file_map, config_file_state) = match path.as_deref() {
+            Some(path) => read_config_file(path),
+            None => (HashMap::new(), ConfigFileState::Absent),
+        };
+        let mut config = Self::from_env_map(merge_env_over_file(file_map, env_map));
+        config.config_file_path = path;
+        config.config_file_state = config_file_state;
+        config
     }
 
     pub fn from_env() -> Self {
@@ -387,6 +435,10 @@ impl Config {
             enrich_max_chars: usize_value(&map, "GROK_SEARCH_ENRICH_MAX_CHARS", 15000),
             max_inline_sources: usize_value(&map, "GROK_SEARCH_MAX_INLINE_SOURCES", 5),
             response_max_chars: usize_value(&map, "GROK_SEARCH_RESPONSE_MAX_CHARS", 45_000),
+            // This is the environment-only constructor; no file was consulted.
+            // `load_from` overwrites both after merging one in.
+            config_file_path: None,
+            config_file_state: ConfigFileState::Absent,
         }
     }
 
@@ -589,17 +641,30 @@ pub const CONFIG_TEMPLATE: &str = r#"# grok-search-rs global configuration
 # response_max_chars    = 45000      # whole-response char budget (answer + inline content); kept below the MCP client token ceiling (default ~25k tokens) after JSON serialization
 "#;
 
-fn load_file_map(path: &Path) -> Option<HashMap<String, String>> {
-    let body = std::fs::read_to_string(path).ok()?;
+/// Read and parse the config file, reporting what happened alongside whatever
+/// values survived. A missing file is `Absent`, not a failure — running purely
+/// on environment variables is normal. Anything present but unusable is
+/// `Rejected` with the reason attached, so the caller can surface it somewhere
+/// the operator will actually look.
+fn read_config_file(path: &Path) -> (HashMap<String, String>, ConfigFileState) {
+    let body = match std::fs::read_to_string(path) {
+        Ok(body) => body,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+            return (HashMap::new(), ConfigFileState::Absent)
+        }
+        Err(err) => return (HashMap::new(), ConfigFileState::Rejected(err.to_string())),
+    };
     match toml::from_str::<ConfigFile>(&body) {
-        Ok(file) => Some(file.into_env_map()),
+        Ok(file) => (file.into_env_map(), ConfigFileState::Loaded),
         Err(err) => {
+            // Kept for anyone running the binary directly; the recorded state
+            // is what reaches an MCP client.
             eprintln!(
                 "grok-search-rs: ignoring malformed config {}: {}",
                 path.display(),
                 err
             );
-            None
+            (HashMap::new(), ConfigFileState::Rejected(err.to_string()))
         }
     }
 }

--- a/src/service.rs
+++ b/src/service.rs
@@ -1314,6 +1314,19 @@ impl SearchService {
                 "detail": firecrawl_probe.detail,
             },
             "source_chain": source_chain,
+            // Whether the config file was read at all, and why not when it was
+            // not. Without this a rejected file is indistinguishable from an
+            // absent one: both leave every setting at its default, and the
+            // only account of the difference went to stderr, which an MCP
+            // client swallows.
+            "config_file": {
+                "path": self.config
+                    .config_file_path
+                    .as_ref()
+                    .map(|path| path.display().to_string()),
+                "state": self.config.config_file_state.as_str(),
+                "detail": self.config.config_file_state.detail(),
+            },
             "default_extra_sources": self.config.default_extra_sources,
             "fallback_sources": self.config.fallback_sources,
             "cache_size": self.config.cache_size,
@@ -2765,6 +2778,81 @@ mod transport_dispatch_tests {
         };
         let report_unset = svc_unset.doctor().await;
         assert_eq!(report_unset["github_token"], "unset");
+    }
+
+    /// Build a service around a config whose file outcome the test dictates.
+    fn service_for_config(config: Config) -> SearchService {
+        SearchService {
+            default_model: resolve_default_model(&config),
+            config,
+            ai: Arc::new(FakeAiProvider),
+            source_slots: Arc::new(Vec::new()),
+            cache: Arc::new(Mutex::new(SourceCache::new(16))),
+            http_client: crate::providers::http::build_client(std::time::Duration::from_secs(30)),
+            source_router: Arc::new(crate::sources::SourceRouter::default()),
+        }
+    }
+
+    #[tokio::test]
+    async fn doctor_reports_a_rejected_config_file_and_why() {
+        // The whole point: a typo used to void the entire file with nothing to
+        // show for it but a stderr line the client swallowed, leaving the
+        // operator to conclude their key "wasn't configured" (issue #35).
+        let mut config = Config::from_env_map([("GROK_SEARCH_API_KEY", "xai-fake")]);
+        config.config_file_path = Some(std::path::PathBuf::from("/tmp/does-not-matter.toml"));
+        config.config_file_state =
+            crate::config::ConfigFileState::Rejected("unknown field `tavly_api_key`".to_string());
+
+        let report = service_for_config(config).doctor().await;
+
+        assert_eq!(report["config_file"]["state"], "rejected");
+        assert_eq!(
+            report["config_file"]["path"], "/tmp/does-not-matter.toml",
+            "the operator needs to know which file: {report}"
+        );
+        assert!(
+            report["config_file"]["detail"]
+                .as_str()
+                .expect("a rejection carries its reason")
+                .contains("tavly_api_key"),
+            "the reason must name the offending key: {report}"
+        );
+    }
+
+    #[tokio::test]
+    async fn doctor_distinguishes_an_absent_config_file_from_a_rejected_one() {
+        // Running on environment variables alone is normal, not a failure.
+        let report =
+            service_for_config(Config::from_env_map([("GROK_SEARCH_API_KEY", "xai-fake")]))
+                .doctor()
+                .await;
+
+        assert_eq!(report["config_file"]["state"], "absent");
+        assert!(
+            report["config_file"]["detail"].is_null(),
+            "nothing failed, so there is no reason to give: {report}"
+        );
+    }
+
+    #[tokio::test]
+    async fn doctor_reports_the_endpoints_that_will_actually_be_called() {
+        // A report that echoes config the providers do not use would send the
+        // operator to debug a URL nothing ever contacts.
+        let config = Config::from_env_map([
+            ("GROK_SEARCH_API_KEY", "xai-fake"),
+            ("GROK_SEARCH_URL", "https://gateway.example"),
+            ("EXA_API_URL", "https://exa.example"),
+            ("TAVILY_API_URL", "https://tavily.example"),
+        ]);
+        let expected_grok = config.grok_api_url.clone();
+        let expected_exa = config.exa_api_url.clone();
+        let expected_tavily = config.tavily_api_url.clone();
+
+        let report = service_for_config(config).doctor().await;
+
+        assert_eq!(report["grok"]["api_url"], expected_grok);
+        assert_eq!(report["exa"]["api_url"], expected_exa);
+        assert_eq!(report["tavily"]["api_url"], expected_tavily);
     }
 
     #[tokio::test]

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -1,6 +1,6 @@
 use std::fs;
 
-use grok_search_rs::config::{self, AuthMode, Config, InitOutcome, Transport};
+use grok_search_rs::config::{self, AuthMode, Config, ConfigFileState, InitOutcome, Transport};
 use tempfile::tempdir;
 
 #[test]
@@ -537,4 +537,55 @@ fn redacted_diagnostics_masks_tinyfish_and_exa_keys() {
     );
     assert!(diagnostics.contains("tinyfish_api_key="));
     assert!(diagnostics.contains("exa_api_key="));
+}
+
+#[test]
+fn a_rejected_config_file_is_recorded_with_its_reason() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("config.toml");
+    fs::write(&path, "grok_api_key = \"xai-typo\"\nnot_a_real_key = 1\n").unwrap();
+
+    let cfg = Config::load_from([("GROK_SEARCH_CONFIG", path.to_string_lossy().to_string())]);
+
+    // Strictness is deliberate and unchanged: one unknown key voids the whole
+    // file rather than half-applying it. What changes is that the rejection is
+    // now recorded instead of living only on a stderr line nobody sees.
+    assert_eq!(
+        cfg.grok_api_key, None,
+        "a rejected file must not partially apply"
+    );
+    assert_eq!(cfg.config_file_path.as_deref(), Some(path.as_path()));
+    match &cfg.config_file_state {
+        ConfigFileState::Rejected(detail) => {
+            assert!(detail.contains("not_a_real_key"), "{detail}")
+        }
+        other => panic!("expected a rejected file, got {other:?}"),
+    }
+}
+
+#[test]
+fn an_absent_config_file_is_not_reported_as_a_failure() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("nothing-here.toml");
+
+    let cfg = Config::load_from([("GROK_SEARCH_CONFIG", path.to_string_lossy().to_string())]);
+
+    assert_eq!(cfg.config_file_state, ConfigFileState::Absent);
+    assert_eq!(
+        cfg.config_file_path.as_deref(),
+        Some(path.as_path()),
+        "the resolved path is worth reporting even when nothing is there"
+    );
+}
+
+#[test]
+fn a_good_config_file_is_recorded_as_loaded() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("config.toml");
+    fs::write(&path, "grok_api_key = \"xai-good\"\n").unwrap();
+
+    let cfg = Config::load_from([("GROK_SEARCH_CONFIG", path.to_string_lossy().to_string())]);
+
+    assert_eq!(cfg.config_file_state, ConfigFileState::Loaded);
+    assert_eq!(cfg.grok_api_key.as_deref(), Some("xai-good"));
 }


### PR DESCRIPTION
Part of #35.

## The problem

A user set an Exa key and a custom endpoint, ran `doctor`, and was told `EXA_API_KEY not configured` — with the endpoint showing its default value. Nothing in the report could tell them which of these had happened:

- no config file was found at all
- a file was found and **rejected**, so every setting fell back to its default
- the file was read fine and the key really was absent

Parsing is strict on purpose: one unknown key voids the whole file rather than half-applying it, so a typo surfaces as an error instead of a silent drop. That is the right call and it is unchanged here. What was wrong is that the only account of a rejection went to **stderr** — which an MCP client swallows. A single mistyped key left the operator staring at defaults with no way to learn why.

## Why doctor could not have been fixed alone

The information did not exist to report. `load_file_map` printed the parse error and returned `None`, dropping the reason on the floor before anything downstream could see it. So the change is in the config layer; `doctor` only renders what is now recorded.

`Config` gains where the file was looked for and what became of it:

```rust
pub enum ConfigFileState {
    Absent,            // nothing there, or no path resolved
    Loaded,
    Rejected(String),  // present but unusable, reason attached
}
```

Three states rather than two, because **absent is not a failure** — running purely on environment variables is normal. Folding it together with a rejection is precisely what made the two indistinguishable.

## Tests

- a rejected file is recorded with its reason, and still does not partially apply
- an absent file is not reported as a failure, and its resolved path is still given (it tells you where to put one)
- a good file is recorded as loaded
- `doctor` renders each state, and never leaks a value out of a rejected file
- the endpoints `doctor` reports are the ones the providers were actually built with

## Verification

- `cargo fmt --all -- --check` — pass
- `cargo clippy --all-targets --locked -D warnings`, default and `--features http` — pass
- `cargo test --locked`, default and `--features http` — pass
- End-to-end against the built binary with a config containing `tavly_api_key` (the `i` dropped): `doctor` reports `rejected`, names the offending key, and the value inside that rejected file appears nowhere in the output

## What this does not do

It does not diagnose #35. The reporter's deployment mode, full `doctor` output, and where they put their configuration are all still unknown. This is the visibility that lets them — and us — find out, and it is worth having regardless of what that turns out to be.

Superseded later by the fuller `DoctorReport` on `wip/doctor-setup`, which is queued as its own task; these few lines drop out when that lands.
