### PR TITLE
refactor(providers): lift the key ring out of the Tavily provider

### DIFF
--- a/src/providers/keyring.rs
+++ b/src/providers/keyring.rs
@@ -1,0 +1,153 @@
+//! Round-robin rotation over one upstream's API keys.
+//!
+//! Extracted from the Tavily provider so every upstream that accepts more than
+//! one key rotates the same way and agrees on which failures are the key's
+//! fault. Behaviour is unchanged from the Tavily-private original.
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+/// Round-robin ring over one or more API keys for a single upstream. Shared
+/// (`Arc`) across provider clones so the rotation cursor is global: each
+/// request starts on the next key, spreading credit consumption evenly across
+/// all keys.
+pub(crate) struct KeyRing {
+    keys: Vec<String>,
+    cursor: AtomicUsize,
+}
+
+impl KeyRing {
+    /// Split a comma-separated key list into the ring. Whitespace around each
+    /// segment is trimmed and empty segments are dropped, so `"a, b,"` yields
+    /// two keys. When no non-empty segment remains (e.g. the raw value is
+    /// empty), the raw value is kept as a single key — preserving the previous
+    /// single-key behavior where a bogus key simply fails upstream with 401.
+    pub(crate) fn parse(raw: &str) -> Self {
+        let mut keys: Vec<String> = raw
+            .split(',')
+            .map(str::trim)
+            .filter(|segment| !segment.is_empty())
+            .map(str::to_string)
+            .collect();
+        if keys.is_empty() {
+            keys.push(raw.to_string());
+        }
+        // Start at a random offset. On the HTTP transport the provider (and this
+        // ring) is rebuilt per request, so a fixed start of 0 would make every
+        // request begin on the first key and concentrate load there. A random
+        // start spreads load across keys statelessly; stdio keeps its persistent
+        // round-robin (the random start is just a one-time offset).
+        let start = random_offset(keys.len());
+        Self {
+            keys,
+            cursor: AtomicUsize::new(start),
+        }
+    }
+
+    pub(crate) fn len(&self) -> usize {
+        self.keys.len()
+    }
+
+    /// Index the next request should start from. `Relaxed` is enough: the
+    /// cursor only needs even distribution, not cross-request ordering.
+    pub(crate) fn start(&self) -> usize {
+        self.cursor.fetch_add(1, Ordering::Relaxed) % self.keys.len()
+    }
+
+    pub(crate) fn key(&self, index: usize) -> &str {
+        &self.keys[index % self.keys.len()]
+    }
+}
+
+/// A best-effort random starting offset in `0..len` (falls back to 0 if the RNG
+/// is unavailable). Only meaningful for multi-key rings.
+fn random_offset(len: usize) -> usize {
+    if len <= 1 {
+        return 0;
+    }
+    let mut buf = [0u8; 8];
+    match getrandom::fill(&mut buf) {
+        Ok(()) => (u64::from_ne_bytes(buf) % len as u64) as usize,
+        Err(_) => 0,
+    }
+}
+
+/// HTTP statuses that indict the *key* rather than the request or upstream:
+/// 401/403 (invalid or unauthorized key), 429 (per-key rate limit), and
+/// Tavily's 432 (plan limit exceeded) / 433 (pay-as-you-go limit exceeded).
+/// Only these trigger rotation to the next key — timeouts and 5xx are
+/// upstream-wide, so retrying with another key would just add latency.
+///
+/// The two Tavily-specific codes are inert for upstreams that never return
+/// them, so one predicate serves every provider.
+pub(crate) fn is_key_scoped_status(status: u16) -> bool {
+    matches!(status, 401 | 403 | 429 | 432 | 433)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn single_key_parses_to_one_entry() {
+        let ring = KeyRing::parse("tvly-only");
+        assert_eq!(ring.len(), 1);
+        assert_eq!(ring.key(0), "tvly-only");
+    }
+
+    #[test]
+    fn comma_separated_keys_split_trim_and_drop_empties() {
+        let ring = KeyRing::parse(" tvly-a, tvly-b ,, tvly-c,");
+        assert_eq!(ring.len(), 3);
+        assert_eq!(ring.key(0), "tvly-a");
+        assert_eq!(ring.key(1), "tvly-b");
+        assert_eq!(ring.key(2), "tvly-c");
+    }
+
+    #[test]
+    fn all_empty_segments_fall_back_to_raw_value() {
+        // Preserves the legacy single-key path: a degenerate value still
+        // produces one key that fails upstream, instead of an empty ring.
+        let ring = KeyRing::parse("");
+        assert_eq!(ring.len(), 1);
+        assert_eq!(ring.key(0), "");
+    }
+
+    #[test]
+    fn start_rotates_round_robin_across_requests() {
+        // The starting key is randomized per ring, but consecutive starts still
+        // advance by one and wrap — round-robin is preserved.
+        let ring = KeyRing::parse("a,b,c");
+        let first = ring.start();
+        assert_eq!(ring.start(), (first + 1) % 3);
+        assert_eq!(ring.start(), (first + 2) % 3);
+        assert_eq!(ring.start(), (first + 3) % 3);
+    }
+
+    #[test]
+    fn single_key_ring_always_starts_at_zero() {
+        // A single-key ring has a deterministic (0) start — no randomization.
+        let ring = KeyRing::parse("solo");
+        assert_eq!(ring.start(), 0);
+        assert_eq!(ring.start(), 0);
+    }
+
+    #[test]
+    fn key_indexing_wraps_for_failover_offsets() {
+        let ring = KeyRing::parse("a,b");
+        assert_eq!(ring.key(2), "a");
+        assert_eq!(ring.key(3), "b");
+    }
+
+    #[test]
+    fn only_key_scoped_statuses_rotate() {
+        for status in [401, 403, 429, 432, 433] {
+            assert!(is_key_scoped_status(status), "{status} indicts the key");
+        }
+        for status in [400, 404, 408, 500, 502, 503] {
+            assert!(
+                !is_key_scoped_status(status),
+                "{status} is not the key's fault; rotating would only add latency"
+            );
+        }
+    }
+}

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -2,6 +2,8 @@ pub mod exa;
 pub mod firecrawl;
 pub mod grok;
 pub mod http;
+/// Crate-internal: shared by the providers, not part of the public surface.
+pub(crate) mod keyring;
 pub mod openai_compatible;
 pub mod tavily;
 pub mod tinyfish;

--- a/src/providers/tavily.rs
+++ b/src/providers/tavily.rs
@@ -2,87 +2,13 @@ use crate::error::Result;
 use crate::model::search::SearchFilters;
 use crate::model::source::{FetchedPage, Source};
 use crate::providers::http::{build_client, post_json_with_status};
+use crate::providers::keyring::{is_key_scoped_status, KeyRing};
 use reqwest::Client;
 use serde_json::{json, Value};
-use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
 use crate::error::GrokSearchError;
-
-/// Round-robin ring over one or more Tavily API keys. Shared (`Arc`) across
-/// provider clones so the rotation cursor is global: each request starts on
-/// the next key, spreading credit consumption evenly across all keys.
-struct KeyRing {
-    keys: Vec<String>,
-    cursor: AtomicUsize,
-}
-
-impl KeyRing {
-    /// Split a comma-separated key list into the ring. Whitespace around each
-    /// segment is trimmed and empty segments are dropped, so `"a, b,"` yields
-    /// two keys. When no non-empty segment remains (e.g. the raw value is
-    /// empty), the raw value is kept as a single key — preserving the previous
-    /// single-key behavior where a bogus key simply fails upstream with 401.
-    fn parse(raw: &str) -> Self {
-        let mut keys: Vec<String> = raw
-            .split(',')
-            .map(str::trim)
-            .filter(|segment| !segment.is_empty())
-            .map(str::to_string)
-            .collect();
-        if keys.is_empty() {
-            keys.push(raw.to_string());
-        }
-        // Start at a random offset. On the HTTP transport the provider (and this
-        // ring) is rebuilt per request, so a fixed start of 0 would make every
-        // request begin on the first key and concentrate load there. A random
-        // start spreads load across keys statelessly; stdio keeps its persistent
-        // round-robin (the random start is just a one-time offset).
-        let start = random_offset(keys.len());
-        Self {
-            keys,
-            cursor: AtomicUsize::new(start),
-        }
-    }
-
-    fn len(&self) -> usize {
-        self.keys.len()
-    }
-
-    /// Index the next request should start from. `Relaxed` is enough: the
-    /// cursor only needs even distribution, not cross-request ordering.
-    fn start(&self) -> usize {
-        self.cursor.fetch_add(1, Ordering::Relaxed) % self.keys.len()
-    }
-
-    fn key(&self, index: usize) -> &str {
-        &self.keys[index % self.keys.len()]
-    }
-}
-
-/// A best-effort random starting offset in `0..len` (falls back to 0 if the RNG
-/// is unavailable). Only meaningful for multi-key rings.
-fn random_offset(len: usize) -> usize {
-    if len <= 1 {
-        return 0;
-    }
-    let mut buf = [0u8; 8];
-    match getrandom::fill(&mut buf) {
-        Ok(()) => (u64::from_ne_bytes(buf) % len as u64) as usize,
-        Err(_) => 0,
-    }
-}
-
-/// HTTP statuses that indict the *key* rather than the request or upstream:
-/// 401/403 (invalid or unauthorized key), 429 (per-key rate limit),
-/// 432 (Tavily plan limit exceeded), 433 (Tavily pay-as-you-go limit
-/// exceeded). Only these trigger rotation to the next key — timeouts and
-/// 5xx are upstream-wide, so retrying with another key would just add
-/// latency.
-fn is_key_scoped_status(status: u16) -> bool {
-    matches!(status, 401 | 403 | 429 | 432 | 433)
-}
 
 #[derive(Clone)]
 pub struct TavilyProvider {
@@ -314,57 +240,6 @@ mod key_ring_tests {
     use super::*;
 
     #[test]
-    fn single_key_parses_to_one_entry() {
-        let ring = KeyRing::parse("tvly-only");
-        assert_eq!(ring.len(), 1);
-        assert_eq!(ring.key(0), "tvly-only");
-    }
-
-    #[test]
-    fn comma_separated_keys_split_trim_and_drop_empties() {
-        let ring = KeyRing::parse(" tvly-a, tvly-b ,, tvly-c,");
-        assert_eq!(ring.len(), 3);
-        assert_eq!(ring.key(0), "tvly-a");
-        assert_eq!(ring.key(1), "tvly-b");
-        assert_eq!(ring.key(2), "tvly-c");
-    }
-
-    #[test]
-    fn all_empty_segments_fall_back_to_raw_value() {
-        // Preserves the legacy single-key path: a degenerate value still
-        // produces one key that fails upstream, instead of an empty ring.
-        let ring = KeyRing::parse("");
-        assert_eq!(ring.len(), 1);
-        assert_eq!(ring.key(0), "");
-    }
-
-    #[test]
-    fn start_rotates_round_robin_across_requests() {
-        // The starting key is randomized per ring, but consecutive starts still
-        // advance by one and wrap — round-robin is preserved.
-        let ring = KeyRing::parse("a,b,c");
-        let first = ring.start();
-        assert_eq!(ring.start(), (first + 1) % 3);
-        assert_eq!(ring.start(), (first + 2) % 3);
-        assert_eq!(ring.start(), (first + 3) % 3);
-    }
-
-    #[test]
-    fn single_key_ring_always_starts_at_zero() {
-        // A single-key ring has a deterministic (0) start — no randomization.
-        let ring = KeyRing::parse("solo");
-        assert_eq!(ring.start(), 0);
-        assert_eq!(ring.start(), 0);
-    }
-
-    #[test]
-    fn key_indexing_wraps_for_failover_offsets() {
-        let ring = KeyRing::parse("a,b");
-        assert_eq!(ring.key(2), "a");
-        assert_eq!(ring.key(3), "b");
-    }
-
-    #[test]
     fn rotation_cursor_is_shared_across_provider_clones() {
         let provider =
             TavilyProvider::with_client(Client::new(), "https://api.tavily.com", "tvly-a,tvly-b");
@@ -374,15 +249,5 @@ mod key_ring_tests {
         let a = provider.keys.start();
         assert_eq!(clone.keys.start(), (a + 1) % 2);
         assert_eq!(provider.keys.start(), (a + 2) % 2);
-    }
-
-    #[test]
-    fn key_scoped_statuses_trigger_rotation_only() {
-        for status in [401, 403, 429, 432, 433] {
-            assert!(is_key_scoped_status(status), "expected rotate on {status}");
-        }
-        for status in [400, 404, 408, 500, 502, 503] {
-            assert!(!is_key_scoped_status(status), "must not rotate on {status}");
-        }
     }
 }


### PR DESCRIPTION
Groundwork for #14 and #13. **No behaviour changes.**

## Why

Multi-key rotation lived inside the Tavily provider, so the AI upstreams could not use it without either duplicating the ring or reaching into a sibling provider. Lifting it out lets the delimiter fix (#13) and the AI-side rotation (#14) proceed independently instead of queueing behind each other.

## What moved

The ring, its randomized start, and the key-scoped status predicate — verbatim.

`tavily.rs` gains **exactly one line**, the import, and loses everything else. That is the whole production diff on the provider, which is about as direct a demonstration of "pure move" as this gets.

The `KeyRing` unit tests move next to the ring so the same assertions do not run twice. The one test that stays behind is `rotation_cursor_is_shared_across_provider_clones` — that is about how the provider wires the ring up, which is the provider's own behaviour, not the ring's.

Tavily's `432` / `433` stay in the key-scoped set. They are inert for upstreams that never return them, so one predicate serves every provider; only the comment changed to say so.

The module is `pub(crate)` — the public API surface is unchanged.

## Verification

- the existing `tavily_rotation` integration tests pass with **their assertions untouched**, which is the real evidence that Tavily behaves identically
- `cargo fmt --all -- --check` — pass
- `cargo clippy --all-targets --locked -D warnings`, default and `--features http` — pass
- `cargo test --locked`, default and `--features http` — pass
- end-to-end drive of the built binary — pass
